### PR TITLE
fix(openapi): remove duplicate Fingerprint schema definition

### DIFF
--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -215,10 +215,6 @@ components:
       type: object
       additionalProperties: true
 
-    Fingerprint:
-      type: object
-      additionalProperties: true
-
     UETimePoint:
       type: object
       properties:


### PR DESCRIPTION
fix #17 

## Summary

This PR resolves a YAML/OpenAPI formatting issue in the OpenWiFi Analytics API specification by removing a duplicate schema declaration.

## Problem

In `openapi/owanalytics.yaml`, the `Fingerprint` schema block was declared twice consecutively under `components/schemas`:

```yaml
Fingerprint:
  type: object
  additionalProperties: true
Fingerprint:
  type: object
  additionalProperties: true
```

Duplicate keys within a YAML map violate YAML and OpenAPI 3.0 specification guidelines. This can cause strict parsing tools, linters, Swagger validators, and OpenAPI code generators to fail or produce warnings.

## Solution

Removed the duplicate schema declaration block. The file now contains a single valid declaration for the `Fingerprint` schema:

```yaml
Fingerprint:
  type: object
  additionalProperties: true
```

## Testing

Validated the updated `owanalytics.yaml` structure using YAML/OpenAPI parsers to verify that it compiles cleanly and passes syntax validation.
