### PR TITLE
design document for Analytics APIs required by MCP tools.

### DIFF
--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -117,12 +117,15 @@ Resolution flow:
 
 ```text
 1. Validate routerId.
-2. Call OWPROV inventory for the serial number with status-aware handling:
+2. Check the request-scoped routerId resolution cache.
+3. Resolve board ownership from the maintained routerId -> boardId map.
+4. If the map has a current entry, use it as resolvedBoardId.
+5. On cache/map miss, call OWPROV inventory with status-aware handling:
      GET /api/v1/inventory/{routerId}
-3. Read inventoryTag.venue as venueId.
-4. Find the Analytics board that currently owns routerId.
-5. Use that board's BoardInfo.info.id as resolvedBoardId.
-6. Query Analytics storage with resolvedBoardId and serialNumber = routerId.
+6. Read inventoryTag.venue as venueId.
+7. Use the OWPROV venue result to verify or refresh board ownership.
+8. Store the resolved result in the request-scoped cache.
+9. Query Analytics storage with resolvedBoardId and serialNumber = routerId.
 ```
 
 Implementation notes:
@@ -135,17 +138,38 @@ OWPROV response field:
   InventoryTag.venue
 
 Analytics local source:
-  BoardsDB records
+  VenueCoordinator maintained routerId -> boardId map
+  BoardInfo records for venue metadata and validation
   BoardInfo.venueList[].id
   BoardInfo.venueList[].monitorSubVenues
 ```
 
-Board ownership resolution must account for child venues. Do not only check whether `inventoryTag.venue` is directly present in `BoardInfo.venueList`.
+Board ownership resolution must use the maintained `routerId -> boardId` map as the primary design. `VenueCoordinator` should maintain this map from the same board device lists used by `VenueWatcher`, updating it when boards start, reconcile, or change device membership.
 
-Preferred ownership algorithm:
+OWPROV inventory lookup is not the normal path for every metric query. It is used when the local map has no entry, when the entry needs verification, or when ownership may be stale. Board ownership refresh must account for child venues. Do not only check whether `inventoryTag.venue` is directly present in `BoardInfo.venueList`.
+
+Primary ownership algorithm:
 
 ```text
-For each local BoardInfo record:
+Look up routerId in VenueCoordinator's maintained routerId -> boardId map.
+
+If exactly one current board mapping exists:
+  resolvedBoardId = mapped boardId
+  return Success
+
+If no mapping exists:
+  perform status-aware OWPROV inventory lookup
+  read InventoryTag.venue
+  refresh candidate board ownership from current venue device lists
+  update the maintained routerId -> boardId map when ownership is determined
+```
+
+This mirrors the existing watcher behavior, where board devices are fetched from OWPROV with the board venue's `monitorSubVenues` setting.
+
+Refresh algorithm for cache/map misses:
+
+```text
+For each local BoardInfo record that can own the inventory venue:
   for each VenueInfo in BoardInfo.venueList:
     call SDK::Prov::Venue::GetDevices(
       client,
@@ -159,17 +183,10 @@ For each local BoardInfo record:
 
 If exactly one candidate exists:
   resolvedBoardId = candidate board
+  update routerId -> boardId map
 ```
 
-This mirrors the existing watcher behavior, where board devices are fetched from OWPROV with the board venue's `monitorSubVenues` setting.
-
-Alternative implementation:
-
-```text
-Expose a current routerId -> boardId map from VenueCoordinator.
-The map must be maintained from the same device lists used by VenueWatcher.
-The resolver may use this map instead of scanning OWPROV for every request.
-```
+Request-scoped reuse is required. A single MCP request that asks for multiple metrics for the same router must resolve `routerId` once, then reuse the same `RouterIdResolutionResult` for all handlers in that request. For example, five MCP metric queries in one request must not repeat the full resolution process five times.
 
 Failure handling:
 
@@ -229,7 +246,7 @@ Option B:
   directly from ResolveRouterIdContext and inspect the HTTP response status.
 ```
 
-Handlers may cache `routerId -> venueId -> boardId` for a short TTL, but must refresh or invalidate the cache when OWPROV reports a different venue.
+Handlers may keep a short-lived process cache for `routerId -> venueId -> boardId`, but it is secondary to the maintained `VenueCoordinator` ownership map. Any cache must refresh or invalidate entries when OWPROV reports a different venue or when `VenueCoordinator` reports changed board membership.
 
 ---
 
@@ -459,6 +476,35 @@ radios[].band
 radios[].temperature
 ```
 
+Temperature samples need explicit validity handling. Current ingestion in `APStats.cpp` defaults a missing radio temperature to `20` and also rewrites a reported `0` to `20`. Those fallback values must not be treated as genuine measurements.
+
+Required ingestion rule:
+
+```text
+If radios[].temperature is present, non-null, and accepted as a measured value:
+  store the measured temperature
+  store temperature_valid = true
+
+If radios[].temperature is missing, null, or rejected as invalid:
+  keep temperature missing/null
+  store temperature_valid = false
+
+Do not synthesize a numeric fallback temperature for missing data.
+Do not store 20, 0, or any other placeholder for a missing temperature.
+For all newly ingested records, temperature_valid must be present.
+```
+
+Historical data rule:
+
+```text
+Existing stored temperature == 20 is ambiguous because it may be either:
+  a genuine measured 20, or
+  the synthetic fallback for missing/zero input
+
+Unless a migration can prove the value came from a real measured source, do not use
+historical 20 values in min/max/average temperature summaries.
+```
+
 The current radio-band mapping is:
 
 ```text
@@ -489,13 +535,28 @@ For each record:
   parse radio_data
   for each radio in radio_data:
     if radio.band is 2 or 5:
-      add radio.temperature to that band's sample list
+      if radio.temperature_valid is true and radio.temperature is present:
+        add radio.temperature to that band's sample list
 
 For each band:
   min_temperature = min(samples)
   max_temperature = max(samples)
   avg_temperature = sum(samples) / sample_count
 ```
+
+A valid temperature sample is:
+
+```text
+New records:
+  temperature is present and non-null
+  and temperature_valid == true
+
+Historical records from the current ingestion behavior:
+  temperature is present
+  and temperature != 20
+```
+
+If all samples for a band are invalid or missing, return `null` for that band's min, max, and average fields.
 
 Do not query `radio_timepoints` unless a separate normalized table and migration are introduced.
 
@@ -615,44 +676,82 @@ The values are cumulative counters, so they must not be summed directly.
 ### Correct Calculation
 
 ```text
-baseline = last sample before start_time for the same client, if available
+stream_key = association/session id when available, otherwise:
+  station MAC
+  BSSID
+  SSID
+  band/radio when present
+
+baseline = last sample before start_time for the same stream_key, if available
 
 first in-window delta:
   if baseline exists:
-    resetSafeDelta(first.rx_bytes, baseline.rx_bytes)
+    counterDelta(first.rx_bytes, baseline.rx_bytes)
   else:
     0
 
 subsequent deltas:
-  resetSafeDelta(current.rx_bytes, previous.rx_bytes)
+  counterDelta(current.rx_bytes, previous.rx_bytes)
 
 data_consume_rx = SUM(reset-safe rx_bytes deltas)
 data_consume_tx = SUM(reset-safe tx_bytes deltas)
 total_data_usage = data_consume_rx + data_consume_tx
 ```
 
+Calculate counter deltas per `stream_key`. After stream-level deltas are calculated, aggregate the resulting RX/TX deltas by station MAC for the response.
+
 ### Reset-Safe Delta Logic
 
 ```cpp
-uint64_t resetSafeDelta(uint64_t current, uint64_t previous) {
+uint64_t counterDelta(uint64_t current, uint64_t previous,
+                      bool confirmedFixedWidthRollover,
+                      uint64_t counterMax) {
     if (current >= previous) {
         return current - previous;
     }
 
-    return current;
+    if (confirmedFixedWidthRollover) {
+        return (counterMax - previous) + current + 1;
+    }
+
+    return 0;
 }
 ```
 
-This handles:
+Do not treat every lower counter as a reset where `current` should be added. A lower value can mean a new association session, movement between radios/BSSIDs, stale or out-of-order telemetry, duplicate station records inside one timepoint, or counter-width rollover. Adding `current` on every decrease can overcount traffic by attributing unknown pre-window traffic to the requested window.
+
+Required sample handling:
 
 ```text
-client reconnection
-counter reset
-gateway reboot
-counter rollover
+Build a deterministic sample key from the stable fields available in the association:
+  station MAC
+  timestamp
+  BSSID, SSID, band/radio when present
+
+Sort samples by:
+  station MAC
+  timestamp ASC
+  BSSID/SSID/band/radio tie-breakers
+
+Deduplicate exact duplicate samples before calculating deltas.
+
+Discard out-of-order samples for the same calculated stream.
+
+When an association/session identifier is available:
+  calculate deltas only within the same session.
+
+When no session identifier is available:
+  use station MAC as the result grouping key,
+  but use BSSID/SSID/band/radio changes as stream boundaries when possible.
+
+If current < previous:
+  if fixed-width rollover is known and can be confirmed:
+    apply rollover math
+  else:
+    treat current as the new baseline and add delta 0
 ```
 
-Without the pre-window baseline, the first sample inside the requested window can include traffic that occurred before `start_time`. Do not add the first in-window cumulative counter directly unless it is known to be a fresh association/reset.
+Without the pre-window baseline for the same calculated stream, the first sample inside the requested window can include traffic that occurred before `start_time`. Do not add the first in-window cumulative counter directly unless it is known to be a fresh association/reset for that same stream.
 
 ### Incorrect Calculation
 
@@ -669,7 +768,7 @@ This would overcount cumulative values.
 GROUP BY station_id
 ```
 
-A client moving between BSSIDs should remain one client unless a per-BSSID result is explicitly required.
+A client moving between BSSIDs should remain one client in the final response unless a per-BSSID result is explicitly required. However, BSSID/SSID/band/radio changes must define separate calculation streams for counter deltas unless a reliable association/session identifier says they are the same counter stream.
 
 ### Unit Conversion
 
@@ -704,15 +803,15 @@ Load TimePointDB records for resolvedBoardId and stored serialNumber == request 
     ↓
 Include records from startTime through endTime
     ↓
-Also load the latest pre-window association sample for each station MAC
+Also load the latest pre-window association sample for each calculated stream_key
     ↓
 Parse ssid_data associations
     ↓
-Group by station MAC and sort by timestamp
+Build stream_key values and sort samples by stream_key and timestamp
     ↓
 Calculate reset-safe RX/TX deltas
     ↓
-Sum values by MAC
+Aggregate stream-level deltas by station MAC
     ↓
 Convert bytes to megabits
     ↓
@@ -942,6 +1041,7 @@ reason
 connection_ip
 session_id
 event_id
+idempotency_key
 metadata
 ```
 
@@ -952,6 +1052,8 @@ Add a dedicated storage class for availability events:
 ```text
 src/storage/storage_device_availability_events.h
 src/storage/storage_device_availability_events.cpp
+src/storage/storage_device_availability_state.h
+src/storage/storage_device_availability_state.cpp
 ```
 
 Required ORM fields and indexes:
@@ -959,7 +1061,7 @@ Required ORM fields and indexes:
 ```text
 Fields:
   id              TEXT primary id
-  board_id        TEXT
+  board_id        TEXT NULL
   serialNumber    TEXT
   event_type      TEXT
   event_time      BIGINT
@@ -967,6 +1069,7 @@ Fields:
   connection_ip   TEXT
   session_id      TEXT
   event_id        TEXT
+  idempotency_key TEXT NOT NULL
   metadata        TEXT
 
 Indexes:
@@ -979,8 +1082,51 @@ Indexes:
     serialNumber ASC
     event_time ASC
 
+Unique constraints:
+  availability_idempotency_key_unique:
+    idempotency_key ASC
+
+Optional indexes:
   availability_event_id_index:
     event_id ASC
+```
+
+`event_id` stores the normalized source event id when the payload provides one, using `payload.ping.uuid`, `payload.uuid`, or `payload.disconnection.uuid` only when that `uuid` is stable for the same logical source event.
+
+`serialNumber` is the durable identity for availability history. `board_id` is event-time context only and must be nullable because connection events can arrive when the router is not currently assigned to an Analytics board, when OWPROV is unavailable, or after ownership has changed. Do not drop availability events only because current board ownership cannot be resolved.
+
+Add a persisted current-state table for restart-safe transition detection:
+
+```text
+device_availability_state
+-------------------------
+serialNumber
+board_id
+current_state
+last_event_time
+last_idempotency_key
+updated_at
+metadata
+```
+
+Required fields and constraints:
+
+```text
+Fields:
+  serialNumber         TEXT primary id
+  board_id             TEXT NULL
+  current_state        TEXT
+  last_event_time      BIGINT
+  last_idempotency_key TEXT
+  updated_at           BIGINT
+  metadata             TEXT
+
+Indexes:
+  availability_state_board_index:
+    board_id ASC
+
+Constraints:
+  current_state must be one of: online, offline, unknown
 ```
 
 Add a `DeviceAvailabilityEvent` REST/storage object with `to_json` and `from_json` support in:
@@ -995,12 +1141,17 @@ Update `StorageService`:
 ```text
 src/StorageService.h
   include storage/storage_device_availability_events.h
+  include storage/storage_device_availability_state.h
   add DeviceAvailabilityEventsDB accessor
+  add DeviceAvailabilityStateDB accessor
   add std::unique_ptr<DeviceAvailabilityEventsDB>
+  add std::unique_ptr<DeviceAvailabilityStateDB>
 
 src/StorageService.cpp
   construct DeviceAvailabilityEventsDB
+  construct DeviceAvailabilityStateDB
   call DeviceAvailabilityEventsDB->Create()
+  call DeviceAvailabilityStateDB->Create()
   include availability retention cleanup if retention should match board timepoint cleanup
 ```
 
@@ -1017,6 +1168,21 @@ src/APStats.cpp
   AP::UpdateConnection(...)
 ```
 
+Ingestion-time board source:
+
+```text
+1. Read board ownership from VenueCoordinator's maintained routerId -> boardId map.
+2. If a current mapping exists:
+     set board_id to the mapped board id.
+3. If no current mapping exists:
+     set board_id to NULL.
+     still persist the availability state/event by serialNumber when the message is otherwise valid.
+4. Do not perform a full OWPROV inventory lookup or board scan for every connection event.
+5. A background refresh or later request-time resolution may update current ownership, but it must not rewrite historical event ownership blindly.
+```
+
+The ingestion path must not depend on HTTP request-time `ResolveRouterIdContext`. That resolver can use OWPROV to verify or refresh ownership for API requests, but Kafka connection ingestion should use the maintained `VenueCoordinator` ownership map and tolerate missing current board ownership.
+
 Rules:
 
 ```text
@@ -1029,7 +1195,200 @@ On ping/capabilities:
 Do not store online events for every ping.
 ```
 
-The event writer must include `resolvedBoardId`/`board_id`, `serialNumber` set from request `routerId`, `event_type`, and the event timestamp. If the incoming connection message has a stable event id or session id, persist it and use `event_id` for idempotency.
+Bootstrap rule when no persisted state exists:
+
+```text
+First observed disconnection:
+  insert one offline event
+  set current_state = offline
+
+First observed ping/capabilities:
+  set current_state = online
+  do not insert an online event
+
+First observed unrecognized connection message:
+  set current_state = unknown
+  do not insert a counted event
+```
+
+In-memory transition checking is only an optimization. It is not sufficient for correctness because Kafka can redeliver messages and the service can restart after losing in-memory state. Transition detection must use `device_availability_state` or derive the latest known state from `device_availability_events` under the same transaction before writing. Duplicate connection messages must be rejected by storage-level idempotency before they can affect `offline_count`.
+
+Normalize connection messages before transition processing:
+
+```text
+If payload.ping exists:
+  message_type = ping
+  event_type = online
+  serialNumber = payload.ping.serialNumber
+  event_time = payload.ping.timestamp
+  source_event_uuid = payload.ping.uuid
+  connection_ip = payload.ping.connectionIp
+
+If payload.capabilities exists:
+  message_type = capabilities
+  event_type = online
+  serialNumber = payload.serial
+  event_time = payload.timestamp
+  source_event_uuid = payload.uuid
+  connection_ip = payload.connectionIp
+  reason = payload.reason
+
+If payload.disconnection exists:
+  message_type = disconnection
+  event_type = offline
+  serialNumber = payload.disconnection.serialNumber
+  event_time = payload.disconnection.timestamp
+  source_event_uuid = payload.disconnection.uuid
+```
+
+The event writer must include `board_id` from the ingestion-time ownership map when available, normalized `serialNumber`, `event_type`, normalized `event_time`, and a stable `idempotency_key`.
+
+Idempotency key rule:
+
+```text
+If the incoming connection message contains a stable source event id:
+  source_event_id = payload.ping.uuid
+    or payload.uuid
+    or payload.disconnection.uuid
+  idempotency_key = deterministic hash of:
+    system.host
+    system.id
+    serialNumber
+    message_type
+    source_event_id
+
+Else if the message contains a stable session id plus event timestamp:
+  idempotency_key = deterministic hash of:
+    serialNumber
+    message_type
+    event_type
+    event_time
+    session_id
+
+Else if connection_ip or reason is available:
+  idempotency_key = deterministic hash of the stable logical message identity:
+    serialNumber
+    message_type
+    event_type
+    event_time
+    reason
+    connection_ip
+
+Else:
+  idempotency_key = deterministic hash of the minimum stable logical identity:
+    serialNumber
+    message_type
+    event_type
+    event_time
+```
+
+Treat `uuid` as a source event id only if it is stable for the same logical connection message across Kafka redelivery and unique within the source namespace identified by `system.host` and `system.id`. If `uuid` is only a random per-delivery value, do not use it as `source_event_id`.
+
+Minimum fields for derived idempotency keys:
+
+```text
+All counted availability events:
+  serialNumber is required
+  event_type is required
+  event_time is required and must have the highest precision available from the source
+
+Offline events derived from disconnection:
+  reason or source disconnect cause is required when available
+  if reason/cause and connection_ip are missing:
+    prefer stable source_event_id from payload.disconnection.uuid
+    otherwise derive the key from serialNumber, message_type, event_type, and event_time
+  if reason/cause and connection_ip are missing and event_time precision is coarser than seconds:
+    do not write a counted offline event unless a stable source_event_id or session_id exists
+
+Online events derived from ping/capabilities:
+  session_id is required when available
+  if session_id is unavailable:
+    event_time plus message type must be precise enough to distinguish separate logical reconnects
+  if event_time is missing or too coarse to distinguish separate reconnects:
+    update current-state metadata only; do not write a counted online transition event
+
+Unrecognized connection messages:
+  do not write counted availability events
+  store only current-state metadata when useful
+```
+
+If the minimum fields for the event type are not present, the implementation must not create a counted `device_availability_events` row. It may update non-counted metadata only when doing so cannot move `device_availability_state` backward or create a false transition.
+
+Do not include `board_id` in the idempotency key unless it is part of a stable source event id. Board ownership can change between delivery and redelivery, and including current ownership in a derived key can turn one logical event into multiple stored events.
+
+Do not include Kafka topic, partition, or offset in the derived logical `idempotency_key`. Kafka coordinates identify a broker record, not the logical connection event. They dedupe redelivery of the same Kafka record, but they do not dedupe the same logical connection event produced as a second Kafka record with a different offset. Store topic, partition, offset, message key, and consumer timestamp in `metadata` for tracing only.
+
+The same delivered logical connection event must always produce the same `idempotency_key`. If the implementation cannot build a stable or deterministic key for an event, it must not write that event as a counted availability transition; log it as an ingestion error instead.
+
+Atomic transition and insert rule:
+
+```text
+For each valid connection message:
+  begin transaction
+  load the persisted state row for serialNumber with write/transaction isolation
+  if no state row exists:
+    treat previous state as unknown
+  determine the new state from the message
+  if state row exists and event_time is older than last_event_time:
+    treat the message as stale
+    do not insert an availability event
+    do not update device_availability_state
+    commit transaction
+    stop processing this message
+  if state row exists and event_time equals last_event_time and no reliable tie-breaker proves this event is later:
+    treat the message as duplicate or non-advancing
+    do not insert a counted availability event
+    do not update device_availability_state
+    commit transaction
+    stop processing this message
+  if previous state is unknown:
+    if new state is offline:
+      insert one offline event with conflict-safe semantics
+      if the insert created a row:
+        update device_availability_state to offline and last_event_time
+      else:
+        do not update device_availability_state
+    else if new state is online:
+      update device_availability_state to online and last_event_time
+      do not insert an online event
+    else:
+      update device_availability_state to unknown and last_event_time
+      do not insert a counted event
+  else if previous state differs from new state:
+    insert availability event with conflict-safe semantics:
+      INSERT ... ON CONFLICT(idempotency_key) DO NOTHING
+    if the insert created a row:
+      update device_availability_state to the new state and last_event_time
+    else:
+      treat it as a duplicate
+      do not update device_availability_state
+  else if previous state equals new state:
+    update last contact metadata only when event_time is newer than last_event_time
+    do not insert a counted transition event
+  commit transaction
+
+or the equivalent database-specific "insert if absent" operation.
+
+The storage method must return whether a row was inserted. Duplicate events that hit
+the unique idempotency constraint must not be treated as new offline transitions and
+must not move `device_availability_state` backward or forward.
+```
+
+Staleness rule:
+
+```text
+An event is stale when its event_time is older than the persisted state's
+last_event_time for the same serialNumber. An event with the same event_time is
+non-advancing unless a deterministic source tie-breaker proves it happened later.
+
+Stale or non-advancing events must not insert counted availability events and must
+not update device_availability_state, even if their idempotency_key has not been
+seen before.
+
+For equal timestamps, use deterministic tie-breakers if the source provides them.
+If no reliable tie-breaker exists, process at most one state-changing event for that
+serialNumber and timestamp.
+```
 
 ### Store Only State Transitions
 
@@ -1060,12 +1419,13 @@ offline_count =
 ```sql
 SELECT COUNT(*) AS offline_count
 FROM device_availability_events
-WHERE board_id = :board_id
-  AND serialNumber = :router_id
+WHERE serialNumber = :router_id
   AND event_type = 'offline'
   AND event_time >= :start_time
   AND event_time <= :end_time;
 ```
+
+Do not require `board_id = :resolvedBoardId` for the availability count. `board_id` is nullable event-time context and can differ from the router's current board after reassignment. The durable query identity for gateway availability history is `serialNumber`.
 
 ### Success Response with No Offline Events
 
@@ -1174,7 +1534,7 @@ usage-summary
 rssi-summary
 ```
 
-All handlers must call a shared serial-resolution helper before storage access:
+Timepoint-backed handlers must call a shared serial-resolution helper before storage access:
 
 ```cpp
 RouterIdResolutionResult ResolveRouterIdContext(
@@ -1182,7 +1542,18 @@ RouterIdResolutionResult ResolveRouterIdContext(
     const std::string& routerId);
 ```
 
-The helper must use status-aware OWPROV inventory lookup, read `InventoryTag.venue`, and resolve board ownership with `monitorSubVenues` support. It can either scan candidate board device lists through `SDK::Prov::Venue::GetDevices(..., VenueInfo.monitorSubVenues, ...)` or use a current `routerId -> boardId` map maintained by `VenueCoordinator`.
+The timepoint-backed handlers are:
+
+```text
+memory-summary
+radio-temperature-summary
+usage-summary
+rssi-summary
+```
+
+The helper must use the current `routerId -> boardId` map maintained by `VenueCoordinator` as the primary ownership source. OWPROV inventory lookup must be status-aware and is used to verify or refresh ownership on cache/map misses. Any refresh path must read `InventoryTag.venue` and resolve board ownership with `monitorSubVenues` support, using candidate board device lists through `SDK::Prov::Venue::GetDevices(..., VenueInfo.monitorSubVenues, ...)` when needed. A single MCP request must reuse one `RouterIdResolutionResult` for repeated metrics targeting the same `routerId`.
+
+`availability-summary` is the exception. It must validate `routerId` and authorization, but it must not require successful current `resolvedBoardId` resolution before reading availability storage. Request-time resolution may be used only for current context or authorization hints. The historical count must query availability storage by durable `serialNumber`, not by mandatory current `resolvedBoardId`.
 
 ---
 
@@ -1226,6 +1597,8 @@ src/storage/storage_wificlients.h
 src/storage/storage_wificlients.cpp
 src/storage/storage_device_availability_events.h
 src/storage/storage_device_availability_events.cpp
+src/storage/storage_device_availability_state.h
+src/storage/storage_device_availability_state.cpp
 src/StorageService.h
 src/StorageService.cpp
 ```
@@ -1261,7 +1634,7 @@ bool GetGatewayAvailabilitySummary(...);
 | `get_gateway_wifi_temp` | `GET /devices/{routerId}/radio-temperature-summary` | `timepoints.radio_data[].temperature` | Resolve routerId to venueId and boardId, then aggregate `timepoints` |
 | `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then reset-safe delta aggregation with pre-window baseline |
 | `get_device_rssi_quality` | `GET /devices/{routerId}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve routerId to venueId and boardId, then classify RSSI samples |
-| `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic | Resolve routerId to venueId and boardId, then aggregate persisted offline state transitions |
+| `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic plus `device_availability_events` | Use routerId as durable serialNumber, persist restart-safe state transitions, then count offline events by serialNumber |
 
 ---
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -1,0 +1,1264 @@
+# Analytics APIs for MCP Tools
+
+This document defines the request format, response format, and implementation logic for the following MCP tools in the `ra-wlan-cloud-analytics` service:
+
+- `get_gateway_free_memory`
+- `get_gateway_wifi_temp`
+- `get_device_bandwidth_consumption`
+- `get_device_rssi_quality`
+- `get_gateway_offline_count`
+
+The API contracts match the MCP tool names and response fields from the provided CSV.
+
+---
+
+# Common Input Parameters
+
+Each MCP tool receives:
+
+```text
+serial_number: str
+timestamp_till: str
+lookback_hours: int
+```
+
+The Analytics API should calculate the requested time range as:
+
+```text
+end_time = parse(timestamp_till)
+start_time = end_time - lookback_hours
+```
+
+Example:
+
+```text
+timestamp_till = 2026-07-27T12:00:00Z
+lookback_hours = 24
+
+start_time = 2026-07-26T12:00:00Z
+end_time   = 2026-07-27T12:00:00Z
+```
+
+Recommended query parameters:
+
+```http
+?timestampTill=2026-07-27T12:00:00Z
+&lookbackHours=24
+```
+
+These are `GET` APIs, so no request body is required.
+
+### Time Conversion and Validation
+
+The public MCP-facing parameters use ISO-8601/RFC3339 time, but the existing Analytics API style uses integer `fromDate` and `endDate` timestamps. Handlers should convert the request as:
+
+```text
+timestampTill: RFC3339 UTC string, for example 2026-07-27T12:00:00Z
+endTime:       Unix epoch seconds parsed from timestampTill
+startTime:     endTime - (lookbackHours * 3600)
+```
+
+Validation rules:
+
+```text
+timestampTill must parse as a valid timestamp.
+lookbackHours must be greater than 0.
+lookbackHours should have a bounded maximum, for example 24 * 31.
+startTime must be less than endTime.
+```
+
+Return `400 Bad Request` for invalid timestamps, unsupported timezones, non-positive `lookbackHours`, or values above the configured maximum. Internally, query `timepoints.timestamp` and `wificlienthistory.timestamp` using epoch seconds.
+
+### Current Storage Model
+
+The current service does not store normalized tables named `device_timepoints`, `radio_timepoints`, or `wifi_client_history`.
+
+Current tables are:
+
+```text
+timepoints
+  boardId
+  timestamp
+  ap_data      JSON string
+  ssid_data    JSON string
+  radio_data   JSON string
+  device_info  JSON string
+  serialNumber
+
+wificlienthistory
+  timestamp
+  station_id
+  bssid
+  ssid
+  rssi
+  rx_bytes
+  tx_bytes
+  venue_id
+  ...
+```
+
+Gateway-scoped APIs should accept only `serialNumber` publicly. The handler must resolve the internal `boardId` before loading `TimePointDB` records.
+
+### Serial Number Resolution
+
+The MCP tool cannot pass `boardId`, so Analytics must resolve it from the gateway serial number.
+
+Resolution flow:
+
+```text
+1. Validate serialNumber.
+2. Call OWPROV inventory for the serial number with status-aware handling:
+     GET /api/v1/inventory/{serialNumber}
+3. Read inventoryTag.venue as venueId.
+4. Find the Analytics board that currently owns serialNumber.
+5. Use that board's BoardInfo.info.id as resolvedBoardId.
+6. Query Analytics storage with resolvedBoardId and serialNumber.
+```
+
+Implementation notes:
+
+```text
+OWPROV source:
+  /api/v1/inventory/{serialNumber}
+
+OWPROV response field:
+  InventoryTag.venue
+
+Analytics local source:
+  BoardsDB records
+  BoardInfo.venueList[].id
+  BoardInfo.venueList[].monitorSubVenues
+```
+
+Board ownership resolution must account for child venues. Do not only check whether `inventoryTag.venue` is directly present in `BoardInfo.venueList`.
+
+Preferred ownership algorithm:
+
+```text
+For each local BoardInfo record:
+  for each VenueInfo in BoardInfo.venueList:
+    call SDK::Prov::Venue::GetDevices(
+      client,
+      VenueInfo.id,
+      VenueInfo.monitorSubVenues,
+      venueDeviceList,
+      venueExists)
+
+    if serialNumber is present in venueDeviceList.devices:
+      add BoardInfo.info.id as a candidate board
+
+If exactly one candidate exists:
+  resolvedBoardId = candidate board
+```
+
+This mirrors the existing watcher behavior, where board devices are fetched from OWPROV with the board venue's `monitorSubVenues` setting.
+
+Alternative implementation:
+
+```text
+Expose a current serialNumber -> boardId map from VenueCoordinator.
+The map must be maintained from the same device lists used by VenueWatcher.
+The resolver may use this map instead of scanning OWPROV for every request.
+```
+
+Failure handling:
+
+```text
+OWPROV inventory not found              -> 404 Not Found
+Inventory exists but venue is empty     -> 404 Not Found
+No Analytics board configured for venue -> 404 Not Found
+Multiple matching boards                -> 409 Conflict unless deterministic ownership exists
+OWPROV unavailable or invalid response  -> 502 Bad Gateway
+```
+
+The resolver must return a status-bearing result, not a boolean, so handlers can map each failure to the correct HTTP response.
+
+```cpp
+enum class SerialResolutionStatus {
+    Success,
+    InvalidSerialNumber,
+    InventoryNotFound,
+    EmptyVenue,
+    BoardNotConfigured,
+    MultipleBoards,
+    OwprovUnavailable,
+    OwprovInvalidResponse
+};
+
+struct SerialResolutionResult {
+    SerialResolutionStatus status = SerialResolutionStatus::OwprovUnavailable;
+    std::string serialNumber;
+    std::string venueId;
+    std::string resolvedBoardId;
+    std::string message;
+};
+```
+
+Status mapping:
+
+```text
+Success               -> continue request
+InvalidSerialNumber   -> 400 Bad Request
+InventoryNotFound     -> 404 Not Found
+EmptyVenue            -> 404 Not Found
+BoardNotConfigured    -> 404 Not Found
+MultipleBoards        -> 409 Conflict
+OwprovUnavailable     -> 502 Bad Gateway
+OwprovInvalidResponse -> 502 Bad Gateway
+```
+
+The existing `SDK::Prov::Device::Get` helper returns only `bool` and does not expose the OWPROV HTTP status. Do not use that bool-only helper when the handler must distinguish `404 Not Found` from OWPROV connectivity or parsing failures. Use one of these instead:
+
+```text
+Option A:
+  Add a status-aware SDK helper, for example:
+    SDK::Prov::Device::GetWithStatus(...)
+
+Option B:
+  Call OpenAPIRequestGet(uSERVICE_PROVISIONING, "/api/v1/inventory/{serialNumber}", ...)
+  directly from ResolveSerialNumberContext and inspect the HTTP response status.
+```
+
+Handlers may cache `serialNumber -> venueId -> boardId` for a short TTL, but must refresh or invalidate the cache when OWPROV reports a different venue.
+
+---
+
+# 1. `get_gateway_free_memory`
+
+## MCP Tool Signature
+
+```text
+get_gateway_free_memory(
+    serial_number: str,
+    timestamp_till: str,
+    lookback_hours: int
+)
+```
+
+## Recommended API
+
+```http
+GET /api/v1/devices/{serialNumber}/memory-summary
+    ?timestampTill=2026-07-27T12:00:00Z
+    &lookbackHours=24
+```
+
+## Example Request
+
+```http
+GET /api/v1/devices/60cf84f22290/memory-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24
+Authorization: Bearer <token>
+```
+
+## Request Body
+
+```text
+None
+```
+
+## Response
+
+```json
+{
+  "min_memfree": 211374,
+  "max_memfree": 215050,
+  "avg_memfree": 212074.36
+}
+```
+
+## API Logic
+
+The gateway state payload contains:
+
+```text
+unit.memory.free
+unit.memory.total
+unit.memory.cached
+unit.memory.buffered
+```
+
+The current Analytics implementation calculates memory usage percentage from `free` and `total`, but does not preserve all raw memory values as separate historical fields.
+
+### Required Model Change
+
+Add raw memory fields to the device time-point model and persist them with each `timepoints` record:
+
+```cpp
+struct DeviceResourceTimePoint {
+    uint64_t memory_free = 0;
+    uint64_t memory_total = 0;
+    uint64_t memory_cached = 0;
+    uint64_t memory_buffered = 0;
+};
+
+struct DeviceTimePoint {
+    ...
+    DeviceResourceTimePoint resource_data;
+};
+```
+
+Required code changes:
+
+```text
+src/RESTObjects/RESTAPI_AnalyticsObjects.h
+  Add DeviceResourceTimePoint.
+  Add DeviceTimePoint::resource_data.
+
+src/RESTObjects/RESTAPI_AnalyticsObjects.cpp
+  Add DeviceResourceTimePoint to_json/from_json.
+  Add resource_data to DeviceTimePoint to_json/from_json.
+
+src/storage/storage_timepoints.h
+  Extend TimePointDBRecordType with a resource_data JSON string field.
+
+src/storage/storage_timepoints.cpp
+  Add ORM field resource_data.
+  Update Convert(record -> DeviceTimePoint).
+  Update Convert(DeviceTimePoint -> record).
+  Add an Upgrade migration for existing DBs.
+
+src/APStats.cpp
+  Populate DTP.resource_data from unit.memory during state ingestion.
+```
+
+Existing rows will not have `resource_data`; treat those rows as missing memory samples rather than zero free memory.
+
+### Ingestion Logic
+
+```cpp
+AnalyticsObjects::DeviceResourceTimePoint resource;
+GetJSON("free", memory, resource.memory_free, uint64_t{0});
+GetJSON("total", memory, resource.memory_total, uint64_t{0});
+GetJSON("cached", memory, resource.memory_cached, uint64_t{0});
+GetJSON("buffered", memory, resource.memory_buffered, uint64_t{0});
+DTP.resource_data = resource;
+```
+
+### Aggregation Logic
+
+Use the current `timepoints` table plus parsed JSON fields:
+
+```text
+Load TimePointDB records where:
+  boardId == resolvedBoardId
+  serialNumber == serialNumber
+  timestamp >= startTime
+  timestamp <= endTime
+
+For each record:
+  read record.resource_data.memory_free
+  ignore missing resource_data
+  ignore memory_free when memory_total is 0 and the sample came from a missing memory block
+
+Return:
+  min_memfree = min(memory_free samples)
+  max_memfree = max(memory_free samples)
+  avg_memfree = sum(memory_free samples) / sample_count
+```
+
+Do not query `device_timepoints.memory_free` unless a separate normalized table and migration are introduced.
+
+### Handler Flow
+
+```text
+Validate serialNumber
+    ↓
+Call ResolveSerialNumberContext(client, serialNumber)
+    ↓
+If status is not Success, map SerialResolutionStatus to HTTP response
+    ↓
+Use result.venueId and result.resolvedBoardId
+    ↓
+Parse timestampTill
+    ↓
+Calculate start_time
+    ↓
+Query timepoints and read resource_data.memory_free samples
+    ↓
+Calculate min, max and average
+    ↓
+Return MCP response shape
+```
+
+### Empty Result
+
+```json
+{
+  "min_memfree": null,
+  "max_memfree": null,
+  "avg_memfree": null
+}
+```
+
+Use HTTP `200 OK` when the query succeeds but no data exists.
+
+---
+
+# 2. `get_gateway_wifi_temp`
+
+## MCP Tool Signature
+
+```text
+get_gateway_wifi_temp(
+    serial_number: str,
+    timestamp_till: str,
+    lookback_hours: int
+)
+```
+
+## Recommended API
+
+```http
+GET /api/v1/devices/{serialNumber}/radio-temperature-summary
+    ?timestampTill=2026-07-27T12:00:00Z
+    &lookbackHours=24
+```
+
+## Example Request
+
+```http
+GET /api/v1/devices/60cf84f22290/radio-temperature-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24
+Authorization: Bearer <token>
+```
+
+## Request Body
+
+```text
+None
+```
+
+## Response
+
+```json
+{
+  "min_wifi_temp_2.4G": 62,
+  "max_wifi_temp_2.4G": 70,
+  "avg_wifi_temp_2.4G": 66.64,
+  "min_wifi_temp_5G": 56,
+  "max_wifi_temp_5G": 65,
+  "avg_wifi_temp_5G": 60.38
+}
+```
+
+## API Logic
+
+Analytics already stores:
+
+```text
+radios[].band
+radios[].temperature
+```
+
+The current radio-band mapping is:
+
+```text
+2G → 2
+5G → 5
+6G → 6
+```
+
+Response mapping:
+
+```text
+band = 2 → fields ending in _2.4G
+band = 5 → fields ending in _5G
+```
+
+### Aggregation Logic
+
+Use the current `timepoints.radio_data` JSON array:
+
+```text
+Load TimePointDB records where:
+  boardId == resolvedBoardId
+  serialNumber == serialNumber
+  timestamp >= startTime
+  timestamp <= endTime
+
+For each record:
+  parse radio_data
+  for each radio in radio_data:
+    if radio.band is 2 or 5:
+      add radio.temperature to that band's sample list
+
+For each band:
+  min_temperature = min(samples)
+  max_temperature = max(samples)
+  avg_temperature = sum(samples) / sample_count
+```
+
+Do not query `radio_timepoints` unless a separate normalized table and migration are introduced.
+
+### Handler Logic
+
+```cpp
+if (radio.band == 2) {
+    response.min_wifi_temp_2_4G = summary.min;
+    response.max_wifi_temp_2_4G = summary.max;
+    response.avg_wifi_temp_2_4G = summary.avg;
+}
+
+if (radio.band == 5) {
+    response.min_wifi_temp_5G = summary.min;
+    response.max_wifi_temp_5G = summary.max;
+    response.avg_wifi_temp_5G = summary.avg;
+}
+```
+
+### Missing Band Example
+
+```json
+{
+  "min_wifi_temp_2.4G": 62,
+  "max_wifi_temp_2.4G": 70,
+  "avg_wifi_temp_2.4G": 66.64,
+  "min_wifi_temp_5G": null,
+  "max_wifi_temp_5G": null,
+  "avg_wifi_temp_5G": null
+}
+```
+
+---
+
+# 3. `get_device_bandwidth_consumption`
+
+## MCP Tool Signature
+
+```text
+get_device_bandwidth_consumption(
+    serial_number: str,
+    timestamp_till: str,
+    lookback_hours: int
+)
+```
+
+## Recommended API
+
+```http
+GET /api/v1/devices/{serialNumber}/wifi-clients/usage-summary
+    ?timestampTill=2026-07-27T12:00:00Z
+    &lookbackHours=24
+```
+
+## Example Request
+
+```http
+GET /api/v1/devices/60cf84f22290/wifi-clients/usage-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24
+Authorization: Bearer <token>
+```
+
+## Request Body
+
+```text
+None
+```
+
+## Response
+
+```json
+[
+  {
+    "mac": "e2:51:95:ed:0f:28",
+    "data_consume_rx": "851.9 Mb",
+    "data_consume_tx": "30.81 Mb",
+    "total_data_usage": "882.71 Mb"
+  },
+  {
+    "mac": "28:39:26:a1:7c:a5",
+    "data_consume_rx": "240.57 Mb",
+    "data_consume_tx": "131.89 Mb",
+    "total_data_usage": "372.46 Mb"
+  }
+]
+```
+
+## API Logic
+
+For gateway-scoped results, use `timepoints.ssid_data[].associations[]` because `wificlienthistory` currently does not store the gateway `serialNumber`.
+
+`timepoints.ssid_data[].associations[]` already stores per-client:
+
+```text
+station MAC
+RX bytes
+TX bytes
+packet counters
+connected duration
+BSSID
+SSID
+radio information
+```
+
+Alternative implementation:
+
+```text
+If wificlienthistory is preferred for performance, first add serialNumber to:
+  AnalyticsObjects::WifiClientHistory
+  WifiClientHistoryDBRecordType
+  storage_wificlients.cpp fields and converters
+  APStats.cpp ingestion
+  DB upgrade migration
+```
+
+The values are cumulative counters, so they must not be summed directly.
+
+### Correct Calculation
+
+```text
+baseline = last sample before start_time for the same client, if available
+
+first in-window delta:
+  if baseline exists:
+    resetSafeDelta(first.rx_bytes, baseline.rx_bytes)
+  else:
+    0
+
+subsequent deltas:
+  resetSafeDelta(current.rx_bytes, previous.rx_bytes)
+
+data_consume_rx = SUM(reset-safe rx_bytes deltas)
+data_consume_tx = SUM(reset-safe tx_bytes deltas)
+total_data_usage = data_consume_rx + data_consume_tx
+```
+
+### Reset-Safe Delta Logic
+
+```cpp
+uint64_t resetSafeDelta(uint64_t current, uint64_t previous) {
+    if (current >= previous) {
+        return current - previous;
+    }
+
+    return current;
+}
+```
+
+This handles:
+
+```text
+client reconnection
+counter reset
+gateway reboot
+counter rollover
+```
+
+Without the pre-window baseline, the first sample inside the requested window can include traffic that occurred before `start_time`. Do not add the first in-window cumulative counter directly unless it is known to be a fresh association/reset.
+
+### Incorrect Calculation
+
+```sql
+SUM(rx_bytes)
+SUM(tx_bytes)
+```
+
+This would overcount cumulative values.
+
+### Grouping
+
+```text
+GROUP BY station_id
+```
+
+A client moving between BSSIDs should remain one client unless a per-BSSID result is explicitly required.
+
+### Unit Conversion
+
+The MCP output expects strings such as:
+
+```text
+851.9 Mb
+30.81 Mb
+```
+
+Recommended conversion:
+
+```cpp
+double rxMb = static_cast<double>(rxBytes) * 8.0 / 1000000.0;
+double txMb = static_cast<double>(txBytes) * 8.0 / 1000000.0;
+```
+
+`Mb` means megabits. If the implementation divides bytes by `1024 * 1024`, label the result as `MiB` or `MB` instead.
+
+Formatting:
+
+```cpp
+fmt::format("{:.2f} Mb", value);
+```
+
+### Query Flow
+
+```text
+Resolve boardId from serialNumber
+    ↓
+Load TimePointDB records for resolvedBoardId and serialNumber
+    ↓
+Include records from startTime through endTime
+    ↓
+Also load the latest pre-window association sample for each station MAC
+    ↓
+Parse ssid_data associations
+    ↓
+Group by station MAC and sort by timestamp
+    ↓
+Calculate reset-safe RX/TX deltas
+    ↓
+Sum values by MAC
+    ↓
+Convert bytes to megabits
+    ↓
+Return array
+```
+
+---
+
+# 4. `get_device_rssi_quality`
+
+## MCP Tool Signature
+
+```text
+get_device_rssi_quality(
+    serial_number: str,
+    timestamp_till: str,
+    lookback_hours: int
+)
+```
+
+## Recommended API
+
+```http
+GET /api/v1/devices/{serialNumber}/wifi-clients/rssi-summary
+    ?timestampTill=2026-07-27T12:00:00Z
+    &lookbackHours=24
+```
+
+## Example Request
+
+```http
+GET /api/v1/devices/60cf84f22290/wifi-clients/rssi-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24
+Authorization: Bearer <token>
+```
+
+## Request Body
+
+```text
+None
+```
+
+## Response
+
+```json
+[
+  {
+    "mac": "e2:51:95:ed:0f:28",
+    "rssi_excellent_pct": 41.67,
+    "rssi_good_pct": 50.0,
+    "rssi_fair_pct": 1.67,
+    "rssi_poor_pct": 6.67,
+    "rssi_total_samples": 60
+  },
+  {
+    "mac": "28:39:26:a1:7c:a5",
+    "rssi_excellent_pct": 92.73,
+    "rssi_good_pct": 7.27,
+    "rssi_fair_pct": 0.0,
+    "rssi_poor_pct": 0.0,
+    "rssi_total_samples": 110
+  }
+]
+```
+
+## API Logic
+
+For gateway-scoped results, read RSSI from `timepoints.ssid_data[].associations[]`. `wificlienthistory` also stores RSSI, but it cannot be filtered by gateway `serialNumber` unless that model is extended as described in the bandwidth section.
+
+### RSSI Thresholds
+
+```text
+Excellent: RSSI >= -55
+Good:      -67 <= RSSI < -55
+Fair:      -75 <= RSSI < -67
+Poor:      RSSI < -75
+```
+
+### Invalid Samples
+
+Ignore:
+
+```text
+RSSI = 0
+RSSI > 0
+RSSI < -127
+NULL
+```
+
+### Per-Client Calculation
+
+```text
+excellent_count = COUNT(rssi >= -55)
+
+good_count =
+    COUNT(rssi >= -67 AND rssi < -55)
+
+fair_count =
+    COUNT(rssi >= -75 AND rssi < -67)
+
+poor_count =
+    COUNT(rssi < -75)
+
+total_samples =
+    excellent_count +
+    good_count +
+    fair_count +
+    poor_count
+```
+
+Percentages:
+
+```text
+excellent_pct = excellent_count × 100 / total_samples
+good_pct      = good_count × 100 / total_samples
+fair_pct      = fair_count × 100 / total_samples
+poor_pct      = poor_count × 100 / total_samples
+```
+
+Round percentages to two decimal places.
+
+### Current Storage Aggregation Logic
+
+```text
+Load TimePointDB records where:
+  boardId == resolvedBoardId
+  serialNumber == serialNumber
+  timestamp >= startTime
+  timestamp <= endTime
+
+For each record:
+  parse ssid_data
+  for each association:
+    station_id = normalized association.station MAC
+    rssi = association.rssi
+    ignore invalid RSSI samples
+    increment the station_id bucket for excellent/good/fair/poor
+
+For each station_id:
+  total_samples = excellent + good + fair + poor
+  calculate percentages from total_samples
+```
+
+Do not query `wifi_client_history.board_id`, `wifi_client_history.serial_number`, or `wifi_client_history.created`; those fields do not exist in the current schema.
+
+The API should return the final percentages directly. The MCP server should not need to perform additional RSSI summarisation.
+
+---
+
+# 5. `get_gateway_offline_count`
+
+## MCP Tool Signature
+
+```text
+get_gateway_offline_count(
+    serial_number: str,
+    timestamp_till: str,
+    lookback_hours: int
+)
+```
+
+## Recommended API
+
+```http
+GET /api/v1/devices/{serialNumber}/availability-summary
+    ?timestampTill=2026-07-27T12:00:00Z
+    &lookbackHours=24
+```
+
+## Example Request
+
+```http
+GET /api/v1/devices/60cf84f22290/availability-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24
+Authorization: Bearer <token>
+```
+
+## Request Body
+
+```text
+None
+```
+
+## Response
+
+```json
+{
+  "gw_uuid": "60cf84f22290",
+  "fetch_status": "success",
+  "offline_count": 6
+}
+```
+
+## API Logic
+
+This API can use gateway events from the existing `connection` topic.
+
+Analytics currently handles gateway-level events:
+
+```text
+ping
+disconnection
+capabilities
+```
+
+The current code updates:
+
+```text
+connected
+lastConnection
+lastDisconnection
+lastPing
+lastContact
+```
+
+To calculate historical offline counts, transitions must be persisted.
+
+### Storage Table
+
+```text
+device_availability_events
+--------------------------
+id
+board_id
+serial_number
+event_type
+event_time
+reason
+connection_ip
+session_id
+event_id
+metadata
+```
+
+### Required Storage Implementation
+
+Add a dedicated storage class for availability events:
+
+```text
+src/storage/storage_device_availability_events.h
+src/storage/storage_device_availability_events.cpp
+```
+
+Required ORM fields and indexes:
+
+```text
+Fields:
+  id              TEXT primary id
+  board_id        TEXT
+  serial_number   TEXT
+  event_type      TEXT
+  event_time      BIGINT
+  reason          TEXT
+  connection_ip   TEXT
+  session_id      TEXT
+  event_id        TEXT
+  metadata        TEXT
+
+Indexes:
+  availability_serial_time_index:
+    serial_number ASC
+    event_time ASC
+
+  availability_board_serial_time_index:
+    board_id ASC
+    serial_number ASC
+    event_time ASC
+
+  availability_event_id_index:
+    event_id ASC
+```
+
+Add a `DeviceAvailabilityEvent` REST/storage object with `to_json` and `from_json` support in:
+
+```text
+src/RESTObjects/RESTAPI_AnalyticsObjects.h
+src/RESTObjects/RESTAPI_AnalyticsObjects.cpp
+```
+
+Update `StorageService`:
+
+```text
+src/StorageService.h
+  include storage/storage_device_availability_events.h
+  add DeviceAvailabilityEventsDB accessor
+  add std::unique_ptr<DeviceAvailabilityEventsDB>
+
+src/StorageService.cpp
+  construct DeviceAvailabilityEventsDB
+  call DeviceAvailabilityEventsDB->Create()
+  include availability retention cleanup if retention should match board timepoint cleanup
+```
+
+Add a DB upgrade/migration path for the new table. Existing deployments will start with no historical availability events; the API should return `offline_count: 0` for successful empty queries, not infer old events from `lastDisconnection`.
+
+Add the files to `CMakeLists.txt`.
+
+### Ingestion Hook
+
+Persist availability events from connection handling:
+
+```text
+src/APStats.cpp
+  AP::UpdateConnection(...)
+```
+
+Rules:
+
+```text
+On disconnection:
+  store one offline event when the device transitions from connected to disconnected.
+
+On ping/capabilities:
+  store one online event only when the device transitions from disconnected to connected.
+
+Do not store online events for every ping.
+```
+
+The event writer must include `resolvedBoardId`/`board_id`, `serial_number`, `event_type`, and the event timestamp. If the incoming connection message has a stable event id or session id, persist it and use `event_id` for idempotency.
+
+### Store Only State Transitions
+
+Correct:
+
+```text
+offline → online: store online event
+online → offline: store offline event
+```
+
+Incorrect:
+
+```text
+every ping → store online event
+```
+
+Every ping should not be treated as a new online transition.
+
+### Calculation
+
+```text
+offline_count =
+    COUNT(event_type = 'offline')
+```
+
+### Query
+
+```sql
+SELECT COUNT(*) AS offline_count
+FROM device_availability_events
+WHERE board_id = :board_id
+  AND serial_number = :serial_number
+  AND event_type = 'offline'
+  AND event_time >= :start_time
+  AND event_time <= :end_time;
+```
+
+### Success Response with No Offline Events
+
+```json
+{
+  "gw_uuid": "60cf84f22290",
+  "fetch_status": "success",
+  "offline_count": 0
+}
+```
+
+### Internal Error
+
+Use an HTTP error:
+
+```http
+500 Internal Server Error
+```
+
+```json
+{
+  "error": "availability_query_failed",
+  "message": "Unable to retrieve gateway availability history"
+}
+```
+
+Do not return `fetch_status: failed` with HTTP 200 for internal failures.
+
+---
+
+# Repository Implementation Structure
+
+Repository:
+
+```text
+routerarchitects/ra-wlan-cloud-analytics
+```
+
+## OpenAPI
+
+Update:
+
+```text
+openapi/owanalytics.yaml
+```
+
+Add:
+
+```yaml
+/devices/{serialNumber}/memory-summary:
+/devices/{serialNumber}/radio-temperature-summary:
+/devices/{serialNumber}/availability-summary:
+/devices/{serialNumber}/wifi-clients/usage-summary:
+/devices/{serialNumber}/wifi-clients/rssi-summary:
+```
+
+---
+
+## REST Objects
+
+Update:
+
+```text
+src/RESTObjects/RESTAPI_AnalyticsObjects.h
+src/RESTObjects/RESTAPI_AnalyticsObjects.cpp
+```
+
+Add objects:
+
+```cpp
+struct GatewayMemorySummary;
+struct GatewayWifiTemperatureSummary;
+struct ClientBandwidthConsumption;
+struct ClientRssiQuality;
+struct GatewayOfflineSummary;
+```
+
+JSON field names should match the MCP CSV exactly.
+
+---
+
+## REST Handlers
+
+Recommended files:
+
+```text
+src/RESTAPI/RESTAPI_device_metrics_summary_handler.h
+src/RESTAPI/RESTAPI_device_metrics_summary_handler.cpp
+
+src/RESTAPI/RESTAPI_wifi_client_metrics_handler.h
+src/RESTAPI/RESTAPI_wifi_client_metrics_handler.cpp
+```
+
+Device metrics handler:
+
+```text
+memory-summary
+radio-temperature-summary
+availability-summary
+```
+
+Wi-Fi client metrics handler:
+
+```text
+usage-summary
+rssi-summary
+```
+
+All handlers must call a shared serial-resolution helper before storage access:
+
+```cpp
+SerialResolutionResult ResolveSerialNumberContext(
+    RESTAPIHandler* client,
+    const std::string& serialNumber);
+```
+
+The helper must use status-aware OWPROV inventory lookup, read `InventoryTag.venue`, and resolve board ownership with `monitorSubVenues` support. It can either scan candidate board device lists through `SDK::Prov::Venue::GetDevices(..., VenueInfo.monitorSubVenues, ...)` or use a current `serialNumber -> boardId` map maintained by `VenueCoordinator`.
+
+---
+
+## Router Registration
+
+Update:
+
+```text
+src/RESTAPI/RESTAPI_routers.cpp
+```
+
+Register the new handlers in both:
+
+```text
+RESTAPI_Router
+RESTAPI_Router_I
+```
+
+---
+
+## Build Configuration
+
+Update:
+
+```text
+CMakeLists.txt
+```
+
+Add all new handler and storage `.cpp` and `.h` files.
+
+---
+
+## Storage Files
+
+Update:
+
+```text
+src/storage/storage_timepoints.h
+src/storage/storage_timepoints.cpp
+src/storage/storage_wificlients.h
+src/storage/storage_wificlients.cpp
+src/storage/storage_device_availability_events.h
+src/storage/storage_device_availability_events.cpp
+src/StorageService.h
+src/StorageService.cpp
+```
+
+`storage_wificlients.*` only needs changes if the implementation chooses to add `serialNumber` to `wificlienthistory`. The default implementation for gateway-scoped client summaries should aggregate `timepoints.ssid_data` to avoid that migration.
+
+Suggested functions:
+
+```cpp
+bool GetMemorySummary(
+    const std::string& resolvedBoardId,
+    const std::string& serialNumber,
+    uint64_t startTime,
+    uint64_t endTime,
+    AnalyticsObjects::GatewayMemorySummary& result);
+
+bool GetRadioTemperatureSummary(...);
+
+bool GetWifiClientUsageSummary(...);
+
+bool GetWifiClientRssiSummary(...);
+
+bool GetGatewayAvailabilitySummary(...);
+```
+
+---
+
+# Final Mapping
+
+| MCP Tool | Analytics API | Data Source | Implementation Status |
+|---|---|---|---|
+| `get_gateway_free_memory` | `GET /devices/{serialNumber}/memory-summary` | `timepoints.resource_data.memory_free` | Resolve serial to venueId and boardId, then aggregate `timepoints` |
+| `get_gateway_wifi_temp` | `GET /devices/{serialNumber}/radio-temperature-summary` | `timepoints.radio_data[].temperature` | Resolve serial to venueId and boardId, then aggregate `timepoints` |
+| `get_device_bandwidth_consumption` | `GET /devices/{serialNumber}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve serial to venueId and boardId, then reset-safe delta aggregation with pre-window baseline |
+| `get_device_rssi_quality` | `GET /devices/{serialNumber}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve serial to venueId and boardId, then classify RSSI samples |
+| `get_gateway_offline_count` | `GET /devices/{serialNumber}/availability-summary` | Existing gateway `connection` topic | Resolve serial to venueId and boardId, then aggregate persisted offline state transitions |
+
+---
+
+# Recommended Implementation Order
+
+1. `get_gateway_wifi_temp`
+2. `get_device_rssi_quality`
+3. `get_device_bandwidth_consumption`
+4. `get_gateway_free_memory`
+5. `get_gateway_offline_count`

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -559,6 +559,45 @@ Existing rows will not have `resource_data`; treat those rows as missing memory 
 
 Do not represent missing memory fields as `0`. A missing `memory_free` value and a genuine reported zero must remain distinguishable.
 
+Migration coverage rule:
+
+```text
+Define a fixed memory_resource_data_valid_from timestamp as the deployment/migration
+timestamp where timepoints.resource_data.memory_free starts being written
+consistently.
+
+If startTime < memory_resource_data_valid_from:
+  effectiveStartTime = min(memory_resource_data_valid_from, endTime)
+  partial = true
+
+If startTime >= memory_resource_data_valid_from:
+  effectiveStartTime = startTime
+  partial = false
+
+effectiveEndTime = endTime
+```
+
+When the requested range starts before memory_resource_data_valid_from, the API
+may still return `200 OK`, but the aggregate values must represent only
+`[effectiveStartTime, endTime)`. The response must include a coverage header so
+consumers can distinguish a complete-window average from a post-migration-only
+partial average.
+
+Response coverage header:
+
+```http
+X-Analytics-Coverage: {"requested_start":"2026-07-26T12:00:00Z","requested_end":"2026-07-27T12:00:00Z","effective_start":"2026-07-26T12:00:00Z","effective_end":"2026-07-27T12:00:00Z","data_available_from":"2026-07-01T00:00:00Z","partial":false}
+```
+
+Header fields must use RFC3339 UTC timestamps. `requested_start` and
+`requested_end` are the original half-open request window. `effective_start` and
+`effective_end` are the half-open window used for aggregation. `data_available_from`
+is `memory_resource_data_valid_from`. `partial` is `true` when
+`effective_start` is later than `requested_start`. If the entire requested range
+is before `memory_resource_data_valid_from`, `effective_start` and
+`effective_end` must both equal `requested_end`, the aggregate window is empty,
+and the response body uses the normal empty-result values.
+
 ### Ingestion Logic
 
 ```cpp
@@ -586,7 +625,7 @@ Use the current `timepoints` table plus parsed JSON fields:
 Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
-  timestamp >= startTime
+  timestamp >= effectiveStartTime
   timestamp < endTime
 
 For each record:
@@ -616,6 +655,8 @@ Use result.venueId and result.resolvedBoardId
 Parse timestampTill
     ↓
 Calculate start_time
+    ↓
+Calculate effectiveStartTime and X-Analytics-Coverage
     ↓
 Query timepoints and read resource_data.memory_free samples
     ↓
@@ -706,7 +747,7 @@ Do not synthesize a numeric fallback temperature for missing data.
 Do not store a placeholder in wifi_temp for a missing temperature.
 ```
 
-Migration boundary rule:
+Migration coverage rule:
 
 ```text
 Define a fixed temperature_migration_cutover_time as the deployment/migration
@@ -717,14 +758,40 @@ Ignore all earlier records because historical temperature values cannot reliably
 distinguish measured values from synthetic fallback values.
 
 If the requested range starts before temperature_migration_cutover_time:
-  effective_start_time = temperature_migration_cutover_time
-else:
-  effective_start_time = startTime
+  effectiveStartTime = min(temperature_migration_cutover_time, endTime)
+  partial = true
+
+If startTime >= temperature_migration_cutover_time:
+  effectiveStartTime = startTime
+  partial = false
+
+effectiveEndTime = endTime
 
 Do not filter out post-cutover samples only because the measured value is 20°C.
 After the cutover, a present wifi_temp value is treated as a legitimate
 measurement.
 ```
+
+When the requested range starts before temperature_migration_cutover_time, the
+API may still return `200 OK`, but the aggregate values must represent only
+`[effectiveStartTime, endTime)`. The response must include a coverage header so
+consumers can distinguish a complete-window average from a post-migration-only
+partial average.
+
+Response coverage header:
+
+```http
+X-Analytics-Coverage: {"requested_start":"2026-07-26T12:00:00Z","requested_end":"2026-07-27T12:00:00Z","effective_start":"2026-07-26T12:00:00Z","effective_end":"2026-07-27T12:00:00Z","data_available_from":"2026-07-01T00:00:00Z","partial":false}
+```
+
+Header fields must use RFC3339 UTC timestamps. `requested_start` and
+`requested_end` are the original half-open request window. `effective_start` and
+`effective_end` are the half-open window used for aggregation. `data_available_from`
+is `temperature_migration_cutover_time`. `partial` is `true` when
+`effective_start` is later than `requested_start`. If the entire requested range
+is before `temperature_migration_cutover_time`, `effective_start` and
+`effective_end` must both equal `requested_end`, the aggregate window is empty,
+and the response body uses the normal empty-result values.
 
 The current radio-band mapping is:
 
@@ -749,7 +816,7 @@ Use the current `timepoints.radio_data` JSON array:
 Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
-  timestamp >= effective_start_time
+  timestamp >= effectiveStartTime
   timestamp < endTime
 
 For each record:

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -17,16 +17,26 @@ The API contracts match the MCP tool names and response fields from the provided
 Each MCP tool receives:
 
 ```text
-serial_number: str
+router_id: str
 timestamp_till: str
 lookback_hours: int
+```
+
+`router_id` is the gateway serial number value from the CSV. Analytics APIs expose the same value as the path variable `routerId`.
+
+```text
+MCP input:              router_id
+Analytics path variable: routerId
+routerId = router_id
+Internal storage field: serialNumber
+serialNumber = routerId
 ```
 
 The Analytics API should calculate the requested time range as:
 
 ```text
 end_time = parse(timestamp_till)
-start_time = end_time - lookback_hours
+start_time = end_time - (lookback_hours * 3600)
 ```
 
 Example:
@@ -97,29 +107,29 @@ wificlienthistory
   ...
 ```
 
-Gateway-scoped APIs should accept only `serialNumber` publicly. The handler must resolve the internal `boardId` before loading `TimePointDB` records.
+Gateway-scoped APIs should accept only `routerId` publicly. The handler must map `routerId` to the existing internal `serialNumber` field and resolve the internal `boardId` before loading `TimePointDB` records. Do not rename the existing `timepoints.serialNumber` field or its indexes to `routerId`.
 
-### Serial Number Resolution
+### RouterId Resolution
 
-The MCP tool cannot pass `boardId`, so Analytics must resolve it from the gateway serial number.
+The MCP tool cannot pass `boardId`, so Analytics must resolve it from `routerId`, which is the gateway serial number.
 
 Resolution flow:
 
 ```text
-1. Validate serialNumber.
+1. Validate routerId.
 2. Call OWPROV inventory for the serial number with status-aware handling:
-     GET /api/v1/inventory/{serialNumber}
+     GET /api/v1/inventory/{routerId}
 3. Read inventoryTag.venue as venueId.
-4. Find the Analytics board that currently owns serialNumber.
+4. Find the Analytics board that currently owns routerId.
 5. Use that board's BoardInfo.info.id as resolvedBoardId.
-6. Query Analytics storage with resolvedBoardId and serialNumber.
+6. Query Analytics storage with resolvedBoardId and serialNumber = routerId.
 ```
 
 Implementation notes:
 
 ```text
 OWPROV source:
-  /api/v1/inventory/{serialNumber}
+  /api/v1/inventory/{routerId}
 
 OWPROV response field:
   InventoryTag.venue
@@ -144,7 +154,7 @@ For each local BoardInfo record:
       venueDeviceList,
       venueExists)
 
-    if serialNumber is present in venueDeviceList.devices:
+    if routerId is present in venueDeviceList.devices:
       add BoardInfo.info.id as a candidate board
 
 If exactly one candidate exists:
@@ -156,7 +166,7 @@ This mirrors the existing watcher behavior, where board devices are fetched from
 Alternative implementation:
 
 ```text
-Expose a current serialNumber -> boardId map from VenueCoordinator.
+Expose a current routerId -> boardId map from VenueCoordinator.
 The map must be maintained from the same device lists used by VenueWatcher.
 The resolver may use this map instead of scanning OWPROV for every request.
 ```
@@ -174,9 +184,9 @@ OWPROV unavailable or invalid response  -> 502 Bad Gateway
 The resolver must return a status-bearing result, not a boolean, so handlers can map each failure to the correct HTTP response.
 
 ```cpp
-enum class SerialResolutionStatus {
+enum class RouterIdResolutionStatus {
     Success,
-    InvalidSerialNumber,
+    InvalidRouterId,
     InventoryNotFound,
     EmptyVenue,
     BoardNotConfigured,
@@ -185,9 +195,9 @@ enum class SerialResolutionStatus {
     OwprovInvalidResponse
 };
 
-struct SerialResolutionResult {
-    SerialResolutionStatus status = SerialResolutionStatus::OwprovUnavailable;
-    std::string serialNumber;
+struct RouterIdResolutionResult {
+    RouterIdResolutionStatus status = RouterIdResolutionStatus::OwprovUnavailable;
+    std::string routerId;
     std::string venueId;
     std::string resolvedBoardId;
     std::string message;
@@ -198,7 +208,7 @@ Status mapping:
 
 ```text
 Success               -> continue request
-InvalidSerialNumber   -> 400 Bad Request
+InvalidRouterId   -> 400 Bad Request
 InventoryNotFound     -> 404 Not Found
 EmptyVenue            -> 404 Not Found
 BoardNotConfigured    -> 404 Not Found
@@ -215,11 +225,11 @@ Option A:
     SDK::Prov::Device::GetWithStatus(...)
 
 Option B:
-  Call OpenAPIRequestGet(uSERVICE_PROVISIONING, "/api/v1/inventory/{serialNumber}", ...)
-  directly from ResolveSerialNumberContext and inspect the HTTP response status.
+  Call OpenAPIRequestGet(uSERVICE_PROVISIONING, "/api/v1/inventory/{routerId}", ...)
+  directly from ResolveRouterIdContext and inspect the HTTP response status.
 ```
 
-Handlers may cache `serialNumber -> venueId -> boardId` for a short TTL, but must refresh or invalidate the cache when OWPROV reports a different venue.
+Handlers may cache `routerId -> venueId -> boardId` for a short TTL, but must refresh or invalidate the cache when OWPROV reports a different venue.
 
 ---
 
@@ -229,7 +239,7 @@ Handlers may cache `serialNumber -> venueId -> boardId` for a short TTL, but mus
 
 ```text
 get_gateway_free_memory(
-    serial_number: str,
+    router_id: str,
     timestamp_till: str,
     lookback_hours: int
 )
@@ -238,7 +248,7 @@ get_gateway_free_memory(
 ## Recommended API
 
 ```http
-GET /api/v1/devices/{serialNumber}/memory-summary
+GET /api/v1/devices/{routerId}/memory-summary
     ?timestampTill=2026-07-27T12:00:00Z
     &lookbackHours=24
 ```
@@ -341,7 +351,7 @@ Use the current `timepoints` table plus parsed JSON fields:
 ```text
 Load TimePointDB records where:
   boardId == resolvedBoardId
-  serialNumber == serialNumber
+  stored serialNumber == request routerId
   timestamp >= startTime
   timestamp <= endTime
 
@@ -361,11 +371,11 @@ Do not query `device_timepoints.memory_free` unless a separate normalized table 
 ### Handler Flow
 
 ```text
-Validate serialNumber
+Validate routerId
     ↓
-Call ResolveSerialNumberContext(client, serialNumber)
+Call ResolveRouterIdContext(client, routerId)
     ↓
-If status is not Success, map SerialResolutionStatus to HTTP response
+If status is not Success, map RouterIdResolutionStatus to HTTP response
     ↓
 Use result.venueId and result.resolvedBoardId
     ↓
@@ -400,7 +410,7 @@ Use HTTP `200 OK` when the query succeeds but no data exists.
 
 ```text
 get_gateway_wifi_temp(
-    serial_number: str,
+    router_id: str,
     timestamp_till: str,
     lookback_hours: int
 )
@@ -409,7 +419,7 @@ get_gateway_wifi_temp(
 ## Recommended API
 
 ```http
-GET /api/v1/devices/{serialNumber}/radio-temperature-summary
+GET /api/v1/devices/{routerId}/radio-temperature-summary
     ?timestampTill=2026-07-27T12:00:00Z
     &lookbackHours=24
 ```
@@ -471,7 +481,7 @@ Use the current `timepoints.radio_data` JSON array:
 ```text
 Load TimePointDB records where:
   boardId == resolvedBoardId
-  serialNumber == serialNumber
+  stored serialNumber == request routerId
   timestamp >= startTime
   timestamp <= endTime
 
@@ -526,7 +536,7 @@ if (radio.band == 5) {
 
 ```text
 get_device_bandwidth_consumption(
-    serial_number: str,
+    router_id: str,
     timestamp_till: str,
     lookback_hours: int
 )
@@ -535,7 +545,7 @@ get_device_bandwidth_consumption(
 ## Recommended API
 
 ```http
-GET /api/v1/devices/{serialNumber}/wifi-clients/usage-summary
+GET /api/v1/devices/{routerId}/wifi-clients/usage-summary
     ?timestampTill=2026-07-27T12:00:00Z
     &lookbackHours=24
 ```
@@ -592,7 +602,7 @@ radio information
 Alternative implementation:
 
 ```text
-If wificlienthistory is preferred for performance, first add serialNumber to:
+If wificlienthistory is preferred for performance, first add the gateway `serialNumber` to:
   AnalyticsObjects::WifiClientHistory
   WifiClientHistoryDBRecordType
   storage_wificlients.cpp fields and converters
@@ -688,9 +698,9 @@ fmt::format("{:.2f} Mb", value);
 ### Query Flow
 
 ```text
-Resolve boardId from serialNumber
+Resolve boardId from routerId
     ↓
-Load TimePointDB records for resolvedBoardId and serialNumber
+Load TimePointDB records for resolvedBoardId and stored serialNumber == request routerId
     ↓
 Include records from startTime through endTime
     ↓
@@ -717,7 +727,7 @@ Return array
 
 ```text
 get_device_rssi_quality(
-    serial_number: str,
+    router_id: str,
     timestamp_till: str,
     lookback_hours: int
 )
@@ -726,7 +736,7 @@ get_device_rssi_quality(
 ## Recommended API
 
 ```http
-GET /api/v1/devices/{serialNumber}/wifi-clients/rssi-summary
+GET /api/v1/devices/{routerId}/wifi-clients/rssi-summary
     ?timestampTill=2026-07-27T12:00:00Z
     &lookbackHours=24
 ```
@@ -828,7 +838,7 @@ Round percentages to two decimal places.
 ```text
 Load TimePointDB records where:
   boardId == resolvedBoardId
-  serialNumber == serialNumber
+  stored serialNumber == request routerId
   timestamp >= startTime
   timestamp <= endTime
 
@@ -845,7 +855,7 @@ For each station_id:
   calculate percentages from total_samples
 ```
 
-Do not query `wifi_client_history.board_id`, `wifi_client_history.serial_number`, or `wifi_client_history.created`; those fields do not exist in the current schema.
+Do not query `wifi_client_history.board_id`, `wifi_client_history.serialNumber`, or `wifi_client_history.created`; those fields do not exist in the current schema.
 
 The API should return the final percentages directly. The MCP server should not need to perform additional RSSI summarisation.
 
@@ -857,7 +867,7 @@ The API should return the final percentages directly. The MCP server should not 
 
 ```text
 get_gateway_offline_count(
-    serial_number: str,
+    router_id: str,
     timestamp_till: str,
     lookback_hours: int
 )
@@ -866,7 +876,7 @@ get_gateway_offline_count(
 ## Recommended API
 
 ```http
-GET /api/v1/devices/{serialNumber}/availability-summary
+GET /api/v1/devices/{routerId}/availability-summary
     ?timestampTill=2026-07-27T12:00:00Z
     &lookbackHours=24
 ```
@@ -925,7 +935,7 @@ device_availability_events
 --------------------------
 id
 board_id
-serial_number
+serialNumber
 event_type
 event_time
 reason
@@ -950,7 +960,7 @@ Required ORM fields and indexes:
 Fields:
   id              TEXT primary id
   board_id        TEXT
-  serial_number   TEXT
+  serialNumber    TEXT
   event_type      TEXT
   event_time      BIGINT
   reason          TEXT
@@ -961,12 +971,12 @@ Fields:
 
 Indexes:
   availability_serial_time_index:
-    serial_number ASC
+    serialNumber ASC
     event_time ASC
 
   availability_board_serial_time_index:
     board_id ASC
-    serial_number ASC
+    serialNumber ASC
     event_time ASC
 
   availability_event_id_index:
@@ -1019,7 +1029,7 @@ On ping/capabilities:
 Do not store online events for every ping.
 ```
 
-The event writer must include `resolvedBoardId`/`board_id`, `serial_number`, `event_type`, and the event timestamp. If the incoming connection message has a stable event id or session id, persist it and use `event_id` for idempotency.
+The event writer must include `resolvedBoardId`/`board_id`, `serialNumber` set from request `routerId`, `event_type`, and the event timestamp. If the incoming connection message has a stable event id or session id, persist it and use `event_id` for idempotency.
 
 ### Store Only State Transitions
 
@@ -1051,7 +1061,7 @@ offline_count =
 SELECT COUNT(*) AS offline_count
 FROM device_availability_events
 WHERE board_id = :board_id
-  AND serial_number = :serial_number
+  AND serialNumber = :router_id
   AND event_type = 'offline'
   AND event_time >= :start_time
   AND event_time <= :end_time;
@@ -1105,11 +1115,11 @@ openapi/owanalytics.yaml
 Add:
 
 ```yaml
-/devices/{serialNumber}/memory-summary:
-/devices/{serialNumber}/radio-temperature-summary:
-/devices/{serialNumber}/availability-summary:
-/devices/{serialNumber}/wifi-clients/usage-summary:
-/devices/{serialNumber}/wifi-clients/rssi-summary:
+/devices/{routerId}/memory-summary:
+/devices/{routerId}/radio-temperature-summary:
+/devices/{routerId}/availability-summary:
+/devices/{routerId}/wifi-clients/usage-summary:
+/devices/{routerId}/wifi-clients/rssi-summary:
 ```
 
 ---
@@ -1167,12 +1177,12 @@ rssi-summary
 All handlers must call a shared serial-resolution helper before storage access:
 
 ```cpp
-SerialResolutionResult ResolveSerialNumberContext(
+RouterIdResolutionResult ResolveRouterIdContext(
     RESTAPIHandler* client,
-    const std::string& serialNumber);
+    const std::string& routerId);
 ```
 
-The helper must use status-aware OWPROV inventory lookup, read `InventoryTag.venue`, and resolve board ownership with `monitorSubVenues` support. It can either scan candidate board device lists through `SDK::Prov::Venue::GetDevices(..., VenueInfo.monitorSubVenues, ...)` or use a current `serialNumber -> boardId` map maintained by `VenueCoordinator`.
+The helper must use status-aware OWPROV inventory lookup, read `InventoryTag.venue`, and resolve board ownership with `monitorSubVenues` support. It can either scan candidate board device lists through `SDK::Prov::Venue::GetDevices(..., VenueInfo.monitorSubVenues, ...)` or use a current `routerId -> boardId` map maintained by `VenueCoordinator`.
 
 ---
 
@@ -1220,14 +1230,14 @@ src/StorageService.h
 src/StorageService.cpp
 ```
 
-`storage_wificlients.*` only needs changes if the implementation chooses to add `serialNumber` to `wificlienthistory`. The default implementation for gateway-scoped client summaries should aggregate `timepoints.ssid_data` to avoid that migration.
+`storage_wificlients.*` only needs changes if the implementation chooses to add gateway `serialNumber` to `wificlienthistory`. The default implementation for gateway-scoped client summaries should aggregate `timepoints.ssid_data` to avoid that migration.
 
 Suggested functions:
 
 ```cpp
 bool GetMemorySummary(
     const std::string& resolvedBoardId,
-    const std::string& serialNumber,
+    const std::string& routerId,
     uint64_t startTime,
     uint64_t endTime,
     AnalyticsObjects::GatewayMemorySummary& result);
@@ -1247,11 +1257,11 @@ bool GetGatewayAvailabilitySummary(...);
 
 | MCP Tool | Analytics API | Data Source | Implementation Status |
 |---|---|---|---|
-| `get_gateway_free_memory` | `GET /devices/{serialNumber}/memory-summary` | `timepoints.resource_data.memory_free` | Resolve serial to venueId and boardId, then aggregate `timepoints` |
-| `get_gateway_wifi_temp` | `GET /devices/{serialNumber}/radio-temperature-summary` | `timepoints.radio_data[].temperature` | Resolve serial to venueId and boardId, then aggregate `timepoints` |
-| `get_device_bandwidth_consumption` | `GET /devices/{serialNumber}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve serial to venueId and boardId, then reset-safe delta aggregation with pre-window baseline |
-| `get_device_rssi_quality` | `GET /devices/{serialNumber}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve serial to venueId and boardId, then classify RSSI samples |
-| `get_gateway_offline_count` | `GET /devices/{serialNumber}/availability-summary` | Existing gateway `connection` topic | Resolve serial to venueId and boardId, then aggregate persisted offline state transitions |
+| `get_gateway_free_memory` | `GET /devices/{routerId}/memory-summary` | `timepoints.resource_data.memory_free` | Resolve routerId to venueId and boardId, then aggregate `timepoints` |
+| `get_gateway_wifi_temp` | `GET /devices/{routerId}/radio-temperature-summary` | `timepoints.radio_data[].temperature` | Resolve routerId to venueId and boardId, then aggregate `timepoints` |
+| `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then reset-safe delta aggregation with pre-window baseline |
+| `get_device_rssi_quality` | `GET /devices/{routerId}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve routerId to venueId and boardId, then classify RSSI samples |
+| `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic | Resolve routerId to venueId and boardId, then aggregate persisted offline state transitions |
 
 ---
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -559,45 +559,6 @@ Existing rows will not have `resource_data`; treat those rows as missing memory 
 
 Do not represent missing memory fields as `0`. A missing `memory_free` value and a genuine reported zero must remain distinguishable.
 
-Migration coverage rule:
-
-```text
-Define a fixed memory_resource_data_valid_from timestamp as the deployment/migration
-timestamp where timepoints.resource_data.memory_free starts being written
-consistently.
-
-If startTime < memory_resource_data_valid_from:
-  effectiveStartTime = min(memory_resource_data_valid_from, endTime)
-  partial = true
-
-If startTime >= memory_resource_data_valid_from:
-  effectiveStartTime = startTime
-  partial = false
-
-effectiveEndTime = endTime
-```
-
-When the requested range starts before memory_resource_data_valid_from, the API
-may still return `200 OK`, but the aggregate values must represent only
-`[effectiveStartTime, endTime)`. The response must include a coverage header so
-consumers can distinguish a complete-window average from a post-migration-only
-partial average.
-
-Response coverage header:
-
-```http
-X-Analytics-Coverage: {"requested_start":"2026-07-26T12:00:00Z","requested_end":"2026-07-27T12:00:00Z","effective_start":"2026-07-26T12:00:00Z","effective_end":"2026-07-27T12:00:00Z","data_available_from":"2026-07-01T00:00:00Z","partial":false}
-```
-
-Header fields must use RFC3339 UTC timestamps. `requested_start` and
-`requested_end` are the original half-open request window. `effective_start` and
-`effective_end` are the half-open window used for aggregation. `data_available_from`
-is `memory_resource_data_valid_from`. `partial` is `true` when
-`effective_start` is later than `requested_start`. If the entire requested range
-is before `memory_resource_data_valid_from`, `effective_start` and
-`effective_end` must both equal `requested_end`, the aggregate window is empty,
-and the response body uses the normal empty-result values.
-
 ### Ingestion Logic
 
 ```cpp
@@ -625,7 +586,7 @@ Use the current `timepoints` table plus parsed JSON fields:
 Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
-  timestamp >= effectiveStartTime
+  timestamp >= startTime
   timestamp < endTime
 
 For each record:
@@ -655,8 +616,6 @@ Use result.venueId and result.resolvedBoardId
 Parse timestampTill
     ↓
 Calculate start_time
-    ↓
-Calculate effectiveStartTime and X-Analytics-Coverage
     ↓
 Query timepoints and read resource_data.memory_free samples
     ↓
@@ -747,7 +706,7 @@ Do not synthesize a numeric fallback temperature for missing data.
 Do not store a placeholder in wifi_temp for a missing temperature.
 ```
 
-Migration coverage rule:
+Migration boundary rule:
 
 ```text
 Define a fixed temperature_migration_cutover_time as the deployment/migration
@@ -758,40 +717,14 @@ Ignore all earlier records because historical temperature values cannot reliably
 distinguish measured values from synthetic fallback values.
 
 If the requested range starts before temperature_migration_cutover_time:
-  effectiveStartTime = min(temperature_migration_cutover_time, endTime)
-  partial = true
-
-If startTime >= temperature_migration_cutover_time:
-  effectiveStartTime = startTime
-  partial = false
-
-effectiveEndTime = endTime
+  effective_start_time = temperature_migration_cutover_time
+else:
+  effective_start_time = startTime
 
 Do not filter out post-cutover samples only because the measured value is 20°C.
 After the cutover, a present wifi_temp value is treated as a legitimate
 measurement.
 ```
-
-When the requested range starts before temperature_migration_cutover_time, the
-API may still return `200 OK`, but the aggregate values must represent only
-`[effectiveStartTime, endTime)`. The response must include a coverage header so
-consumers can distinguish a complete-window average from a post-migration-only
-partial average.
-
-Response coverage header:
-
-```http
-X-Analytics-Coverage: {"requested_start":"2026-07-26T12:00:00Z","requested_end":"2026-07-27T12:00:00Z","effective_start":"2026-07-26T12:00:00Z","effective_end":"2026-07-27T12:00:00Z","data_available_from":"2026-07-01T00:00:00Z","partial":false}
-```
-
-Header fields must use RFC3339 UTC timestamps. `requested_start` and
-`requested_end` are the original half-open request window. `effective_start` and
-`effective_end` are the half-open window used for aggregation. `data_available_from`
-is `temperature_migration_cutover_time`. `partial` is `true` when
-`effective_start` is later than `requested_start`. If the entire requested range
-is before `temperature_migration_cutover_time`, `effective_start` and
-`effective_end` must both equal `requested_end`, the aggregate window is empty,
-and the response body uses the normal empty-result values.
 
 The current radio-band mapping is:
 
@@ -816,7 +749,7 @@ Use the current `timepoints.radio_data` JSON array:
 Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
-  timestamp >= effectiveStartTime
+  timestamp >= effective_start_time
   timestamp < endTime
 
 For each record:

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -73,11 +73,124 @@ Validation rules:
 ```text
 timestampTill must parse as a valid timestamp.
 lookbackHours must be greater than 0.
-lookbackHours should have a bounded maximum, for example 24 * 31.
+maxLookbackHours = floor(configured monitoringDuration / 3600).
+lookbackHours must be less than or equal to maxLookbackHours.
 startTime must be less than endTime.
 ```
 
-Return `400 Bad Request` for invalid timestamps, unsupported timezones, non-positive `lookbackHours`, or values above the configured maximum. Internally, query `timepoints.timestamp` and `wificlienthistory.timestamp` using epoch seconds.
+All APIs in this document derive `maxLookbackHours` from the configured `monitoringDuration` for the resolved router ownership scope. All APIs share this limit unless an endpoint section explicitly names a stricter limit. No endpoint currently defines a separate limit.
+
+For a one-year monitoring configuration, `maxLookbackHours` is `365 * 24` only when the configured monitoring duration is exactly 365 days. Do not assume every calendar year is 8760 hours; use the configured duration and effective retention timestamps when validating the request.
+
+Return `400 Bad Request` for invalid timestamps, unsupported timezones, non-positive `lookbackHours`, or values above the applicable maximum. Internally, query `timepoints.timestamp` and `wificlienthistory.timestamp` using epoch seconds.
+
+### Monitoring Configuration
+
+Handlers must load the monitoring configuration for the resolved router ownership scope before querying metric storage.
+
+```text
+monitoringDuration = configured monitoring retention duration
+retentionEnd = min(currentTime, monitoringConfigurationExpiry)
+retentionStart = retentionEnd - monitoringDuration
+
+If monitoring has been enabled for less time than monitoringDuration:
+  retentionStart = max(monitoringEnabledAt, retentionEnd - monitoringDuration)
+```
+
+Use the configured duration and effective retention timestamps instead of calendar assumptions so leap years, partial-year retention, recently enabled monitoring, and changed retention policies behave consistently.
+
+The requested half-open range must fit inside the configured retention window:
+
+```text
+startTime >= retentionStart
+endTime <= retentionEnd
+```
+
+If the requested range is outside the configured retention window, return `400 Bad Request` with `error: "lookback_outside_retention"`.
+
+When monitoring is disabled:
+
+```text
+stop ingesting new metric and availability records
+retain existing records until their existing expiry timestamp
+return 409 Conflict for all summary requests
+```
+
+Error response:
+
+```json
+{
+  "error": "monitoring_disabled",
+  "message": "Monitoring is disabled for this router scope"
+}
+```
+
+When monitoring is not configured for the resolved router scope, return:
+
+```http
+404 Not Found
+```
+
+```json
+{
+  "error": "monitoring_not_configured",
+  "message": "Monitoring is not configured for this router scope"
+}
+```
+
+### Time Window Semantics
+
+All summary APIs must use a half-open time interval:
+
+```text
+[startTime, endTime)
+
+timestamp >= startTime
+timestamp < endTime
+```
+
+`timestampTill` is the exclusive upper bound. This prevents adjacent requests from double-counting samples or events at the shared boundary.
+
+Example:
+
+```text
+Request 1: 10:00 <= timestamp < 11:00
+Request 2: 11:00 <= timestamp < 12:00
+```
+
+A sample exactly at `11:00` belongs only to Request 2.
+
+### Authorization
+
+All device metric handlers must enforce authorization before returning data:
+
+```text
+1. Authenticate the bearer token.
+   If the token is missing, invalid, or expired, return 401 Unauthorized.
+2. Resolve the caller's accessible entity, venue, and board scope from the token.
+3. Resolve routerId to its current router ownership context.
+4. Verify that the resolved router belongs to a board or venue the caller may read.
+5. Return 404 Not Found when the router exists but the caller cannot access it.
+6. Return 404 Not Found when the router does not exist.
+```
+
+Required permission:
+
+```text
+analytics.gateway_metrics.read
+```
+
+The permission is evaluated against the resolved board first, then the resolved venue, then the parent entity. Child-venue access is allowed only when the caller's venue permission explicitly includes descendant venues according to the same venue hierarchy rules used by OWPROV and `VenueCoordinator`; otherwise access is limited to the exact resolved venue or board.
+
+Authorization must not rely on the caller-supplied `routerId` alone. A caller must not be able to request an arbitrary gateway serial number and retrieve metrics without proving access to the router's current ownership scope. The external API intentionally returns `404 Not Found` for both nonexistent routers and routers outside the caller's authorized scope to avoid exposing router existence. Internal logs and metrics should preserve the exact reason.
+
+For historical availability, authorize by current router ownership before querying `device_availability_events` by `serialNumber`. The event-time `board_id` field is historical context only and must not be the sole authorization source. If current ownership cannot be resolved for a non-operator caller, do not serve serial-number-only availability history. A privileged operator-level permission may bypass current ownership resolution only if explicitly implemented and audited.
+
+Privileged operator bypass, if implemented, must use a separate permission:
+
+```text
+analytics.gateway_metrics.read_any
+```
 
 ### Current Storage Model
 
@@ -117,16 +230,21 @@ Resolution flow:
 
 ```text
 1. Validate routerId.
-2. Check the request-scoped routerId resolution cache.
-3. Resolve board ownership from the maintained routerId -> boardId map.
-4. If the map has a current entry, use it as resolvedBoardId.
-5. On cache/map miss, call OWPROV inventory with status-aware handling:
+2. Read the current VenueCoordinator ownershipVersion.
+3. Check the process-level router resolution cache.
+4. Use an unexpired positive cache entry only if its ownershipVersion matches
+   the current VenueCoordinator ownershipVersion.
+5. Resolve board ownership from the maintained routerId -> boardId map.
+6. If the map has a current entry, use it as resolvedBoardId.
+7. On cache/map miss or expired cache entry, call OWPROV inventory with status-aware handling:
      GET /api/v1/inventory/{routerId}
-6. Read inventoryTag.venue as venueId.
-7. Use the OWPROV venue result to verify or refresh board ownership.
-8. Store the resolved result in the request-scoped cache.
-9. Query Analytics storage with resolvedBoardId and serialNumber = routerId.
+8. Read inventoryTag.venue as venueId.
+9. Use the OWPROV venue result to verify or refresh board ownership.
+10. Store the resolved result in the process-level cache.
+11. Query Analytics storage with resolvedBoardId and serialNumber = routerId.
 ```
+
+Separate MCP metric calls are separate HTTP requests. They do not share an HTTP request context, so router resolution reuse across different metric endpoints must come from the maintained `VenueCoordinator` ownership map or the process-level cache, not from request-scoped state.
 
 Implementation notes:
 
@@ -157,6 +275,10 @@ If exactly one current board mapping exists:
   resolvedBoardId = mapped boardId
   return Success
 
+If multiple current board mappings exist:
+  return MultipleBoards
+  log a configuration error
+
 If no mapping exists:
   perform status-aware OWPROV inventory lookup
   read InventoryTag.venue
@@ -165,6 +287,8 @@ If no mapping exists:
 ```
 
 This mirrors the existing watcher behavior, where board devices are fetched from OWPROV with the board venue's `monitorSubVenues` setting.
+
+A router must have exactly one authoritative board mapping. Never resolve multiple candidates by list order, oldest board, most recently updated board, or direct venue preference. If multiple active mappings exist, return `409 Conflict` and log a configuration error.
 
 Refresh algorithm for cache/map misses:
 
@@ -184,9 +308,11 @@ For each local BoardInfo record that can own the inventory venue:
 If exactly one candidate exists:
   resolvedBoardId = candidate board
   update routerId -> boardId map
-```
 
-Request-scoped reuse is required. A single MCP request that asks for multiple metrics for the same router must resolve `routerId` once, then reuse the same `RouterIdResolutionResult` for all handlers in that request. For example, five MCP metric queries in one request must not repeat the full resolution process five times.
+If more than one candidate exists:
+  return MultipleBoards
+  do not choose a candidate by list order or heuristic tie-breaker
+```
 
 Failure handling:
 
@@ -194,8 +320,8 @@ Failure handling:
 OWPROV inventory not found              -> 404 Not Found
 Inventory exists but venue is empty     -> 404 Not Found
 No Analytics board configured for venue -> 404 Not Found
-Multiple matching boards                -> 409 Conflict unless deterministic ownership exists
-OWPROV unavailable or invalid response  -> 502 Bad Gateway
+Multiple matching boards                -> 409 Conflict
+OWPROV unavailable or invalid response  -> 502 Bad Gateway after cache fallback is exhausted
 ```
 
 The resolver must return a status-bearing result, not a boolean, so handlers can map each failure to the correct HTTP response.
@@ -208,6 +334,9 @@ enum class RouterIdResolutionStatus {
     EmptyVenue,
     BoardNotConfigured,
     MultipleBoards,
+    AccessDenied,
+    MonitoringNotConfigured,
+    MonitoringDisabled,
     OwprovUnavailable,
     OwprovInvalidResponse
 };
@@ -217,6 +346,8 @@ struct RouterIdResolutionResult {
     std::string routerId;
     std::string venueId;
     std::string resolvedBoardId;
+    uint64_t resolvedAt = 0;
+    uint64_t ownershipVersion = 0;
     std::string message;
 };
 ```
@@ -225,11 +356,14 @@ Status mapping:
 
 ```text
 Success               -> continue request
-InvalidRouterId   -> 400 Bad Request
+InvalidRouterId       -> 400 Bad Request
 InventoryNotFound     -> 404 Not Found
 EmptyVenue            -> 404 Not Found
 BoardNotConfigured    -> 404 Not Found
 MultipleBoards        -> 409 Conflict
+AccessDenied          -> 404 Not Found
+MonitoringNotConfigured -> 404 Not Found
+MonitoringDisabled    -> 409 Conflict
 OwprovUnavailable     -> 502 Bad Gateway
 OwprovInvalidResponse -> 502 Bad Gateway
 ```
@@ -246,7 +380,80 @@ Option B:
   directly from ResolveRouterIdContext and inspect the HTTP response status.
 ```
 
-Handlers may keep a short-lived process cache for `routerId -> venueId -> boardId`, but it is secondary to the maintained `VenueCoordinator` ownership map. Any cache must refresh or invalidate entries when OWPROV reports a different venue or when `VenueCoordinator` reports changed board membership.
+Router resolution process cache:
+
+```text
+Scope:
+  thread-safe, process-level cache shared by all REST handlers
+
+Key:
+  routerId
+
+Positive value:
+  venueId
+  boardId
+  resolvedAt
+  ownershipVersion
+
+Negative value:
+  resolution status
+  resolvedAt
+  ownershipVersion when available
+
+Positive TTL:
+  5 minutes, absolute from resolvedAt
+
+Negative TTL:
+  30 seconds or less, absolute from resolvedAt
+
+Maximum size:
+  10000 routerId entries per process
+
+Eviction:
+  expire entries by TTL first, then evict least-recently-used entries when the
+  maximum size is reached
+
+On unexpired positive cache hit:
+  return cached venueId and boardId if ownershipVersion still matches the
+  current VenueCoordinator ownershipVersion
+
+On expired entry:
+  resolve again before serving the request
+
+On OWPROV failure:
+  an unexpired positive local ownership entry may be used if ownershipVersion
+  still matches
+  an expired entry must not be extended silently
+  if no usable unexpired entry exists, return OwprovUnavailable or
+  OwprovInvalidResponse according to the failure
+
+Negative-result caching:
+  cache InventoryNotFound, EmptyVenue, BoardNotConfigured, MultipleBoards, and
+  MonitoringNotConfigured for the negative TTL
+  do not cache OwprovUnavailable or OwprovInvalidResponse as ownership facts
+
+Invalidation:
+  invalidate the routerId entry immediately when OWPROV reports a different
+  venue for the router
+  invalidate affected routerId entries when VenueCoordinator detects board
+  membership changes
+  invalidate affected routerId entries on board deletion or board venue
+  reconfiguration
+  invalidate affected routerId entries when board configuration changes
+  invalidate affected routerId entries when venue monitoring settings change
+  invalidate the routerId entry when router assignment changes
+  invalidate the routerId entry when the router is removed
+  invalidate the routerId entry when ownershipVersion changes
+
+Concurrency:
+  cache reads and writes must be synchronized
+  concurrent misses for the same routerId should coalesce to one refresh when
+  practical
+  if coalescing is not implemented, racing refreshes must not publish older
+  ownershipVersion results over newer results
+```
+
+The cache is secondary to `VenueCoordinator` ownership. A cache hit must not override a newer `VenueCoordinator` ownershipVersion.
 
 ---
 
@@ -312,10 +519,10 @@ Add raw memory fields to the device time-point model and persist them with each 
 
 ```cpp
 struct DeviceResourceTimePoint {
-    uint64_t memory_free = 0;
-    uint64_t memory_total = 0;
-    uint64_t memory_cached = 0;
-    uint64_t memory_buffered = 0;
+    std::optional<uint64_t> memory_free;
+    std::optional<uint64_t> memory_total;
+    std::optional<uint64_t> memory_cached;
+    std::optional<uint64_t> memory_buffered;
 };
 
 struct DeviceTimePoint {
@@ -350,14 +557,24 @@ src/APStats.cpp
 
 Existing rows will not have `resource_data`; treat those rows as missing memory samples rather than zero free memory.
 
+Do not represent missing memory fields as `0`. A missing `memory_free` value and a genuine reported zero must remain distinguishable.
+
 ### Ingestion Logic
 
 ```cpp
 AnalyticsObjects::DeviceResourceTimePoint resource;
-GetJSON("free", memory, resource.memory_free, uint64_t{0});
-GetJSON("total", memory, resource.memory_total, uint64_t{0});
-GetJSON("cached", memory, resource.memory_cached, uint64_t{0});
-GetJSON("buffered", memory, resource.memory_buffered, uint64_t{0});
+if (memory.has("free")) {
+    resource.memory_free = memory["free"].as<uint64_t>();
+}
+if (memory.has("total")) {
+    resource.memory_total = memory["total"].as<uint64_t>();
+}
+if (memory.has("cached")) {
+    resource.memory_cached = memory["cached"].as<uint64_t>();
+}
+if (memory.has("buffered")) {
+    resource.memory_buffered = memory["buffered"].as<uint64_t>();
+}
 DTP.resource_data = resource;
 ```
 
@@ -370,12 +587,12 @@ Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
   timestamp >= startTime
-  timestamp <= endTime
+  timestamp < endTime
 
 For each record:
   read record.resource_data.memory_free
   ignore missing resource_data
-  ignore memory_free when memory_total is 0 and the sample came from a missing memory block
+  include the sample only when memory_free is present
 
 Return:
   min_memfree = min(memory_free samples)
@@ -469,40 +686,44 @@ None
 
 ## API Logic
 
-Analytics already stores:
+Analytics should store a nullable Wi-Fi temperature value per radio:
 
 ```text
 radios[].band
-radios[].temperature
+radios[].wifi_temp
 ```
-
-Temperature samples need explicit validity handling. Current ingestion in `APStats.cpp` defaults a missing radio temperature to `20` and also rewrites a reported `0` to `20`. Those fallback values must not be treated as genuine measurements.
 
 Required ingestion rule:
 
 ```text
-If radios[].temperature is present, non-null, and accepted as a measured value:
-  store the measured temperature
-  store temperature_valid = true
+If the source radio temperature is present and non-null:
+  store radios[].wifi_temp = source temperature
 
-If radios[].temperature is missing, null, or rejected as invalid:
-  keep temperature missing/null
-  store temperature_valid = false
+If the source radio temperature is missing or null:
+  omit radios[].wifi_temp or store radios[].wifi_temp = null
 
 Do not synthesize a numeric fallback temperature for missing data.
-Do not store 20, 0, or any other placeholder for a missing temperature.
-For all newly ingested records, temperature_valid must be present.
+Do not store a placeholder in wifi_temp for a missing temperature.
 ```
 
-Historical data rule:
+Migration boundary rule:
 
 ```text
-Existing stored temperature == 20 is ambiguous because it may be either:
-  a genuine measured 20, or
-  the synthetic fallback for missing/zero input
+Define a fixed temperature_migration_cutover_time as the deployment/migration
+timestamp where radios[].wifi_temp starts being written consistently.
 
-Unless a migration can prove the value came from a real measured source, do not use
-historical 20 values in min/max/average temperature summaries.
+Only use temperature records created at or after temperature_migration_cutover_time.
+Ignore all earlier records because historical temperature values cannot reliably
+distinguish measured values from synthetic fallback values.
+
+If the requested range starts before temperature_migration_cutover_time:
+  effective_start_time = temperature_migration_cutover_time
+else:
+  effective_start_time = startTime
+
+Do not filter out post-cutover samples only because the measured value is 20°C.
+After the cutover, a present wifi_temp value is treated as a legitimate
+measurement.
 ```
 
 The current radio-band mapping is:
@@ -528,15 +749,15 @@ Use the current `timepoints.radio_data` JSON array:
 Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
-  timestamp >= startTime
-  timestamp <= endTime
+  timestamp >= effective_start_time
+  timestamp < endTime
 
 For each record:
   parse radio_data
   for each radio in radio_data:
     if radio.band is 2 or 5:
-      if radio.temperature_valid is true and radio.temperature is present:
-        add radio.temperature to that band's sample list
+      if radio.wifi_temp is present and non-null:
+        add radio.wifi_temp to that band's sample list
 
 For each band:
   min_temperature = min(samples)
@@ -547,13 +768,8 @@ For each band:
 A valid temperature sample is:
 
 ```text
-New records:
-  temperature is present and non-null
-  and temperature_valid == true
-
-Historical records from the current ingestion behavior:
-  temperature is present
-  and temperature != 20
+record timestamp is at or after temperature_migration_cutover_time
+radio.wifi_temp is present and non-null
 ```
 
 If all samples for a band are invalid or missing, return `null` for that band's min, max, and average fields.
@@ -630,15 +846,25 @@ None
 [
   {
     "mac": "e2:51:95:ed:0f:28",
+    "rx_bytes": 106487500,
+    "tx_bytes": 3851250,
+    "total_bytes": 110338750,
     "data_consume_rx": "851.9 Mb",
     "data_consume_tx": "30.81 Mb",
-    "total_data_usage": "882.71 Mb"
+    "total_data_usage": "882.71 Mb",
+    "usage_accuracy": "exact",
+    "incomplete": false
   },
   {
     "mac": "28:39:26:a1:7c:a5",
+    "rx_bytes": 30071250,
+    "tx_bytes": 16486250,
+    "total_bytes": 46557500,
     "data_consume_rx": "240.57 Mb",
     "data_consume_tx": "131.89 Mb",
-    "total_data_usage": "372.46 Mb"
+    "total_data_usage": "372.46 Mb",
+    "usage_accuracy": "lower_bound",
+    "incomplete": true
   }
 ]
 ```
@@ -687,34 +913,82 @@ baseline = last sample before start_time for the same stream_key, if available
 first in-window delta:
   if baseline exists:
     counterDelta(first.rx_bytes, baseline.rx_bytes)
+    counterDelta(first.tx_bytes, baseline.tx_bytes)
+  else if this is a confirmed new association/session that began within the window:
+    first.rx_bytes
+    first.tx_bytes
   else:
     0
 
 subsequent deltas:
   counterDelta(current.rx_bytes, previous.rx_bytes)
+  counterDelta(current.tx_bytes, previous.tx_bytes)
 
 data_consume_rx = SUM(reset-safe rx_bytes deltas)
 data_consume_tx = SUM(reset-safe tx_bytes deltas)
 total_data_usage = data_consume_rx + data_consume_tx
+
+usage_accuracy = exact when no contributing stream is incomplete, otherwise lower_bound
+incomplete = true when usage_accuracy is lower_bound
 ```
 
-Calculate counter deltas per `stream_key`. After stream-level deltas are calculated, aggregate the resulting RX/TX deltas by station MAC for the response.
+Calculate counter deltas independently for RX and TX per `stream_key`. After stream-level deltas are calculated, aggregate the resulting RX/TX deltas by station MAC for the response. If any stream contributing to a station MAC is incomplete/estimated, that station's usage is incomplete/estimated.
+
+Usage accuracy contract:
+
+```text
+Returned usage is exact only when every stream has enough information to account
+for the requested window:
+  a pre-window baseline exists for an ongoing stream, or
+  the stream is confirmed to have begun within the requested window, or
+  any counter rollover is confirmed and handled with rollover arithmetic.
+
+When a stream lacks a pre-window baseline, has no reliable session/association
+start, or has an ambiguous counter decrease, the returned usage is a lower-bound
+estimate. The algorithm must avoid overcounting unknown traffic, so it adds zero
+for ambiguous intervals and treats the result as incomplete/estimated.
+
+The response must expose `usage_accuracy` per client:
+  exact: all contributing streams are fully accounted for
+  lower_bound: at least one contributing stream used a conservative zero delta
+    for an ambiguous interval or missing baseline
+
+When `usage_accuracy` is `lower_bound`, the reported byte and formatted usage
+values are the safely observed minimum. Actual usage may be higher.
+```
+
+A fixed-width rollover is confirmed only when the counter width is known for that source and the observed decrease is consistent with a rollover for that counter. If the counter width is unknown, or the decrease could also be a reset/reconnect/stale sample, treat it as ambiguous.
 
 ### Reset-Safe Delta Logic
 
 ```cpp
-uint64_t counterDelta(uint64_t current, uint64_t previous,
-                      bool confirmedFixedWidthRollover,
-                      uint64_t counterMax) {
+struct CounterDeltaResult {
+    uint64_t delta;
+    bool incomplete;
+};
+
+CounterDeltaResult counterDelta(uint64_t current,
+                                uint64_t previous,
+                                bool confirmedNewSession,
+                                bool newSessionStartedInWindow,
+                                bool confirmedFixedWidthRollover,
+                                uint64_t counterMax) {
     if (current >= previous) {
-        return current - previous;
+        return {current - previous, false};
+    }
+
+    if (confirmedNewSession) {
+        if (newSessionStartedInWindow) {
+            return {current, false};
+        }
+        return {0, true};
     }
 
     if (confirmedFixedWidthRollover) {
-        return (counterMax - previous) + current + 1;
+        return {(counterMax - previous) + current + 1, false};
     }
 
-    return 0;
+    return {0, true};
 }
 ```
 
@@ -745,13 +1019,46 @@ When no session identifier is available:
   but use BSSID/SSID/band/radio changes as stream boundaries when possible.
 
 If current < previous:
-  if fixed-width rollover is known and can be confirmed:
+  if a new association/session is confirmed:
+    if the new session start time is within [startTime, endTime):
+      add current as post-session-start traffic
+    else:
+      treat current as the new baseline, add delta 0, and mark the result
+      incomplete/estimated
+  else if fixed-width rollover is known and can be confirmed:
     apply rollover math
   else:
-    treat current as the new baseline and add delta 0
+    treat current as the new baseline, add delta 0, and mark the result
+    incomplete/estimated
 ```
 
-Without the pre-window baseline for the same calculated stream, the first sample inside the requested window can include traffic that occurred before `start_time`. Do not add the first in-window cumulative counter directly unless it is known to be a fresh association/reset for that same stream.
+Without the pre-window baseline for the same calculated stream, the first sample inside the requested window can include traffic that occurred before `start_time`. Do not add the first in-window cumulative counter directly unless it is known to be a fresh association/session that started inside the requested window. If the stream may have started before `start_time`, add zero for the first sample and mark the result incomplete/estimated.
+
+A new association/session is confirmed only when the source provides reliable session identity or timing evidence. For example, a session id change, association id change, or connected-duration reset may prove a new session if it also proves the session start time is within the requested window. BSSID, SSID, band, or radio changes define separate calculation streams, but they do not by themselves prove that the new cumulative counter started inside the requested window.
+
+Example:
+
+```text
+10:00 rx_bytes = 1000
+10:05 rx_bytes = 1500
+10:10 rx_bytes = 200
+
+Delta 10:00 -> 10:05 = 500
+
+If 10:10 is a confirmed new session that started inside the request window:
+  add 200
+  total rx_bytes = 700
+  usage_accuracy = exact, unless another stream is incomplete
+
+If 10:10 is an ambiguous decrease:
+  add 0
+  total rx_bytes = 500
+  usage_accuracy = lower_bound
+
+If previous = 9900, current = 100, counterMax = 9999, and rollover is confirmed:
+  delta = (9999 - 9900) + 100 + 1
+  delta = 200
+```
 
 ### Incorrect Calculation
 
@@ -801,7 +1108,7 @@ Resolve boardId from routerId
     ↓
 Load TimePointDB records for resolvedBoardId and stored serialNumber == request routerId
     ↓
-Include records from startTime through endTime
+Include records from startTime up to but not including endTime
     ↓
 Also load the latest pre-window association sample for each calculated stream_key
     ↓
@@ -939,7 +1246,7 @@ Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
   timestamp >= startTime
-  timestamp <= endTime
+  timestamp < endTime
 
 For each record:
   parse ssid_data
@@ -1155,7 +1462,7 @@ src/StorageService.cpp
   include availability retention cleanup if retention should match board timepoint cleanup
 ```
 
-Add a DB upgrade/migration path for the new table. Existing deployments will start with no historical availability events; the API should return `offline_count: 0` for successful empty queries, not infer old events from `lastDisconnection`.
+Add a DB upgrade/migration path for the new table. Existing deployments will start with no historical availability events. Define a fixed `availabilityValidFrom` timestamp as the deployment/migration time when availability-event persistence starts. The API should return `offline_count: 0` only for successful empty queries whose requested range starts at or after `availabilityValidFrom`; do not infer old events from `lastDisconnection`.
 
 Add the files to `CMakeLists.txt`.
 
@@ -1414,6 +1721,24 @@ offline_count =
     COUNT(event_type = 'offline')
 ```
 
+Availability migration boundary:
+
+```text
+availabilityValidFrom = deployment timestamp when device_availability_events
+persistence became active
+
+If startTime < availabilityValidFrom:
+  reject the request
+  do not query device_availability_events
+  do not return offline_count: 0
+
+If startTime >= availabilityValidFrom:
+  query device_availability_events normally
+```
+
+Rejecting pre-cutover ranges prevents a successful zero response from meaning either
+"no outages occurred" or "Analytics was not collecting availability events yet."
+
 ### Query
 
 ```sql
@@ -1422,10 +1747,25 @@ FROM device_availability_events
 WHERE serialNumber = :router_id
   AND event_type = 'offline'
   AND event_time >= :start_time
-  AND event_time <= :end_time;
+  AND event_time < :end_time;
 ```
 
 Do not require `board_id = :resolvedBoardId` for the availability count. `board_id` is nullable event-time context and can differ from the router's current board after reassignment. The durable query identity for gateway availability history is `serialNumber`.
+
+### Range Before Availability Cutover
+
+Use an HTTP error:
+
+```http
+400 Bad Request
+```
+
+```json
+{
+  "error": "availability_range_before_cutover",
+  "message": "Availability history is only available for ranges starting at or after availabilityValidFrom"
+}
+```
 
 ### Success Response with No Offline Events
 
@@ -1503,7 +1843,7 @@ struct ClientRssiQuality;
 struct GatewayOfflineSummary;
 ```
 
-JSON field names should match the MCP CSV exactly.
+JSON field names should match the MCP CSV where the API is directly returning MCP fields. `usage-summary` additionally returns raw byte totals and usage accuracy fields so callers can distinguish exact usage from lower-bound estimates.
 
 ---
 
@@ -1551,9 +1891,9 @@ usage-summary
 rssi-summary
 ```
 
-The helper must use the current `routerId -> boardId` map maintained by `VenueCoordinator` as the primary ownership source. OWPROV inventory lookup must be status-aware and is used to verify or refresh ownership on cache/map misses. Any refresh path must read `InventoryTag.venue` and resolve board ownership with `monitorSubVenues` support, using candidate board device lists through `SDK::Prov::Venue::GetDevices(..., VenueInfo.monitorSubVenues, ...)` when needed. A single MCP request must reuse one `RouterIdResolutionResult` for repeated metrics targeting the same `routerId`.
+The helper must use the current `routerId -> boardId` map maintained by `VenueCoordinator` as the primary ownership source. OWPROV inventory lookup must be status-aware and is used to verify or refresh ownership on cache/map misses. Any refresh path must read `InventoryTag.venue` and resolve board ownership with `monitorSubVenues` support, using candidate board device lists through `SDK::Prov::Venue::GetDevices(..., VenueInfo.monitorSubVenues, ...)` when needed.
 
-`availability-summary` is the exception. It must validate `routerId` and authorization, but it must not require successful current `resolvedBoardId` resolution before reading availability storage. Request-time resolution may be used only for current context or authorization hints. The historical count must query availability storage by durable `serialNumber`, not by mandatory current `resolvedBoardId`.
+`availability-summary` is the storage-query exception, not an authorization exception. It must authenticate the caller, resolve current router ownership, and verify the caller has `analytics.gateway_metrics.read` on the resolved board, venue, or parent entity before querying availability storage. After authorization succeeds, the historical count must query availability storage by durable `serialNumber`, not by mandatory current `resolvedBoardId`. Event-time `board_id` is historical context only and must not authorize the request by itself.
 
 ---
 
@@ -1631,7 +1971,7 @@ bool GetGatewayAvailabilitySummary(...);
 | MCP Tool | Analytics API | Data Source | Implementation Status |
 |---|---|---|---|
 | `get_gateway_free_memory` | `GET /devices/{routerId}/memory-summary` | `timepoints.resource_data.memory_free` | Resolve routerId to venueId and boardId, then aggregate `timepoints` |
-| `get_gateway_wifi_temp` | `GET /devices/{routerId}/radio-temperature-summary` | `timepoints.radio_data[].temperature` | Resolve routerId to venueId and boardId, then aggregate `timepoints` |
+| `get_gateway_wifi_temp` | `GET /devices/{routerId}/radio-temperature-summary` | `timepoints.radio_data[].wifi_temp` | Resolve routerId to venueId and boardId, then aggregate present Wi-Fi temperature samples from `timepoints` |
 | `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then reset-safe delta aggregation with pre-window baseline |
 | `get_device_rssi_quality` | `GET /devices/{routerId}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve routerId to venueId and boardId, then classify RSSI samples |
 | `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic plus `device_availability_events` | Use routerId as durable serialNumber, persist restart-safe state transitions, then count offline events by serialNumber |


### PR DESCRIPTION
## Overview

This PR adds a detailed design document for Analytics APIs required by MCP tools.

The document defines the request format, response format, data sources, validation rules, storage changes, and implementation approach for the following MCP methods:

* `get_gateway_free_memory`
* `get_gateway_wifi_temp`
* `get_device_bandwidth_consumption`
* `get_device_rssi_quality`
* `get_gateway_offline_count`

The document is based on the current structure and storage model of the `ra-wlan-cloud-analytics` service.

## Changes Included

### MCP-Compatible API Contracts

Added request and response contracts that match the MCP tool definitions and expected CSV response fields.

Common MCP parameters:

```text
router_id
timestamp_till
lookback_hours
```

The document also defines the mapping between layers:

```text
MCP parameter: router_id
REST path parameter: routerId
Analytics storage field: serialNumber
```

### Time-Range Handling

Defined RFC3339 timestamp parsing and lookback calculation:

```text
endTime = parse(timestampTill)
startTime = endTime - (lookbackHours * 3600)
```

Validation rules are included for invalid timestamps, unsupported values, and excessive lookback ranges.

### Router-to-Board Resolution

Documented how Analytics can resolve the internal `boardId` using the gateway serial number through OWPROV inventory and existing board/venue configuration.

The design covers:

* direct venue assignment;
* child venue monitoring;
* multiple matching boards;
* inventory lookup errors;
* OWPROV availability failures;
* optional resolver caching.

### Gateway Free-Memory Summary

Added the proposed API:

```http
GET /api/v1/devices/{routerId}/memory-summary
```

The document describes how to preserve raw memory telemetry such as:

```text
unit.memory.free
unit.memory.total
unit.memory.cached
unit.memory.buffered
```

It also defines the required model, storage migration, ingestion, and aggregation changes.

### Radio Temperature Summary

Added the proposed API:

```http
GET /api/v1/devices/{routerId}/radio-temperature-summary
```

The implementation uses the existing `timepoints.radio_data` values and calculates minimum, maximum, and average temperatures separately for 2.4 GHz and 5 GHz radios.

### Client Bandwidth Consumption

Added the proposed API:

```http
GET /api/v1/devices/{routerId}/wifi-clients/usage-summary
```

The document defines reset-safe RX/TX counter delta calculations and explains why cumulative byte counters must not be summed directly.

It also covers the use of a pre-window baseline to avoid including traffic generated before the requested interval.

### Client RSSI Quality

Added the proposed API:

```http
GET /api/v1/devices/{routerId}/wifi-clients/rssi-summary
```

The API groups client RSSI samples into:

* excellent;
* good;
* fair;
* poor.

It returns per-client sample counts and percentage distributions matching the MCP response contract.

### Gateway Offline Count

Added the proposed API:

```http
GET /api/v1/devices/{routerId}/availability-summary
```

The design uses the existing gateway `connection` topic and introduces persistence for gateway online/offline state transitions.

It ensures that:

* only actual state transitions are stored;
* regular ping messages are not counted as new online events;
* historical offline counts can be queried by time range;
* duplicate Kafka events do not inflate results.

## Scope Clarification

`get_wifi_client_connect_disconnect_stats` is not included in this document because the current Analytics service does not ingest the required Wi-Fi client lifecycle and authentication events.

Supporting that MCP method would require a separate event-ingestion design and implementation.

## Repository Areas Covered

The document identifies required changes in:

```text
openapi/owanalytics.yaml
src/RESTObjects/RESTAPI_AnalyticsObjects.*
src/RESTAPI/
src/storage/
src/StorageService.*
src/APStats.cpp
src/RESTAPI/RESTAPI_routers.cpp
CMakeLists.txt
```

## Testing Guidance

When these APIs are implemented, verification should include:

* valid and invalid timestamp handling;
* zero and excessive lookback values;
* gateway-to-board resolution;
* gateways assigned through child venues;
* empty time ranges;
* missing radio bands;
* memory records created before schema migration;
* client counter resets and reconnects;
* invalid RSSI samples;
* duplicate connection events;
* repeated gateway ping messages;
* offline count queries with no matching events.

## Notes for Reviewers

This PR only adds the API design and implementation guidance document. It does not yet implement the REST handlers, storage migrations, Kafka persistence, or OpenAPI routes.

Please review:

* MCP request and response compatibility;
* router-to-board resolution strategy;
* internal use of `serialNumber`;
* storage and migration recommendations;
* counter-delta calculations;
* gateway availability-event handling;
* proposed API naming and response fields.
