### PR TITLE
Update OpenAPI YAML and README Documentation to Match Latest API Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,89 +9,20 @@ The OpenWiFi Analytics Service is a service for the TIP OpenWiFi CloudSDK (OWSDK
 OWANALYTICS gathers statistics about device used in OpenWiFI and groups them according to their 
 provisioning (OWPROV) entities or venues. OWANALYTICS, like all other OWSDK microservices, is
 defined using an OpenAPI definition and uses the ucentral communication protocol to interact with Access Points. To use
-the OWANALYTICS, you either need to [build it](#building) or use the [Docker version](#docker).
+the OWANALYTICS, you need to use the Docker.
 
 ## OpenAPI
-You may get static page with OpenAPI docs generated from the definition on [GitHub Page](https://telecominfraproject.github.io/wlan-cloud-analytics/).
-Also, you may use [Swagger UI](https://petstore.swagger.io/#/) with OpenAPI definition file raw link (i.e. [latest version file](https://raw.githubusercontent.com/Telecominfraproject/wlan-cloud-analytics/main/openapi/owanalytics.yaml)) to get interactive docs page.
-
-## Building
-To build the microservice from source, please follow the instructions in [here](./BUILDING.md)
+The OWANALYTICS REST API is defined in [`openapi/owanalytics.yaml`](https://github.com/routerarchitects/wlan-cloud-analytics/blob/main/openapi/owanalytics.yaml). You can use this OpenAPI definition to generate static API documentation, inspect the available endpoints, or build client SDKs.
 
 ## Docker
 To use the CLoudSDK deployment please follow [here](https://github.com/Telecominfraproject/wlan-cloud-ucentral-deploy)
 
-#### Expected directory layout
-From the directory where your cloned source is, you will need to create the `certs`, `logs`, and `uploads` directories.
-```bash
-mkdir certs
-mkdir certs/cas
-mkdir logs
-mkdir uploads
-```
-You should now have the following:
-```text
---+-- certs
-  |   +--- cas
-  +-- cmake
-  +-- cmake-build
-  +-- logs
-  +-- src
-  +-- test_scripts
-  +-- openapi
-  +-- uploads
-  +-- owsec.properties
-```
-
-### Certificate
-The OWANALYTICS uses a certificate to provide security for the REST API Certificate to secure the Northbound API.
-
-#### The `certs` directory
-For all deployments, you will need the following `certs` directory, populated with the proper files.
-
-```text
-certs ---+--- restapi-ca.pem
-         +--- restapi-cert.pem
-         +--- restapi-key.pem
-```
-
-## Firewall Considerations
-| Port  | Description                                    | Configurable |
-|:------|:-----------------------------------------------|:------------:|
-| 16005 | Default port for REST API Access to the OWANALYTICS |     yes      |
-
-### Environment variables
-The following environment variables should be set from the root directory of the service. They tell the OWANALYTICS process where to find
-the configuration and the root directory.
-```bash
-export OWANALYTICS_ROOT=`pwd`
-export OWANALYTICS_CONFIG=`pwd`
-```
-You can run the shell script `set_env.sh` from the microservice root.
-
 ### OWANALYTICS Service Configuration
 The configuration is kept in a file called `owanalytics.properties`. To understand the content of this file,
-please look [here](https://github.com/Telecominfraproject/wlan-cloud-analytics/blob/main/CONFIGURATION.md)
+please look [here](https://github.com/routerarchitects/ra-wlan-cloud-analytics/blob/main/owanalytics.properties)
 
 ## Kafka topics
-Toe read more about Kafka, follow the [document](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/main/KAFKA.md)
+To read more about Kafka, follow the [document](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/main/KAFKA.md)
 
-## Contributions
-We need more contributors. Should you wish to contribute,
-please follow the [contributions](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/CONTRIBUTING.md) document.
-
-## Pull Requests
-Please create a branch with the Jira addressing the issue you are fixing or the feature you are implementing.
-Create a pull-request from the branch into master.
-
-## Additional OWSDK Microservices
-Here is a list of additional OWSDK microservices
-| Name | Description | Link | OpenAPI |
-| :--- | :--- | :---: | :---: |
-| OWSEC | Security Service | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralsec) | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralsec/blob/main/openpapi/owsec.yaml) |
-| OWGW | Controller Service | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw) | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/openapi/owgw.yaml) |
-| OWFMS | Firmware Management Service | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralfms) | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralfms/blob/main/openapi/owfms.yaml) |
-| OWPROV | Provisioning Service | [here](https://github.com/Telecominfraproject/wlan-cloud-owprov) | [here](https://github.com/Telecominfraproject/wlan-cloud-owprov/blob/main/openapi/owprov.yaml) |
-| OWANALYTICS | Analytics Service | [here](https://github.com/Telecominfraproject/wlan-cloud-analytics) | [here](https://github.com/Telecominfraproject/wlan-cloud-analytics/blob/main/openapi/owanalytics.yaml) |
-| OWSUB | Subscriber Service | [here](https://github.com/Telecominfraproject/wlan-cloud-userportal) | [here](https://github.com/Telecominfraproject/wlan-cloud-userportal/blob/main/openapi/userportal.yaml) |
-
+| OWANALYTICS | Analytics Service | [here](https://github.com/routerarchitects/wlan-cloud-analytics) | [here](https://github.com/routerarchitects/wlan-cloud-analytics/blob/main/openapi/owanalytics.yaml) |
+| OWSUB | Subscriber Service | [here](https://github.com/routerarchitects/wlan-cloud-userportal) | [here](https://github.com/routerarchitects/wlan-cloud-userportal/blob/main/openapi/userportal.yaml) |

--- a/README.md
+++ b/README.md
@@ -9,89 +9,17 @@ The OpenWiFi Analytics Service is a service for the TIP OpenWiFi CloudSDK (OWSDK
 OWANALYTICS gathers statistics about device used in OpenWiFI and groups them according to their 
 provisioning (OWPROV) entities or venues. OWANALYTICS, like all other OWSDK microservices, is
 defined using an OpenAPI definition and uses the ucentral communication protocol to interact with Access Points. To use
-the OWANALYTICS, you either need to [build it](#building) or use the [Docker version](#docker).
+the OWANALYTICS, you need to use the Docker.
 
 ## OpenAPI
-You may get static page with OpenAPI docs generated from the definition on [GitHub Page](https://telecominfraproject.github.io/wlan-cloud-analytics/).
-Also, you may use [Swagger UI](https://petstore.swagger.io/#/) with OpenAPI definition file raw link (i.e. [latest version file](https://raw.githubusercontent.com/Telecominfraproject/wlan-cloud-analytics/main/openapi/owanalytics.yaml)) to get interactive docs page.
-
-## Building
-To build the microservice from source, please follow the instructions in [here](./BUILDING.md)
+The OWANALYTICS REST API is defined in [`openapi/owanalytics.yaml`](https://github.com/routerarchitects/ra-wlan-cloud-analytics/blob/main/openapi/owanalytics.yaml). You can use this OpenAPI definition to generate static API documentation, inspect the available endpoints, or build client SDKs.
 
 ## Docker
-To use the CLoudSDK deployment please follow [here](https://github.com/Telecominfraproject/wlan-cloud-ucentral-deploy)
-
-#### Expected directory layout
-From the directory where your cloned source is, you will need to create the `certs`, `logs`, and `uploads` directories.
-```bash
-mkdir certs
-mkdir certs/cas
-mkdir logs
-mkdir uploads
-```
-You should now have the following:
-```text
---+-- certs
-  |   +--- cas
-  +-- cmake
-  +-- cmake-build
-  +-- logs
-  +-- src
-  +-- test_scripts
-  +-- openapi
-  +-- uploads
-  +-- owsec.properties
-```
-
-### Certificate
-The OWANALYTICS uses a certificate to provide security for the REST API Certificate to secure the Northbound API.
-
-#### The `certs` directory
-For all deployments, you will need the following `certs` directory, populated with the proper files.
-
-```text
-certs ---+--- restapi-ca.pem
-         +--- restapi-cert.pem
-         +--- restapi-key.pem
-```
-
-## Firewall Considerations
-| Port  | Description                                    | Configurable |
-|:------|:-----------------------------------------------|:------------:|
-| 16005 | Default port for REST API Access to the OWANALYTICS |     yes      |
-
-### Environment variables
-The following environment variables should be set from the root directory of the service. They tell the OWANALYTICS process where to find
-the configuration and the root directory.
-```bash
-export OWANALYTICS_ROOT=`pwd`
-export OWANALYTICS_CONFIG=`pwd`
-```
-You can run the shell script `set_env.sh` from the microservice root.
+To use the CLoudSDK deployment please follow [here](https://github.com/routerarchitects/mango-cloud-deployment)
 
 ### OWANALYTICS Service Configuration
 The configuration is kept in a file called `owanalytics.properties`. To understand the content of this file,
-please look [here](https://github.com/Telecominfraproject/wlan-cloud-analytics/blob/main/CONFIGURATION.md)
+please look [here](https://github.com/routerarchitects/ra-wlan-cloud-analytics/blob/main/owanalytics.properties)
 
 ## Kafka topics
-Toe read more about Kafka, follow the [document](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/main/KAFKA.md)
-
-## Contributions
-We need more contributors. Should you wish to contribute,
-please follow the [contributions](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/CONTRIBUTING.md) document.
-
-## Pull Requests
-Please create a branch with the Jira addressing the issue you are fixing or the feature you are implementing.
-Create a pull-request from the branch into master.
-
-## Additional OWSDK Microservices
-Here is a list of additional OWSDK microservices
-| Name | Description | Link | OpenAPI |
-| :--- | :--- | :---: | :---: |
-| OWSEC | Security Service | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralsec) | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralsec/blob/main/openpapi/owsec.yaml) |
-| OWGW | Controller Service | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw) | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/openapi/owgw.yaml) |
-| OWFMS | Firmware Management Service | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralfms) | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralfms/blob/main/openapi/owfms.yaml) |
-| OWPROV | Provisioning Service | [here](https://github.com/Telecominfraproject/wlan-cloud-owprov) | [here](https://github.com/Telecominfraproject/wlan-cloud-owprov/blob/main/openapi/owprov.yaml) |
-| OWANALYTICS | Analytics Service | [here](https://github.com/Telecominfraproject/wlan-cloud-analytics) | [here](https://github.com/Telecominfraproject/wlan-cloud-analytics/blob/main/openapi/owanalytics.yaml) |
-| OWSUB | Subscriber Service | [here](https://github.com/Telecominfraproject/wlan-cloud-userportal) | [here](https://github.com/Telecominfraproject/wlan-cloud-userportal/blob/main/openapi/userportal.yaml) |
-
+To read more about Kafka, follow the [document](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/main/KAFKA.md)

--- a/README.md
+++ b/README.md
@@ -9,20 +9,89 @@ The OpenWiFi Analytics Service is a service for the TIP OpenWiFi CloudSDK (OWSDK
 OWANALYTICS gathers statistics about device used in OpenWiFI and groups them according to their 
 provisioning (OWPROV) entities or venues. OWANALYTICS, like all other OWSDK microservices, is
 defined using an OpenAPI definition and uses the ucentral communication protocol to interact with Access Points. To use
-the OWANALYTICS, you need to use the Docker.
+the OWANALYTICS, you either need to [build it](#building) or use the [Docker version](#docker).
 
 ## OpenAPI
-The OWANALYTICS REST API is defined in [`openapi/owanalytics.yaml`](https://github.com/routerarchitects/wlan-cloud-analytics/blob/main/openapi/owanalytics.yaml). You can use this OpenAPI definition to generate static API documentation, inspect the available endpoints, or build client SDKs.
+You may get static page with OpenAPI docs generated from the definition on [GitHub Page](https://telecominfraproject.github.io/wlan-cloud-analytics/).
+Also, you may use [Swagger UI](https://petstore.swagger.io/#/) with OpenAPI definition file raw link (i.e. [latest version file](https://raw.githubusercontent.com/Telecominfraproject/wlan-cloud-analytics/main/openapi/owanalytics.yaml)) to get interactive docs page.
+
+## Building
+To build the microservice from source, please follow the instructions in [here](./BUILDING.md)
 
 ## Docker
 To use the CLoudSDK deployment please follow [here](https://github.com/Telecominfraproject/wlan-cloud-ucentral-deploy)
 
+#### Expected directory layout
+From the directory where your cloned source is, you will need to create the `certs`, `logs`, and `uploads` directories.
+```bash
+mkdir certs
+mkdir certs/cas
+mkdir logs
+mkdir uploads
+```
+You should now have the following:
+```text
+--+-- certs
+  |   +--- cas
+  +-- cmake
+  +-- cmake-build
+  +-- logs
+  +-- src
+  +-- test_scripts
+  +-- openapi
+  +-- uploads
+  +-- owsec.properties
+```
+
+### Certificate
+The OWANALYTICS uses a certificate to provide security for the REST API Certificate to secure the Northbound API.
+
+#### The `certs` directory
+For all deployments, you will need the following `certs` directory, populated with the proper files.
+
+```text
+certs ---+--- restapi-ca.pem
+         +--- restapi-cert.pem
+         +--- restapi-key.pem
+```
+
+## Firewall Considerations
+| Port  | Description                                    | Configurable |
+|:------|:-----------------------------------------------|:------------:|
+| 16005 | Default port for REST API Access to the OWANALYTICS |     yes      |
+
+### Environment variables
+The following environment variables should be set from the root directory of the service. They tell the OWANALYTICS process where to find
+the configuration and the root directory.
+```bash
+export OWANALYTICS_ROOT=`pwd`
+export OWANALYTICS_CONFIG=`pwd`
+```
+You can run the shell script `set_env.sh` from the microservice root.
+
 ### OWANALYTICS Service Configuration
 The configuration is kept in a file called `owanalytics.properties`. To understand the content of this file,
-please look [here](https://github.com/routerarchitects/ra-wlan-cloud-analytics/blob/main/owanalytics.properties)
+please look [here](https://github.com/Telecominfraproject/wlan-cloud-analytics/blob/main/CONFIGURATION.md)
 
 ## Kafka topics
-To read more about Kafka, follow the [document](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/main/KAFKA.md)
+Toe read more about Kafka, follow the [document](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/main/KAFKA.md)
 
-| OWANALYTICS | Analytics Service | [here](https://github.com/routerarchitects/wlan-cloud-analytics) | [here](https://github.com/routerarchitects/wlan-cloud-analytics/blob/main/openapi/owanalytics.yaml) |
-| OWSUB | Subscriber Service | [here](https://github.com/routerarchitects/wlan-cloud-userportal) | [here](https://github.com/routerarchitects/wlan-cloud-userportal/blob/main/openapi/userportal.yaml) |
+## Contributions
+We need more contributors. Should you wish to contribute,
+please follow the [contributions](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/CONTRIBUTING.md) document.
+
+## Pull Requests
+Please create a branch with the Jira addressing the issue you are fixing or the feature you are implementing.
+Create a pull-request from the branch into master.
+
+## Additional OWSDK Microservices
+Here is a list of additional OWSDK microservices
+| Name | Description | Link | OpenAPI |
+| :--- | :--- | :---: | :---: |
+| OWSEC | Security Service | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralsec) | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralsec/blob/main/openpapi/owsec.yaml) |
+| OWGW | Controller Service | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw) | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/openapi/owgw.yaml) |
+| OWFMS | Firmware Management Service | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralfms) | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralfms/blob/main/openapi/owfms.yaml) |
+| OWPROV | Provisioning Service | [here](https://github.com/Telecominfraproject/wlan-cloud-owprov) | [here](https://github.com/Telecominfraproject/wlan-cloud-owprov/blob/main/openapi/owprov.yaml) |
+| OWANALYTICS | Analytics Service | [here](https://github.com/Telecominfraproject/wlan-cloud-analytics) | [here](https://github.com/Telecominfraproject/wlan-cloud-analytics/blob/main/openapi/owanalytics.yaml) |
+| OWSUB | Subscriber Service | [here](https://github.com/Telecominfraproject/wlan-cloud-userportal) | [here](https://github.com/Telecominfraproject/wlan-cloud-userportal/blob/main/openapi/userportal.yaml) |
+

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -8,7 +8,7 @@ info:
     url: https://github.com/routerarchitects/wlan-cloud-ucentralgw/blob/master/LICENSE
 
 servers:
-  - url: 'https://localhost:16009/api/v1'
+  - url: 'https://openwifi.wlan.local:16009/api/v1'
 
 security:
   - bearerAuth: []
@@ -219,11 +219,9 @@ components:
       type: object
       properties:
         association_bssid:
-          type: integer
-          format: int64
+          type: string
         station:
-          type: integer
-          format: int64
+          type: string
         fingerprint:
           $ref: '#/components/schemas/Fingerprint'
         rssi:
@@ -470,6 +468,10 @@ components:
     DeviceTimePointAnalysis:
       type: object
       properties:
+        timestamp:
+          type: integer
+          format: int64
+          description: Start (or representative time) of the aggregation window
         noise:
           $ref: '#/components/schemas/AveragePoint'
         active_pct:
@@ -621,14 +623,12 @@ components:
             type: string
 
     ExtraSystemConfiguration:
-      type: array
-      items:
-        type: object
-        properties:
-          parameterName:
-            type: string
-          parameterValue:
-            type: string
+      type: object
+      properties:
+        parameterName:
+          type: string
+        parameterValue:
+          type: string
 
     #########################################################################################
     ##
@@ -648,6 +648,13 @@ components:
           type: array
           items:
             type: string
+
+    ExtraConfigurationStatus:
+      type: object
+      properties:
+        additionalConfiguration:
+          type: boolean
+          description: Indicates whether additional configuration is enabled
 
     TagValuePair:
       type: object
@@ -763,6 +770,7 @@ components:
         - $ref: '#/components/schemas/SystemInfoResults'
         - $ref: '#/components/schemas/StringList'
         - $ref: '#/components/schemas/TagValuePairList'
+        - $ref: '#/components/schemas/ExtraConfigurationStatus' 
 
     Dashboard:
       type: object
@@ -1090,9 +1098,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/DeviceTimePointList'
-                  - $ref: '#/components/schemas/DeviceTimePointStats'
+                $ref: '#/components/schemas/DeviceTimePointList'
         400:
           $ref: '#/components/responses/BadRequest'
         403:
@@ -1137,7 +1143,7 @@ paths:
       tags:
         - WiFiClientHistory
       operationId: getWifiClientHistory
-      summary: Retrieve WiFi client history for debugging purpose
+      summary: Retrieve WiFi client addresses 
       parameters:
         - in: query
           name: fromDate
@@ -1206,8 +1212,8 @@ paths:
     get:
       tags:
         - WiFiClientHistory
-      operationId: getWifiClients
-      summary: Retrieve WiFi client history for debugging purpose
+      operationId: getWifiClientHistoryEntries
+      summary: Retrieve WiFi client history per device
       parameters:
         - in: path
           name: client
@@ -1274,7 +1280,7 @@ paths:
           required: false
       responses:
         200:
-          description: Return WiFi client history entries
+          description: Return WiFi client history entries per device
           content:
             application/json:
               schema:
@@ -1288,7 +1294,7 @@ paths:
       tags:
         - WiFiClientHistory
       operationId: deleteWifiClientHistory
-      summary: Retrieve WiFi client history for debugging purpose
+      summary: Delete WiFi client history per device
       parameters:
         - in: query
           description: The venue to for the search.

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -96,13 +96,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BoardInfo'
- 
+
     DeviceInfo:
       type: object
       properties:
-        boardId:
-          type: string
-          format: uuid
         type:
           type: string
           enum:
@@ -212,10 +209,6 @@ components:
           type:
             boolean
 
-    Fingerprint:
-      type: object
-      additionalProperties: true
-
     UETimePoint:
       type: object
       properties:
@@ -225,8 +218,6 @@ components:
         station:
           type: integer
           format: int64
-        fingerprint:
-          $ref: '#/components/schemas/Fingerprint'
         rssi:
           type: integer
           format: int64
@@ -471,6 +462,9 @@ components:
     DeviceTimePointAnalysis:
       type: object
       properties:
+        timestamp:
+          type: integer
+          format: int64
         noise:
           $ref: '#/components/schemas/AveragePoint'
         active_pct:
@@ -506,9 +500,7 @@ components:
         points:
           type: array
           items:
-            type: array
-            items:
-              $ref: '#/components/schemas/DeviceTimePoint'
+            $ref: '#/components/schemas/DeviceTimePoint'
         stats:
           type: array
           items:
@@ -842,13 +834,13 @@ components:
     SystemGetSubSystemNamesResult:
       type: object
       properties:
-        list:
+        taglist:
           type: array
           items:
-            type: string
+            $ref: '#/components/schemas/TagValuePair'
 
 paths:
-  /api/v1/boards:
+  /boards:
     get:
       tags:
         - Boards
@@ -900,7 +892,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/board/{id}:
+  /board/{id}:
     get:
       tags:
         - Boards
@@ -1001,7 +993,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/board/{id}/devices:
+  /board/{id}/devices:
     get:
       tags:
         - Board Devices
@@ -1025,7 +1017,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/board/{id}/timepoints:
+  /board/{id}/timepoints:
     get:
       tags:
         - Board data
@@ -1075,13 +1067,7 @@ paths:
 
       responses:
         200:
-          description: Return board timepoints or summary statistics
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: '#/components/schemas/DeviceTimePointList'
-                  - $ref: '#/components/schemas/DeviceTimePointStats'
+          $ref: '#/components/schemas/DeviceTimePointList'
         400:
           $ref: '#/components/responses/BadRequest'
         403:
@@ -1121,7 +1107,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/wifiClientHistory:
+  /wifiClientHistory:
     get:
       tags:
         - WiFiClientHistory
@@ -1156,7 +1142,7 @@ paths:
           schema:
             type: boolean
             default: false
-          required: false
+          required: true
         - in: query
           description: Maximum number of entries to return (if absent, no limit is assumed)
           name: macFilter
@@ -1166,32 +1152,21 @@ paths:
               112233445566, 11223344*, *5566
           required: false
         - in: query
-          description: Venue for the search. If omitted, boardId may be used to derive it.
+          description: The venue to for the search.
           name: venue
           schema:
             type: string
             format: uuid
-          required: false
-        - in: query
-          description: Board used to derive venue when venue is not provided.
-          name: boardId
-          schema:
-            type: string
-            format: uuid
-          required: false
+          required: true
       responses:
         200:
-          description: Return matching client MAC addresses
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MacList'
+          $ref: '#/components/schemas/StringList'
         403:
           $ref: '#/components/responses/Unauthorized'
         404:
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/wifiClientHistory/{client}:
+  /wifiClientHistory/{client}:
     get:
       tags:
         - WiFiClientHistory
@@ -1228,19 +1203,12 @@ paths:
             type: integer
           required: false
         - in: query
-          description: Venue for the search. If omitted, boardId may be used to derive it.
+          description: The venue to for the search.
           name: venue
           schema:
             type: string
             format: uuid
-          required: false
-        - in: query
-          description: Board used to derive venue when venue is not provided.
-          name: boardId
-          schema:
-            type: string
-            format: uuid
-          required: false
+          required: true
         - in: query
           description: return extended information
           name: orderBy
@@ -1254,12 +1222,6 @@ paths:
           schema:
             type: boolean
             default: false
-          required: false
-        - in: query
-          description: Return count only
-          name: countOnly
-          schema:
-            type: boolean
           required: false
       responses:
         200:
@@ -1299,6 +1261,14 @@ paths:
           schema:
             type: integer
           required: false
+        - in: query
+          description: Maximum number of entries to return (if absent, no limit is assumed)
+          name: macFilter
+          schema:
+            type: string
+            example:
+              112233445566, 11223344*, *5566
+          required: false
       responses:
         200:
           $ref: '#/components/responses/Success'
@@ -1312,7 +1282,7 @@ paths:
   ## These are endpoints that all services in the OpenWiFi stack must provide
   ##
   #########################################################################################
-  /api/v1/system:
+  /system:
     post:
       tags:
         - System Commands
@@ -1369,7 +1339,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/systemConfiguration:
+  /systemConfiguration:
     get:
       tags:
         - SystemConfiguration
@@ -1384,7 +1354,7 @@ paths:
             example:
               - element1
               - element1,element2,element3
-          required: true
+          required: false
       responses:
         200:
           description: List of configuration elements
@@ -1394,6 +1364,39 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ExtraSystemConfiguration'
+        403:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      tags:
+        - SystemConfiguration
+      summary: Set some or all system configuration
+      operationId: setSystemConfiguration
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExtraSystemConfiguration'
+
+      responses:
+        200:
+          $ref: '#/components/schemas/ExtraSystemConfiguration'
+        403:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      tags:
+        - SystemConfiguration
+      summary: Delete all additional system configuration
+      operationId: deleteSystemConfiguration
+
+      responses:
+        200:
+          $ref: '#/components/responses/Success'
         403:
           $ref: '#/components/responses/Unauthorized'
         404:

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -5,7 +5,7 @@ info:
   version: 2.6.0
   license:
     name: BSD3
-    url: https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/LICENSE
+    url: https://github.com/routerarchitects/wlan-cloud-ucentralgw/blob/master/LICENSE
 
 servers:
   - url: 'https://localhost:16009/api/v1'
@@ -27,13 +27,13 @@ components:
 
   responses:
     NotFound:
-      $ref: 'https://github.com/Telecominfraproject/wlan-cloud-ucentralsec/blob/main/openpapi/owsec.yaml#/components/responses/NotFound'
+      $ref: 'https://github.com/routerarchitects/wlan-cloud-ucentralsec/blob/main/openapi/owsec.yaml#/components/responses/NotFound'
     Unauthorized:
-      $ref: 'https://github.com/Telecominfraproject/wlan-cloud-ucentralsec/blob/main/openpapi/owsec.yaml#/components/responses/Unauthorized'
+      $ref: 'https://github.com/routerarchitects/wlan-cloud-ucentralsec/blob/main/openapi/owsec.yaml#/components/responses/Unauthorized'
     Success:
-      $ref: 'https://github.com/Telecominfraproject/wlan-cloud-ucentralsec/blob/main/openpapi/owsec.yaml#/components/responses/Success'
+      $ref: 'https://github.com/routerarchitects/wlan-cloud-ucentralsec/blob/main/openapi/owsec.yaml#/components/responses/Success'
     BadRequest:
-      $ref: 'https://github.com/Telecominfraproject/wlan-cloud-ucentralsec/blob/main/openpapi/owsec.yaml#/components/responses/BadRequest'
+      $ref: 'https://github.com/routerarchitects/wlan-cloud-ucentralsec/blob/main/openapi/owsec.yaml#/components/responses/BadRequest'
 
   schemas:
     ObjectInfo:
@@ -80,14 +80,14 @@ components:
           type: boolean
 
     BoardInfo:
-      type: object
-      properties:
-        allOf:
-          $ref: '#/components/schemas/ObjectInfo'
-        venueList:
-          type: array
-          items:
-            $ref: '#/components/schemas/VenueInfo'
+      allOf:
+        - $ref: '#/components/schemas/ObjectInfo'
+        - type: object
+          properties:
+            venueList:
+              type: array
+              items:
+                $ref: '#/components/schemas/VenueInfo'
 
     BoardInfoList:
       type: object
@@ -96,10 +96,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BoardInfo'
-
+ 
     DeviceInfo:
       type: object
       properties:
+        boardId:
+          type: string
+          format: uuid
         type:
           type: string
           enum:
@@ -206,8 +209,11 @@ components:
         ht:
           type: boolean
         sgi:
-          type:
-            boolean
+          type: boolean
+
+    Fingerprint:
+      type: object
+      additionalProperties: true
 
     UETimePoint:
       type: object
@@ -218,6 +224,8 @@ components:
         station:
           type: integer
           format: int64
+        fingerprint:
+          $ref: '#/components/schemas/Fingerprint'
         rssi:
           type: integer
           format: int64
@@ -462,9 +470,6 @@ components:
     DeviceTimePointAnalysis:
       type: object
       properties:
-        timestamp:
-          type: integer
-          format: int64
         noise:
           $ref: '#/components/schemas/AveragePoint'
         active_pct:
@@ -500,7 +505,9 @@ components:
         points:
           type: array
           items:
-            $ref: '#/components/schemas/DeviceTimePoint'
+            type: array
+            items:
+              $ref: '#/components/schemas/DeviceTimePoint'
         stats:
           type: array
           items:
@@ -709,10 +716,10 @@ components:
           type: string
         uptime:
           type: integer
-          format: integer64
+          format: int64
         start:
           type: integer
-          format: integer64
+          format: int64
         os:
           type: string
         processors:
@@ -834,10 +841,10 @@ components:
     SystemGetSubSystemNamesResult:
       type: object
       properties:
-        taglist:
+        list:
           type: array
           items:
-            $ref: '#/components/schemas/TagValuePair'
+            type: string
 
 paths:
   /boards:
@@ -959,7 +966,11 @@ paths:
               $ref: '#/components/schemas/BoardInfo'
       responses:
         200:
-          $ref: '#/components/schemas/BoardInfo'
+          description: Return the created board
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BoardInfo'
         400:
           $ref: '#/components/responses/BadRequest'
         403:
@@ -985,7 +996,11 @@ paths:
               $ref: '#/components/schemas/BoardInfo'
       responses:
         200:
-          $ref: '#/components/schemas/BoardInfo'
+          description: Return the updated board
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BoardInfo'
         400:
           $ref: '#/components/responses/BadRequest'
         403:
@@ -1009,7 +1024,11 @@ paths:
 
       responses:
         200:
-          $ref: '#/components/schemas/DeviceInfoList'
+          description: Return device information for the board
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceInfoList'
         400:
           $ref: '#/components/responses/BadRequest'
         403:
@@ -1067,7 +1086,13 @@ paths:
 
       responses:
         200:
-          $ref: '#/components/schemas/DeviceTimePointList'
+          description: Return board timepoints or summary statistics
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/DeviceTimePointList'
+                  - $ref: '#/components/schemas/DeviceTimePointStats'
         400:
           $ref: '#/components/responses/BadRequest'
         403:
@@ -1142,7 +1167,7 @@ paths:
           schema:
             type: boolean
             default: false
-          required: true
+          required: false
         - in: query
           description: Maximum number of entries to return (if absent, no limit is assumed)
           name: macFilter
@@ -1152,15 +1177,26 @@ paths:
               112233445566, 11223344*, *5566
           required: false
         - in: query
-          description: The venue to for the search.
+          description: Venue for the search. If omitted, boardId may be used to derive it.
           name: venue
           schema:
             type: string
             format: uuid
-          required: true
+          required: false
+        - in: query
+          description: Board used to derive venue when venue is not provided.
+          name: boardId
+          schema:
+            type: string
+            format: uuid
+          required: false
       responses:
         200:
-          $ref: '#/components/schemas/StringList'
+          description: Return matching client MAC addresses
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacList'
         403:
           $ref: '#/components/responses/Unauthorized'
         404:
@@ -1203,12 +1239,19 @@ paths:
             type: integer
           required: false
         - in: query
-          description: The venue to for the search.
+          description: Venue for the search. If omitted, boardId may be used to derive it.
           name: venue
           schema:
             type: string
             format: uuid
-          required: true
+          required: false
+        - in: query
+          description: Board used to derive venue when venue is not provided.
+          name: boardId
+          schema:
+            type: string
+            format: uuid
+          required: false
         - in: query
           description: return extended information
           name: orderBy
@@ -1223,9 +1266,19 @@ paths:
             type: boolean
             default: false
           required: false
+        - in: query
+          description: Return count only
+          name: countOnly
+          schema:
+            type: boolean
+          required: false
       responses:
         200:
-          $ref: '#/components/schemas/WifiClientHistoryList'
+          description: Return WiFi client history entries
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WifiClientHistoryList'
         403:
           $ref: '#/components/responses/Unauthorized'
         404:
@@ -1260,14 +1313,6 @@ paths:
           name: endDate
           schema:
             type: integer
-          required: false
-        - in: query
-          description: Maximum number of entries to return (if absent, no limit is assumed)
-          name: macFilter
-          schema:
-            type: string
-            example:
-              112233445566, 11223344*, *5566
           required: false
       responses:
         200:
@@ -1333,7 +1378,11 @@ paths:
           required: true
       responses:
         200:
-          $ref: '#/components/schemas/SystemCommandResults'
+          description: Return the requested system information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemCommandResults'
         403:
           $ref: '#/components/responses/Unauthorized'
         404:
@@ -1354,7 +1403,7 @@ paths:
             example:
               - element1
               - element1,element2,element3
-          required: false
+          required: true
       responses:
         200:
           description: List of configuration elements
@@ -1364,39 +1413,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ExtraSystemConfiguration'
-        403:
-          $ref: '#/components/responses/Unauthorized'
-        404:
-          $ref: '#/components/responses/NotFound'
-
-    put:
-      tags:
-        - SystemConfiguration
-      summary: Set some or all system configuration
-      operationId: setSystemConfiguration
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ExtraSystemConfiguration'
-
-      responses:
-        200:
-          $ref: '#/components/schemas/ExtraSystemConfiguration'
-        403:
-          $ref: '#/components/responses/Unauthorized'
-        404:
-          $ref: '#/components/responses/NotFound'
-
-    delete:
-      tags:
-        - SystemConfiguration
-      summary: Delete all additional system configuration
-      operationId: deleteSystemConfiguration
-
-      responses:
-        200:
-          $ref: '#/components/responses/Success'
         403:
           $ref: '#/components/responses/Unauthorized'
         404:

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -96,10 +96,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BoardInfo'
-
+ 
     DeviceInfo:
       type: object
       properties:
+        boardId:
+          type: string
+          format: uuid
         type:
           type: string
           enum:
@@ -209,6 +212,10 @@ components:
           type:
             boolean
 
+    Fingerprint:
+      type: object
+      additionalProperties: true
+
     UETimePoint:
       type: object
       properties:
@@ -218,6 +225,8 @@ components:
         station:
           type: integer
           format: int64
+        fingerprint:
+          $ref: '#/components/schemas/Fingerprint'
         rssi:
           type: integer
           format: int64
@@ -462,9 +471,6 @@ components:
     DeviceTimePointAnalysis:
       type: object
       properties:
-        timestamp:
-          type: integer
-          format: int64
         noise:
           $ref: '#/components/schemas/AveragePoint'
         active_pct:
@@ -500,7 +506,9 @@ components:
         points:
           type: array
           items:
-            $ref: '#/components/schemas/DeviceTimePoint'
+            type: array
+            items:
+              $ref: '#/components/schemas/DeviceTimePoint'
         stats:
           type: array
           items:
@@ -834,13 +842,13 @@ components:
     SystemGetSubSystemNamesResult:
       type: object
       properties:
-        taglist:
+        list:
           type: array
           items:
-            $ref: '#/components/schemas/TagValuePair'
+            type: string
 
 paths:
-  /boards:
+  /api/v1/boards:
     get:
       tags:
         - Boards
@@ -892,7 +900,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /board/{id}:
+  /api/v1/board/{id}:
     get:
       tags:
         - Boards
@@ -993,7 +1001,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /board/{id}/devices:
+  /api/v1/board/{id}/devices:
     get:
       tags:
         - Board Devices
@@ -1017,7 +1025,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /board/{id}/timepoints:
+  /api/v1/board/{id}/timepoints:
     get:
       tags:
         - Board data
@@ -1067,7 +1075,13 @@ paths:
 
       responses:
         200:
-          $ref: '#/components/schemas/DeviceTimePointList'
+          description: Return board timepoints or summary statistics
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/DeviceTimePointList'
+                  - $ref: '#/components/schemas/DeviceTimePointStats'
         400:
           $ref: '#/components/responses/BadRequest'
         403:
@@ -1107,7 +1121,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /wifiClientHistory:
+  /api/v1/wifiClientHistory:
     get:
       tags:
         - WiFiClientHistory
@@ -1142,7 +1156,7 @@ paths:
           schema:
             type: boolean
             default: false
-          required: true
+          required: false
         - in: query
           description: Maximum number of entries to return (if absent, no limit is assumed)
           name: macFilter
@@ -1152,21 +1166,32 @@ paths:
               112233445566, 11223344*, *5566
           required: false
         - in: query
-          description: The venue to for the search.
+          description: Venue for the search. If omitted, boardId may be used to derive it.
           name: venue
           schema:
             type: string
             format: uuid
-          required: true
+          required: false
+        - in: query
+          description: Board used to derive venue when venue is not provided.
+          name: boardId
+          schema:
+            type: string
+            format: uuid
+          required: false
       responses:
         200:
-          $ref: '#/components/schemas/StringList'
+          description: Return matching client MAC addresses
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacList'
         403:
           $ref: '#/components/responses/Unauthorized'
         404:
           $ref: '#/components/responses/NotFound'
 
-  /wifiClientHistory/{client}:
+  /api/v1/wifiClientHistory/{client}:
     get:
       tags:
         - WiFiClientHistory
@@ -1203,12 +1228,19 @@ paths:
             type: integer
           required: false
         - in: query
-          description: The venue to for the search.
+          description: Venue for the search. If omitted, boardId may be used to derive it.
           name: venue
           schema:
             type: string
             format: uuid
-          required: true
+          required: false
+        - in: query
+          description: Board used to derive venue when venue is not provided.
+          name: boardId
+          schema:
+            type: string
+            format: uuid
+          required: false
         - in: query
           description: return extended information
           name: orderBy
@@ -1222,6 +1254,12 @@ paths:
           schema:
             type: boolean
             default: false
+          required: false
+        - in: query
+          description: Return count only
+          name: countOnly
+          schema:
+            type: boolean
           required: false
       responses:
         200:
@@ -1261,14 +1299,6 @@ paths:
           schema:
             type: integer
           required: false
-        - in: query
-          description: Maximum number of entries to return (if absent, no limit is assumed)
-          name: macFilter
-          schema:
-            type: string
-            example:
-              112233445566, 11223344*, *5566
-          required: false
       responses:
         200:
           $ref: '#/components/responses/Success'
@@ -1282,7 +1312,7 @@ paths:
   ## These are endpoints that all services in the OpenWiFi stack must provide
   ##
   #########################################################################################
-  /system:
+  /api/v1/system:
     post:
       tags:
         - System Commands
@@ -1339,7 +1369,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /systemConfiguration:
+  /api/v1/systemConfiguration:
     get:
       tags:
         - SystemConfiguration
@@ -1354,7 +1384,7 @@ paths:
             example:
               - element1
               - element1,element2,element3
-          required: false
+          required: true
       responses:
         200:
           description: List of configuration elements
@@ -1364,39 +1394,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ExtraSystemConfiguration'
-        403:
-          $ref: '#/components/responses/Unauthorized'
-        404:
-          $ref: '#/components/responses/NotFound'
-
-    put:
-      tags:
-        - SystemConfiguration
-      summary: Set some or all system configuration
-      operationId: setSystemConfiguration
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ExtraSystemConfiguration'
-
-      responses:
-        200:
-          $ref: '#/components/schemas/ExtraSystemConfiguration'
-        403:
-          $ref: '#/components/responses/Unauthorized'
-        404:
-          $ref: '#/components/responses/NotFound'
-
-    delete:
-      tags:
-        - SystemConfiguration
-      summary: Delete all additional system configuration
-      operationId: deleteSystemConfiguration
-
-      responses:
-        200:
-          $ref: '#/components/responses/Success'
         403:
           $ref: '#/components/responses/Unauthorized'
         404:


### PR DESCRIPTION
# Description:

This branch updates the OpenAPI documentation references in `README.md` and revises `openapi/owanalytics.yaml` so the specification better reflects the current OWANALYTICS service behavior.

## Changes in `README.md`

- Improved the OpenAPI section wording to make it clearer and more precise.
- removed unnecessary links
- removed build section since it's using mango cloud deploy service .

## Changes in `openapi/owanalytics.yaml`

- Added `boardId` to the `DeviceInfo` schema.
- Updated the `DeviceTimePointList` schema so `points` matches the nested array structure returned by the implementation.
- Updated `/api/v1/board/{id}/timepoints` `GET` to document multiple possible response shapes using `oneOf`.
- Updated `/api/v1/wifiClientHistory` to return `MacList` instead of `StringList`.
- Adjusted WiFi client history parameters so optional fields such as `venue`, `boardId`, and `countOnly` match actual handler behavior.
- Updated `SystemGetSubSystemNamesResult` to use `list` instead of `taglist`.
- Updated `/api/v1/systemConfiguration` so `entries` is required.
- Removed unsupported `PUT` and `DELETE` definitions from `/api/v1/systemConfiguration` to match the currently documented implementation scope.
