### PR TITLE
Test Cases of Analytics api for mcp server

### DIFF
--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -117,12 +117,15 @@ Resolution flow:
 
 ```text
 1. Validate routerId.
-2. Call OWPROV inventory for the serial number with status-aware handling:
+2. Check the request-scoped routerId resolution cache.
+3. Resolve board ownership from the maintained routerId -> boardId map.
+4. If the map has a current entry, use it as resolvedBoardId.
+5. On cache/map miss, call OWPROV inventory with status-aware handling:
      GET /api/v1/inventory/{routerId}
-3. Read inventoryTag.venue as venueId.
-4. Find the Analytics board that currently owns routerId.
-5. Use that board's BoardInfo.info.id as resolvedBoardId.
-6. Query Analytics storage with resolvedBoardId and serialNumber = routerId.
+6. Read inventoryTag.venue as venueId.
+7. Use the OWPROV venue result to verify or refresh board ownership.
+8. Store the resolved result in the request-scoped cache.
+9. Query Analytics storage with resolvedBoardId and serialNumber = routerId.
 ```
 
 Implementation notes:
@@ -135,17 +138,38 @@ OWPROV response field:
   InventoryTag.venue
 
 Analytics local source:
-  BoardsDB records
+  VenueCoordinator maintained routerId -> boardId map
+  BoardInfo records for venue metadata and validation
   BoardInfo.venueList[].id
   BoardInfo.venueList[].monitorSubVenues
 ```
 
-Board ownership resolution must account for child venues. Do not only check whether `inventoryTag.venue` is directly present in `BoardInfo.venueList`.
+Board ownership resolution must use the maintained `routerId -> boardId` map as the primary design. `VenueCoordinator` should maintain this map from the same board device lists used by `VenueWatcher`, updating it when boards start, reconcile, or change device membership.
 
-Preferred ownership algorithm:
+OWPROV inventory lookup is not the normal path for every metric query. It is used when the local map has no entry, when the entry needs verification, or when ownership may be stale. Board ownership refresh must account for child venues. Do not only check whether `inventoryTag.venue` is directly present in `BoardInfo.venueList`.
+
+Primary ownership algorithm:
 
 ```text
-For each local BoardInfo record:
+Look up routerId in VenueCoordinator's maintained routerId -> boardId map.
+
+If exactly one current board mapping exists:
+  resolvedBoardId = mapped boardId
+  return Success
+
+If no mapping exists:
+  perform status-aware OWPROV inventory lookup
+  read InventoryTag.venue
+  refresh candidate board ownership from current venue device lists
+  update the maintained routerId -> boardId map when ownership is determined
+```
+
+This mirrors the existing watcher behavior, where board devices are fetched from OWPROV with the board venue's `monitorSubVenues` setting.
+
+Refresh algorithm for cache/map misses:
+
+```text
+For each local BoardInfo record that can own the inventory venue:
   for each VenueInfo in BoardInfo.venueList:
     call SDK::Prov::Venue::GetDevices(
       client,
@@ -159,17 +183,10 @@ For each local BoardInfo record:
 
 If exactly one candidate exists:
   resolvedBoardId = candidate board
+  update routerId -> boardId map
 ```
 
-This mirrors the existing watcher behavior, where board devices are fetched from OWPROV with the board venue's `monitorSubVenues` setting.
-
-Alternative implementation:
-
-```text
-Expose a current routerId -> boardId map from VenueCoordinator.
-The map must be maintained from the same device lists used by VenueWatcher.
-The resolver may use this map instead of scanning OWPROV for every request.
-```
+Request-scoped reuse is required. A single MCP request that asks for multiple metrics for the same router must resolve `routerId` once, then reuse the same `RouterIdResolutionResult` for all handlers in that request. For example, five MCP metric queries in one request must not repeat the full resolution process five times.
 
 Failure handling:
 
@@ -229,7 +246,7 @@ Option B:
   directly from ResolveRouterIdContext and inspect the HTTP response status.
 ```
 
-Handlers may cache `routerId -> venueId -> boardId` for a short TTL, but must refresh or invalidate the cache when OWPROV reports a different venue.
+Handlers may keep a short-lived process cache for `routerId -> venueId -> boardId`, but it is secondary to the maintained `VenueCoordinator` ownership map. Any cache must refresh or invalidate entries when OWPROV reports a different venue or when `VenueCoordinator` reports changed board membership.
 
 ---
 
@@ -459,6 +476,35 @@ radios[].band
 radios[].temperature
 ```
 
+Temperature samples need explicit validity handling. Current ingestion in `APStats.cpp` defaults a missing radio temperature to `20` and also rewrites a reported `0` to `20`. Those fallback values must not be treated as genuine measurements.
+
+Required ingestion rule:
+
+```text
+If radios[].temperature is present, non-null, and accepted as a measured value:
+  store the measured temperature
+  store temperature_valid = true
+
+If radios[].temperature is missing, null, or rejected as invalid:
+  keep temperature missing/null
+  store temperature_valid = false
+
+Do not synthesize a numeric fallback temperature for missing data.
+Do not store 20, 0, or any other placeholder for a missing temperature.
+For all newly ingested records, temperature_valid must be present.
+```
+
+Historical data rule:
+
+```text
+Existing stored temperature == 20 is ambiguous because it may be either:
+  a genuine measured 20, or
+  the synthetic fallback for missing/zero input
+
+Unless a migration can prove the value came from a real measured source, do not use
+historical 20 values in min/max/average temperature summaries.
+```
+
 The current radio-band mapping is:
 
 ```text
@@ -489,13 +535,28 @@ For each record:
   parse radio_data
   for each radio in radio_data:
     if radio.band is 2 or 5:
-      add radio.temperature to that band's sample list
+      if radio.temperature_valid is true and radio.temperature is present:
+        add radio.temperature to that band's sample list
 
 For each band:
   min_temperature = min(samples)
   max_temperature = max(samples)
   avg_temperature = sum(samples) / sample_count
 ```
+
+A valid temperature sample is:
+
+```text
+New records:
+  temperature is present and non-null
+  and temperature_valid == true
+
+Historical records from the current ingestion behavior:
+  temperature is present
+  and temperature != 20
+```
+
+If all samples for a band are invalid or missing, return `null` for that band's min, max, and average fields.
 
 Do not query `radio_timepoints` unless a separate normalized table and migration are introduced.
 
@@ -615,44 +676,82 @@ The values are cumulative counters, so they must not be summed directly.
 ### Correct Calculation
 
 ```text
-baseline = last sample before start_time for the same client, if available
+stream_key = association/session id when available, otherwise:
+  station MAC
+  BSSID
+  SSID
+  band/radio when present
+
+baseline = last sample before start_time for the same stream_key, if available
 
 first in-window delta:
   if baseline exists:
-    resetSafeDelta(first.rx_bytes, baseline.rx_bytes)
+    counterDelta(first.rx_bytes, baseline.rx_bytes)
   else:
     0
 
 subsequent deltas:
-  resetSafeDelta(current.rx_bytes, previous.rx_bytes)
+  counterDelta(current.rx_bytes, previous.rx_bytes)
 
 data_consume_rx = SUM(reset-safe rx_bytes deltas)
 data_consume_tx = SUM(reset-safe tx_bytes deltas)
 total_data_usage = data_consume_rx + data_consume_tx
 ```
 
+Calculate counter deltas per `stream_key`. After stream-level deltas are calculated, aggregate the resulting RX/TX deltas by station MAC for the response.
+
 ### Reset-Safe Delta Logic
 
 ```cpp
-uint64_t resetSafeDelta(uint64_t current, uint64_t previous) {
+uint64_t counterDelta(uint64_t current, uint64_t previous,
+                      bool confirmedFixedWidthRollover,
+                      uint64_t counterMax) {
     if (current >= previous) {
         return current - previous;
     }
 
-    return current;
+    if (confirmedFixedWidthRollover) {
+        return (counterMax - previous) + current + 1;
+    }
+
+    return 0;
 }
 ```
 
-This handles:
+Do not treat every lower counter as a reset where `current` should be added. A lower value can mean a new association session, movement between radios/BSSIDs, stale or out-of-order telemetry, duplicate station records inside one timepoint, or counter-width rollover. Adding `current` on every decrease can overcount traffic by attributing unknown pre-window traffic to the requested window.
+
+Required sample handling:
 
 ```text
-client reconnection
-counter reset
-gateway reboot
-counter rollover
+Build a deterministic sample key from the stable fields available in the association:
+  station MAC
+  timestamp
+  BSSID, SSID, band/radio when present
+
+Sort samples by:
+  station MAC
+  timestamp ASC
+  BSSID/SSID/band/radio tie-breakers
+
+Deduplicate exact duplicate samples before calculating deltas.
+
+Discard out-of-order samples for the same calculated stream.
+
+When an association/session identifier is available:
+  calculate deltas only within the same session.
+
+When no session identifier is available:
+  use station MAC as the result grouping key,
+  but use BSSID/SSID/band/radio changes as stream boundaries when possible.
+
+If current < previous:
+  if fixed-width rollover is known and can be confirmed:
+    apply rollover math
+  else:
+    treat current as the new baseline and add delta 0
 ```
 
-Without the pre-window baseline, the first sample inside the requested window can include traffic that occurred before `start_time`. Do not add the first in-window cumulative counter directly unless it is known to be a fresh association/reset.
+Without the pre-window baseline for the same calculated stream, the first sample inside the requested window can include traffic that occurred before `start_time`. Do not add the first in-window cumulative counter directly unless it is known to be a fresh association/reset for that same stream.
 
 ### Incorrect Calculation
 
@@ -669,7 +768,7 @@ This would overcount cumulative values.
 GROUP BY station_id
 ```
 
-A client moving between BSSIDs should remain one client unless a per-BSSID result is explicitly required.
+A client moving between BSSIDs should remain one client in the final response unless a per-BSSID result is explicitly required. However, BSSID/SSID/band/radio changes must define separate calculation streams for counter deltas unless a reliable association/session identifier says they are the same counter stream.
 
 ### Unit Conversion
 
@@ -704,15 +803,15 @@ Load TimePointDB records for resolvedBoardId and stored serialNumber == request 
     ↓
 Include records from startTime through endTime
     ↓
-Also load the latest pre-window association sample for each station MAC
+Also load the latest pre-window association sample for each calculated stream_key
     ↓
 Parse ssid_data associations
     ↓
-Group by station MAC and sort by timestamp
+Build stream_key values and sort samples by stream_key and timestamp
     ↓
 Calculate reset-safe RX/TX deltas
     ↓
-Sum values by MAC
+Aggregate stream-level deltas by station MAC
     ↓
 Convert bytes to megabits
     ↓
@@ -942,6 +1041,7 @@ reason
 connection_ip
 session_id
 event_id
+idempotency_key
 metadata
 ```
 
@@ -952,6 +1052,8 @@ Add a dedicated storage class for availability events:
 ```text
 src/storage/storage_device_availability_events.h
 src/storage/storage_device_availability_events.cpp
+src/storage/storage_device_availability_state.h
+src/storage/storage_device_availability_state.cpp
 ```
 
 Required ORM fields and indexes:
@@ -959,7 +1061,7 @@ Required ORM fields and indexes:
 ```text
 Fields:
   id              TEXT primary id
-  board_id        TEXT
+  board_id        TEXT NULL
   serialNumber    TEXT
   event_type      TEXT
   event_time      BIGINT
@@ -967,6 +1069,7 @@ Fields:
   connection_ip   TEXT
   session_id      TEXT
   event_id        TEXT
+  idempotency_key TEXT NOT NULL
   metadata        TEXT
 
 Indexes:
@@ -979,8 +1082,51 @@ Indexes:
     serialNumber ASC
     event_time ASC
 
+Unique constraints:
+  availability_idempotency_key_unique:
+    idempotency_key ASC
+
+Optional indexes:
   availability_event_id_index:
     event_id ASC
+```
+
+`event_id` stores the normalized source event id when the payload provides one, using `payload.ping.uuid`, `payload.uuid`, or `payload.disconnection.uuid` only when that `uuid` is stable for the same logical source event.
+
+`serialNumber` is the durable identity for availability history. `board_id` is event-time context only and must be nullable because connection events can arrive when the router is not currently assigned to an Analytics board, when OWPROV is unavailable, or after ownership has changed. Do not drop availability events only because current board ownership cannot be resolved.
+
+Add a persisted current-state table for restart-safe transition detection:
+
+```text
+device_availability_state
+-------------------------
+serialNumber
+board_id
+current_state
+last_event_time
+last_idempotency_key
+updated_at
+metadata
+```
+
+Required fields and constraints:
+
+```text
+Fields:
+  serialNumber         TEXT primary id
+  board_id             TEXT NULL
+  current_state        TEXT
+  last_event_time      BIGINT
+  last_idempotency_key TEXT
+  updated_at           BIGINT
+  metadata             TEXT
+
+Indexes:
+  availability_state_board_index:
+    board_id ASC
+
+Constraints:
+  current_state must be one of: online, offline, unknown
 ```
 
 Add a `DeviceAvailabilityEvent` REST/storage object with `to_json` and `from_json` support in:
@@ -995,12 +1141,17 @@ Update `StorageService`:
 ```text
 src/StorageService.h
   include storage/storage_device_availability_events.h
+  include storage/storage_device_availability_state.h
   add DeviceAvailabilityEventsDB accessor
+  add DeviceAvailabilityStateDB accessor
   add std::unique_ptr<DeviceAvailabilityEventsDB>
+  add std::unique_ptr<DeviceAvailabilityStateDB>
 
 src/StorageService.cpp
   construct DeviceAvailabilityEventsDB
+  construct DeviceAvailabilityStateDB
   call DeviceAvailabilityEventsDB->Create()
+  call DeviceAvailabilityStateDB->Create()
   include availability retention cleanup if retention should match board timepoint cleanup
 ```
 
@@ -1017,6 +1168,21 @@ src/APStats.cpp
   AP::UpdateConnection(...)
 ```
 
+Ingestion-time board source:
+
+```text
+1. Read board ownership from VenueCoordinator's maintained routerId -> boardId map.
+2. If a current mapping exists:
+     set board_id to the mapped board id.
+3. If no current mapping exists:
+     set board_id to NULL.
+     still persist the availability state/event by serialNumber when the message is otherwise valid.
+4. Do not perform a full OWPROV inventory lookup or board scan for every connection event.
+5. A background refresh or later request-time resolution may update current ownership, but it must not rewrite historical event ownership blindly.
+```
+
+The ingestion path must not depend on HTTP request-time `ResolveRouterIdContext`. That resolver can use OWPROV to verify or refresh ownership for API requests, but Kafka connection ingestion should use the maintained `VenueCoordinator` ownership map and tolerate missing current board ownership.
+
 Rules:
 
 ```text
@@ -1029,7 +1195,200 @@ On ping/capabilities:
 Do not store online events for every ping.
 ```
 
-The event writer must include `resolvedBoardId`/`board_id`, `serialNumber` set from request `routerId`, `event_type`, and the event timestamp. If the incoming connection message has a stable event id or session id, persist it and use `event_id` for idempotency.
+Bootstrap rule when no persisted state exists:
+
+```text
+First observed disconnection:
+  insert one offline event
+  set current_state = offline
+
+First observed ping/capabilities:
+  set current_state = online
+  do not insert an online event
+
+First observed unrecognized connection message:
+  set current_state = unknown
+  do not insert a counted event
+```
+
+In-memory transition checking is only an optimization. It is not sufficient for correctness because Kafka can redeliver messages and the service can restart after losing in-memory state. Transition detection must use `device_availability_state` or derive the latest known state from `device_availability_events` under the same transaction before writing. Duplicate connection messages must be rejected by storage-level idempotency before they can affect `offline_count`.
+
+Normalize connection messages before transition processing:
+
+```text
+If payload.ping exists:
+  message_type = ping
+  event_type = online
+  serialNumber = payload.ping.serialNumber
+  event_time = payload.ping.timestamp
+  source_event_uuid = payload.ping.uuid
+  connection_ip = payload.ping.connectionIp
+
+If payload.capabilities exists:
+  message_type = capabilities
+  event_type = online
+  serialNumber = payload.serial
+  event_time = payload.timestamp
+  source_event_uuid = payload.uuid
+  connection_ip = payload.connectionIp
+  reason = payload.reason
+
+If payload.disconnection exists:
+  message_type = disconnection
+  event_type = offline
+  serialNumber = payload.disconnection.serialNumber
+  event_time = payload.disconnection.timestamp
+  source_event_uuid = payload.disconnection.uuid
+```
+
+The event writer must include `board_id` from the ingestion-time ownership map when available, normalized `serialNumber`, `event_type`, normalized `event_time`, and a stable `idempotency_key`.
+
+Idempotency key rule:
+
+```text
+If the incoming connection message contains a stable source event id:
+  source_event_id = payload.ping.uuid
+    or payload.uuid
+    or payload.disconnection.uuid
+  idempotency_key = deterministic hash of:
+    system.host
+    system.id
+    serialNumber
+    message_type
+    source_event_id
+
+Else if the message contains a stable session id plus event timestamp:
+  idempotency_key = deterministic hash of:
+    serialNumber
+    message_type
+    event_type
+    event_time
+    session_id
+
+Else if connection_ip or reason is available:
+  idempotency_key = deterministic hash of the stable logical message identity:
+    serialNumber
+    message_type
+    event_type
+    event_time
+    reason
+    connection_ip
+
+Else:
+  idempotency_key = deterministic hash of the minimum stable logical identity:
+    serialNumber
+    message_type
+    event_type
+    event_time
+```
+
+Treat `uuid` as a source event id only if it is stable for the same logical connection message across Kafka redelivery and unique within the source namespace identified by `system.host` and `system.id`. If `uuid` is only a random per-delivery value, do not use it as `source_event_id`.
+
+Minimum fields for derived idempotency keys:
+
+```text
+All counted availability events:
+  serialNumber is required
+  event_type is required
+  event_time is required and must have the highest precision available from the source
+
+Offline events derived from disconnection:
+  reason or source disconnect cause is required when available
+  if reason/cause and connection_ip are missing:
+    prefer stable source_event_id from payload.disconnection.uuid
+    otherwise derive the key from serialNumber, message_type, event_type, and event_time
+  if reason/cause and connection_ip are missing and event_time precision is coarser than seconds:
+    do not write a counted offline event unless a stable source_event_id or session_id exists
+
+Online events derived from ping/capabilities:
+  session_id is required when available
+  if session_id is unavailable:
+    event_time plus message type must be precise enough to distinguish separate logical reconnects
+  if event_time is missing or too coarse to distinguish separate reconnects:
+    update current-state metadata only; do not write a counted online transition event
+
+Unrecognized connection messages:
+  do not write counted availability events
+  store only current-state metadata when useful
+```
+
+If the minimum fields for the event type are not present, the implementation must not create a counted `device_availability_events` row. It may update non-counted metadata only when doing so cannot move `device_availability_state` backward or create a false transition.
+
+Do not include `board_id` in the idempotency key unless it is part of a stable source event id. Board ownership can change between delivery and redelivery, and including current ownership in a derived key can turn one logical event into multiple stored events.
+
+Do not include Kafka topic, partition, or offset in the derived logical `idempotency_key`. Kafka coordinates identify a broker record, not the logical connection event. They dedupe redelivery of the same Kafka record, but they do not dedupe the same logical connection event produced as a second Kafka record with a different offset. Store topic, partition, offset, message key, and consumer timestamp in `metadata` for tracing only.
+
+The same delivered logical connection event must always produce the same `idempotency_key`. If the implementation cannot build a stable or deterministic key for an event, it must not write that event as a counted availability transition; log it as an ingestion error instead.
+
+Atomic transition and insert rule:
+
+```text
+For each valid connection message:
+  begin transaction
+  load the persisted state row for serialNumber with write/transaction isolation
+  if no state row exists:
+    treat previous state as unknown
+  determine the new state from the message
+  if state row exists and event_time is older than last_event_time:
+    treat the message as stale
+    do not insert an availability event
+    do not update device_availability_state
+    commit transaction
+    stop processing this message
+  if state row exists and event_time equals last_event_time and no reliable tie-breaker proves this event is later:
+    treat the message as duplicate or non-advancing
+    do not insert a counted availability event
+    do not update device_availability_state
+    commit transaction
+    stop processing this message
+  if previous state is unknown:
+    if new state is offline:
+      insert one offline event with conflict-safe semantics
+      if the insert created a row:
+        update device_availability_state to offline and last_event_time
+      else:
+        do not update device_availability_state
+    else if new state is online:
+      update device_availability_state to online and last_event_time
+      do not insert an online event
+    else:
+      update device_availability_state to unknown and last_event_time
+      do not insert a counted event
+  else if previous state differs from new state:
+    insert availability event with conflict-safe semantics:
+      INSERT ... ON CONFLICT(idempotency_key) DO NOTHING
+    if the insert created a row:
+      update device_availability_state to the new state and last_event_time
+    else:
+      treat it as a duplicate
+      do not update device_availability_state
+  else if previous state equals new state:
+    update last contact metadata only when event_time is newer than last_event_time
+    do not insert a counted transition event
+  commit transaction
+
+or the equivalent database-specific "insert if absent" operation.
+
+The storage method must return whether a row was inserted. Duplicate events that hit
+the unique idempotency constraint must not be treated as new offline transitions and
+must not move `device_availability_state` backward or forward.
+```
+
+Staleness rule:
+
+```text
+An event is stale when its event_time is older than the persisted state's
+last_event_time for the same serialNumber. An event with the same event_time is
+non-advancing unless a deterministic source tie-breaker proves it happened later.
+
+Stale or non-advancing events must not insert counted availability events and must
+not update device_availability_state, even if their idempotency_key has not been
+seen before.
+
+For equal timestamps, use deterministic tie-breakers if the source provides them.
+If no reliable tie-breaker exists, process at most one state-changing event for that
+serialNumber and timestamp.
+```
 
 ### Store Only State Transitions
 
@@ -1060,12 +1419,13 @@ offline_count =
 ```sql
 SELECT COUNT(*) AS offline_count
 FROM device_availability_events
-WHERE board_id = :board_id
-  AND serialNumber = :router_id
+WHERE serialNumber = :router_id
   AND event_type = 'offline'
   AND event_time >= :start_time
   AND event_time <= :end_time;
 ```
+
+Do not require `board_id = :resolvedBoardId` for the availability count. `board_id` is nullable event-time context and can differ from the router's current board after reassignment. The durable query identity for gateway availability history is `serialNumber`.
 
 ### Success Response with No Offline Events
 
@@ -1174,7 +1534,7 @@ usage-summary
 rssi-summary
 ```
 
-All handlers must call a shared serial-resolution helper before storage access:
+Timepoint-backed handlers must call a shared serial-resolution helper before storage access:
 
 ```cpp
 RouterIdResolutionResult ResolveRouterIdContext(
@@ -1182,7 +1542,18 @@ RouterIdResolutionResult ResolveRouterIdContext(
     const std::string& routerId);
 ```
 
-The helper must use status-aware OWPROV inventory lookup, read `InventoryTag.venue`, and resolve board ownership with `monitorSubVenues` support. It can either scan candidate board device lists through `SDK::Prov::Venue::GetDevices(..., VenueInfo.monitorSubVenues, ...)` or use a current `routerId -> boardId` map maintained by `VenueCoordinator`.
+The timepoint-backed handlers are:
+
+```text
+memory-summary
+radio-temperature-summary
+usage-summary
+rssi-summary
+```
+
+The helper must use the current `routerId -> boardId` map maintained by `VenueCoordinator` as the primary ownership source. OWPROV inventory lookup must be status-aware and is used to verify or refresh ownership on cache/map misses. Any refresh path must read `InventoryTag.venue` and resolve board ownership with `monitorSubVenues` support, using candidate board device lists through `SDK::Prov::Venue::GetDevices(..., VenueInfo.monitorSubVenues, ...)` when needed. A single MCP request must reuse one `RouterIdResolutionResult` for repeated metrics targeting the same `routerId`.
+
+`availability-summary` is the exception. It must validate `routerId` and authorization, but it must not require successful current `resolvedBoardId` resolution before reading availability storage. Request-time resolution may be used only for current context or authorization hints. The historical count must query availability storage by durable `serialNumber`, not by mandatory current `resolvedBoardId`.
 
 ---
 
@@ -1226,6 +1597,8 @@ src/storage/storage_wificlients.h
 src/storage/storage_wificlients.cpp
 src/storage/storage_device_availability_events.h
 src/storage/storage_device_availability_events.cpp
+src/storage/storage_device_availability_state.h
+src/storage/storage_device_availability_state.cpp
 src/StorageService.h
 src/StorageService.cpp
 ```
@@ -1261,7 +1634,7 @@ bool GetGatewayAvailabilitySummary(...);
 | `get_gateway_wifi_temp` | `GET /devices/{routerId}/radio-temperature-summary` | `timepoints.radio_data[].temperature` | Resolve routerId to venueId and boardId, then aggregate `timepoints` |
 | `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then reset-safe delta aggregation with pre-window baseline |
 | `get_device_rssi_quality` | `GET /devices/{routerId}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve routerId to venueId and boardId, then classify RSSI samples |
-| `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic | Resolve routerId to venueId and boardId, then aggregate persisted offline state transitions |
+| `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic plus `device_availability_events` | Use routerId as durable serialNumber, persist restart-safe state transitions, then count offline events by serialNumber |
 
 ---
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -1,0 +1,1264 @@
+# Analytics APIs for MCP Tools
+
+This document defines the request format, response format, and implementation logic for the following MCP tools in the `ra-wlan-cloud-analytics` service:
+
+- `get_gateway_free_memory`
+- `get_gateway_wifi_temp`
+- `get_device_bandwidth_consumption`
+- `get_device_rssi_quality`
+- `get_gateway_offline_count`
+
+The API contracts match the MCP tool names and response fields from the provided CSV.
+
+---
+
+# Common Input Parameters
+
+Each MCP tool receives:
+
+```text
+serial_number: str
+timestamp_till: str
+lookback_hours: int
+```
+
+The Analytics API should calculate the requested time range as:
+
+```text
+end_time = parse(timestamp_till)
+start_time = end_time - lookback_hours
+```
+
+Example:
+
+```text
+timestamp_till = 2026-07-27T12:00:00Z
+lookback_hours = 24
+
+start_time = 2026-07-26T12:00:00Z
+end_time   = 2026-07-27T12:00:00Z
+```
+
+Recommended query parameters:
+
+```http
+?timestampTill=2026-07-27T12:00:00Z
+&lookbackHours=24
+```
+
+These are `GET` APIs, so no request body is required.
+
+### Time Conversion and Validation
+
+The public MCP-facing parameters use ISO-8601/RFC3339 time, but the existing Analytics API style uses integer `fromDate` and `endDate` timestamps. Handlers should convert the request as:
+
+```text
+timestampTill: RFC3339 UTC string, for example 2026-07-27T12:00:00Z
+endTime:       Unix epoch seconds parsed from timestampTill
+startTime:     endTime - (lookbackHours * 3600)
+```
+
+Validation rules:
+
+```text
+timestampTill must parse as a valid timestamp.
+lookbackHours must be greater than 0.
+lookbackHours should have a bounded maximum, for example 24 * 31.
+startTime must be less than endTime.
+```
+
+Return `400 Bad Request` for invalid timestamps, unsupported timezones, non-positive `lookbackHours`, or values above the configured maximum. Internally, query `timepoints.timestamp` and `wificlienthistory.timestamp` using epoch seconds.
+
+### Current Storage Model
+
+The current service does not store normalized tables named `device_timepoints`, `radio_timepoints`, or `wifi_client_history`.
+
+Current tables are:
+
+```text
+timepoints
+  boardId
+  timestamp
+  ap_data      JSON string
+  ssid_data    JSON string
+  radio_data   JSON string
+  device_info  JSON string
+  serialNumber
+
+wificlienthistory
+  timestamp
+  station_id
+  bssid
+  ssid
+  rssi
+  rx_bytes
+  tx_bytes
+  venue_id
+  ...
+```
+
+Gateway-scoped APIs should accept only `serialNumber` publicly. The handler must resolve the internal `boardId` before loading `TimePointDB` records.
+
+### Serial Number Resolution
+
+The MCP tool cannot pass `boardId`, so Analytics must resolve it from the gateway serial number.
+
+Resolution flow:
+
+```text
+1. Validate serialNumber.
+2. Call OWPROV inventory for the serial number with status-aware handling:
+     GET /api/v1/inventory/{serialNumber}
+3. Read inventoryTag.venue as venueId.
+4. Find the Analytics board that currently owns serialNumber.
+5. Use that board's BoardInfo.info.id as resolvedBoardId.
+6. Query Analytics storage with resolvedBoardId and serialNumber.
+```
+
+Implementation notes:
+
+```text
+OWPROV source:
+  /api/v1/inventory/{serialNumber}
+
+OWPROV response field:
+  InventoryTag.venue
+
+Analytics local source:
+  BoardsDB records
+  BoardInfo.venueList[].id
+  BoardInfo.venueList[].monitorSubVenues
+```
+
+Board ownership resolution must account for child venues. Do not only check whether `inventoryTag.venue` is directly present in `BoardInfo.venueList`.
+
+Preferred ownership algorithm:
+
+```text
+For each local BoardInfo record:
+  for each VenueInfo in BoardInfo.venueList:
+    call SDK::Prov::Venue::GetDevices(
+      client,
+      VenueInfo.id,
+      VenueInfo.monitorSubVenues,
+      venueDeviceList,
+      venueExists)
+
+    if serialNumber is present in venueDeviceList.devices:
+      add BoardInfo.info.id as a candidate board
+
+If exactly one candidate exists:
+  resolvedBoardId = candidate board
+```
+
+This mirrors the existing watcher behavior, where board devices are fetched from OWPROV with the board venue's `monitorSubVenues` setting.
+
+Alternative implementation:
+
+```text
+Expose a current serialNumber -> boardId map from VenueCoordinator.
+The map must be maintained from the same device lists used by VenueWatcher.
+The resolver may use this map instead of scanning OWPROV for every request.
+```
+
+Failure handling:
+
+```text
+OWPROV inventory not found              -> 404 Not Found
+Inventory exists but venue is empty     -> 404 Not Found
+No Analytics board configured for venue -> 404 Not Found
+Multiple matching boards                -> 409 Conflict unless deterministic ownership exists
+OWPROV unavailable or invalid response  -> 502 Bad Gateway
+```
+
+The resolver must return a status-bearing result, not a boolean, so handlers can map each failure to the correct HTTP response.
+
+```cpp
+enum class SerialResolutionStatus {
+    Success,
+    InvalidSerialNumber,
+    InventoryNotFound,
+    EmptyVenue,
+    BoardNotConfigured,
+    MultipleBoards,
+    OwprovUnavailable,
+    OwprovInvalidResponse
+};
+
+struct SerialResolutionResult {
+    SerialResolutionStatus status = SerialResolutionStatus::OwprovUnavailable;
+    std::string serialNumber;
+    std::string venueId;
+    std::string resolvedBoardId;
+    std::string message;
+};
+```
+
+Status mapping:
+
+```text
+Success               -> continue request
+InvalidSerialNumber   -> 400 Bad Request
+InventoryNotFound     -> 404 Not Found
+EmptyVenue            -> 404 Not Found
+BoardNotConfigured    -> 404 Not Found
+MultipleBoards        -> 409 Conflict
+OwprovUnavailable     -> 502 Bad Gateway
+OwprovInvalidResponse -> 502 Bad Gateway
+```
+
+The existing `SDK::Prov::Device::Get` helper returns only `bool` and does not expose the OWPROV HTTP status. Do not use that bool-only helper when the handler must distinguish `404 Not Found` from OWPROV connectivity or parsing failures. Use one of these instead:
+
+```text
+Option A:
+  Add a status-aware SDK helper, for example:
+    SDK::Prov::Device::GetWithStatus(...)
+
+Option B:
+  Call OpenAPIRequestGet(uSERVICE_PROVISIONING, "/api/v1/inventory/{serialNumber}", ...)
+  directly from ResolveSerialNumberContext and inspect the HTTP response status.
+```
+
+Handlers may cache `serialNumber -> venueId -> boardId` for a short TTL, but must refresh or invalidate the cache when OWPROV reports a different venue.
+
+---
+
+# 1. `get_gateway_free_memory`
+
+## MCP Tool Signature
+
+```text
+get_gateway_free_memory(
+    serial_number: str,
+    timestamp_till: str,
+    lookback_hours: int
+)
+```
+
+## Recommended API
+
+```http
+GET /api/v1/devices/{serialNumber}/memory-summary
+    ?timestampTill=2026-07-27T12:00:00Z
+    &lookbackHours=24
+```
+
+## Example Request
+
+```http
+GET /api/v1/devices/60cf84f22290/memory-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24
+Authorization: Bearer <token>
+```
+
+## Request Body
+
+```text
+None
+```
+
+## Response
+
+```json
+{
+  "min_memfree": 211374,
+  "max_memfree": 215050,
+  "avg_memfree": 212074.36
+}
+```
+
+## API Logic
+
+The gateway state payload contains:
+
+```text
+unit.memory.free
+unit.memory.total
+unit.memory.cached
+unit.memory.buffered
+```
+
+The current Analytics implementation calculates memory usage percentage from `free` and `total`, but does not preserve all raw memory values as separate historical fields.
+
+### Required Model Change
+
+Add raw memory fields to the device time-point model and persist them with each `timepoints` record:
+
+```cpp
+struct DeviceResourceTimePoint {
+    uint64_t memory_free = 0;
+    uint64_t memory_total = 0;
+    uint64_t memory_cached = 0;
+    uint64_t memory_buffered = 0;
+};
+
+struct DeviceTimePoint {
+    ...
+    DeviceResourceTimePoint resource_data;
+};
+```
+
+Required code changes:
+
+```text
+src/RESTObjects/RESTAPI_AnalyticsObjects.h
+  Add DeviceResourceTimePoint.
+  Add DeviceTimePoint::resource_data.
+
+src/RESTObjects/RESTAPI_AnalyticsObjects.cpp
+  Add DeviceResourceTimePoint to_json/from_json.
+  Add resource_data to DeviceTimePoint to_json/from_json.
+
+src/storage/storage_timepoints.h
+  Extend TimePointDBRecordType with a resource_data JSON string field.
+
+src/storage/storage_timepoints.cpp
+  Add ORM field resource_data.
+  Update Convert(record -> DeviceTimePoint).
+  Update Convert(DeviceTimePoint -> record).
+  Add an Upgrade migration for existing DBs.
+
+src/APStats.cpp
+  Populate DTP.resource_data from unit.memory during state ingestion.
+```
+
+Existing rows will not have `resource_data`; treat those rows as missing memory samples rather than zero free memory.
+
+### Ingestion Logic
+
+```cpp
+AnalyticsObjects::DeviceResourceTimePoint resource;
+GetJSON("free", memory, resource.memory_free, uint64_t{0});
+GetJSON("total", memory, resource.memory_total, uint64_t{0});
+GetJSON("cached", memory, resource.memory_cached, uint64_t{0});
+GetJSON("buffered", memory, resource.memory_buffered, uint64_t{0});
+DTP.resource_data = resource;
+```
+
+### Aggregation Logic
+
+Use the current `timepoints` table plus parsed JSON fields:
+
+```text
+Load TimePointDB records where:
+  boardId == resolvedBoardId
+  serialNumber == serialNumber
+  timestamp >= startTime
+  timestamp <= endTime
+
+For each record:
+  read record.resource_data.memory_free
+  ignore missing resource_data
+  ignore memory_free when memory_total is 0 and the sample came from a missing memory block
+
+Return:
+  min_memfree = min(memory_free samples)
+  max_memfree = max(memory_free samples)
+  avg_memfree = sum(memory_free samples) / sample_count
+```
+
+Do not query `device_timepoints.memory_free` unless a separate normalized table and migration are introduced.
+
+### Handler Flow
+
+```text
+Validate serialNumber
+    ↓
+Call ResolveSerialNumberContext(client, serialNumber)
+    ↓
+If status is not Success, map SerialResolutionStatus to HTTP response
+    ↓
+Use result.venueId and result.resolvedBoardId
+    ↓
+Parse timestampTill
+    ↓
+Calculate start_time
+    ↓
+Query timepoints and read resource_data.memory_free samples
+    ↓
+Calculate min, max and average
+    ↓
+Return MCP response shape
+```
+
+### Empty Result
+
+```json
+{
+  "min_memfree": null,
+  "max_memfree": null,
+  "avg_memfree": null
+}
+```
+
+Use HTTP `200 OK` when the query succeeds but no data exists.
+
+---
+
+# 2. `get_gateway_wifi_temp`
+
+## MCP Tool Signature
+
+```text
+get_gateway_wifi_temp(
+    serial_number: str,
+    timestamp_till: str,
+    lookback_hours: int
+)
+```
+
+## Recommended API
+
+```http
+GET /api/v1/devices/{serialNumber}/radio-temperature-summary
+    ?timestampTill=2026-07-27T12:00:00Z
+    &lookbackHours=24
+```
+
+## Example Request
+
+```http
+GET /api/v1/devices/60cf84f22290/radio-temperature-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24
+Authorization: Bearer <token>
+```
+
+## Request Body
+
+```text
+None
+```
+
+## Response
+
+```json
+{
+  "min_wifi_temp_2.4G": 62,
+  "max_wifi_temp_2.4G": 70,
+  "avg_wifi_temp_2.4G": 66.64,
+  "min_wifi_temp_5G": 56,
+  "max_wifi_temp_5G": 65,
+  "avg_wifi_temp_5G": 60.38
+}
+```
+
+## API Logic
+
+Analytics already stores:
+
+```text
+radios[].band
+radios[].temperature
+```
+
+The current radio-band mapping is:
+
+```text
+2G → 2
+5G → 5
+6G → 6
+```
+
+Response mapping:
+
+```text
+band = 2 → fields ending in _2.4G
+band = 5 → fields ending in _5G
+```
+
+### Aggregation Logic
+
+Use the current `timepoints.radio_data` JSON array:
+
+```text
+Load TimePointDB records where:
+  boardId == resolvedBoardId
+  serialNumber == serialNumber
+  timestamp >= startTime
+  timestamp <= endTime
+
+For each record:
+  parse radio_data
+  for each radio in radio_data:
+    if radio.band is 2 or 5:
+      add radio.temperature to that band's sample list
+
+For each band:
+  min_temperature = min(samples)
+  max_temperature = max(samples)
+  avg_temperature = sum(samples) / sample_count
+```
+
+Do not query `radio_timepoints` unless a separate normalized table and migration are introduced.
+
+### Handler Logic
+
+```cpp
+if (radio.band == 2) {
+    response.min_wifi_temp_2_4G = summary.min;
+    response.max_wifi_temp_2_4G = summary.max;
+    response.avg_wifi_temp_2_4G = summary.avg;
+}
+
+if (radio.band == 5) {
+    response.min_wifi_temp_5G = summary.min;
+    response.max_wifi_temp_5G = summary.max;
+    response.avg_wifi_temp_5G = summary.avg;
+}
+```
+
+### Missing Band Example
+
+```json
+{
+  "min_wifi_temp_2.4G": 62,
+  "max_wifi_temp_2.4G": 70,
+  "avg_wifi_temp_2.4G": 66.64,
+  "min_wifi_temp_5G": null,
+  "max_wifi_temp_5G": null,
+  "avg_wifi_temp_5G": null
+}
+```
+
+---
+
+# 3. `get_device_bandwidth_consumption`
+
+## MCP Tool Signature
+
+```text
+get_device_bandwidth_consumption(
+    serial_number: str,
+    timestamp_till: str,
+    lookback_hours: int
+)
+```
+
+## Recommended API
+
+```http
+GET /api/v1/devices/{serialNumber}/wifi-clients/usage-summary
+    ?timestampTill=2026-07-27T12:00:00Z
+    &lookbackHours=24
+```
+
+## Example Request
+
+```http
+GET /api/v1/devices/60cf84f22290/wifi-clients/usage-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24
+Authorization: Bearer <token>
+```
+
+## Request Body
+
+```text
+None
+```
+
+## Response
+
+```json
+[
+  {
+    "mac": "e2:51:95:ed:0f:28",
+    "data_consume_rx": "851.9 Mb",
+    "data_consume_tx": "30.81 Mb",
+    "total_data_usage": "882.71 Mb"
+  },
+  {
+    "mac": "28:39:26:a1:7c:a5",
+    "data_consume_rx": "240.57 Mb",
+    "data_consume_tx": "131.89 Mb",
+    "total_data_usage": "372.46 Mb"
+  }
+]
+```
+
+## API Logic
+
+For gateway-scoped results, use `timepoints.ssid_data[].associations[]` because `wificlienthistory` currently does not store the gateway `serialNumber`.
+
+`timepoints.ssid_data[].associations[]` already stores per-client:
+
+```text
+station MAC
+RX bytes
+TX bytes
+packet counters
+connected duration
+BSSID
+SSID
+radio information
+```
+
+Alternative implementation:
+
+```text
+If wificlienthistory is preferred for performance, first add serialNumber to:
+  AnalyticsObjects::WifiClientHistory
+  WifiClientHistoryDBRecordType
+  storage_wificlients.cpp fields and converters
+  APStats.cpp ingestion
+  DB upgrade migration
+```
+
+The values are cumulative counters, so they must not be summed directly.
+
+### Correct Calculation
+
+```text
+baseline = last sample before start_time for the same client, if available
+
+first in-window delta:
+  if baseline exists:
+    resetSafeDelta(first.rx_bytes, baseline.rx_bytes)
+  else:
+    0
+
+subsequent deltas:
+  resetSafeDelta(current.rx_bytes, previous.rx_bytes)
+
+data_consume_rx = SUM(reset-safe rx_bytes deltas)
+data_consume_tx = SUM(reset-safe tx_bytes deltas)
+total_data_usage = data_consume_rx + data_consume_tx
+```
+
+### Reset-Safe Delta Logic
+
+```cpp
+uint64_t resetSafeDelta(uint64_t current, uint64_t previous) {
+    if (current >= previous) {
+        return current - previous;
+    }
+
+    return current;
+}
+```
+
+This handles:
+
+```text
+client reconnection
+counter reset
+gateway reboot
+counter rollover
+```
+
+Without the pre-window baseline, the first sample inside the requested window can include traffic that occurred before `start_time`. Do not add the first in-window cumulative counter directly unless it is known to be a fresh association/reset.
+
+### Incorrect Calculation
+
+```sql
+SUM(rx_bytes)
+SUM(tx_bytes)
+```
+
+This would overcount cumulative values.
+
+### Grouping
+
+```text
+GROUP BY station_id
+```
+
+A client moving between BSSIDs should remain one client unless a per-BSSID result is explicitly required.
+
+### Unit Conversion
+
+The MCP output expects strings such as:
+
+```text
+851.9 Mb
+30.81 Mb
+```
+
+Recommended conversion:
+
+```cpp
+double rxMb = static_cast<double>(rxBytes) * 8.0 / 1000000.0;
+double txMb = static_cast<double>(txBytes) * 8.0 / 1000000.0;
+```
+
+`Mb` means megabits. If the implementation divides bytes by `1024 * 1024`, label the result as `MiB` or `MB` instead.
+
+Formatting:
+
+```cpp
+fmt::format("{:.2f} Mb", value);
+```
+
+### Query Flow
+
+```text
+Resolve boardId from serialNumber
+    ↓
+Load TimePointDB records for resolvedBoardId and serialNumber
+    ↓
+Include records from startTime through endTime
+    ↓
+Also load the latest pre-window association sample for each station MAC
+    ↓
+Parse ssid_data associations
+    ↓
+Group by station MAC and sort by timestamp
+    ↓
+Calculate reset-safe RX/TX deltas
+    ↓
+Sum values by MAC
+    ↓
+Convert bytes to megabits
+    ↓
+Return array
+```
+
+---
+
+# 4. `get_device_rssi_quality`
+
+## MCP Tool Signature
+
+```text
+get_device_rssi_quality(
+    serial_number: str,
+    timestamp_till: str,
+    lookback_hours: int
+)
+```
+
+## Recommended API
+
+```http
+GET /api/v1/devices/{serialNumber}/wifi-clients/rssi-summary
+    ?timestampTill=2026-07-27T12:00:00Z
+    &lookbackHours=24
+```
+
+## Example Request
+
+```http
+GET /api/v1/devices/60cf84f22290/wifi-clients/rssi-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24
+Authorization: Bearer <token>
+```
+
+## Request Body
+
+```text
+None
+```
+
+## Response
+
+```json
+[
+  {
+    "mac": "e2:51:95:ed:0f:28",
+    "rssi_excellent_pct": 41.67,
+    "rssi_good_pct": 50.0,
+    "rssi_fair_pct": 1.67,
+    "rssi_poor_pct": 6.67,
+    "rssi_total_samples": 60
+  },
+  {
+    "mac": "28:39:26:a1:7c:a5",
+    "rssi_excellent_pct": 92.73,
+    "rssi_good_pct": 7.27,
+    "rssi_fair_pct": 0.0,
+    "rssi_poor_pct": 0.0,
+    "rssi_total_samples": 110
+  }
+]
+```
+
+## API Logic
+
+For gateway-scoped results, read RSSI from `timepoints.ssid_data[].associations[]`. `wificlienthistory` also stores RSSI, but it cannot be filtered by gateway `serialNumber` unless that model is extended as described in the bandwidth section.
+
+### RSSI Thresholds
+
+```text
+Excellent: RSSI >= -55
+Good:      -67 <= RSSI < -55
+Fair:      -75 <= RSSI < -67
+Poor:      RSSI < -75
+```
+
+### Invalid Samples
+
+Ignore:
+
+```text
+RSSI = 0
+RSSI > 0
+RSSI < -127
+NULL
+```
+
+### Per-Client Calculation
+
+```text
+excellent_count = COUNT(rssi >= -55)
+
+good_count =
+    COUNT(rssi >= -67 AND rssi < -55)
+
+fair_count =
+    COUNT(rssi >= -75 AND rssi < -67)
+
+poor_count =
+    COUNT(rssi < -75)
+
+total_samples =
+    excellent_count +
+    good_count +
+    fair_count +
+    poor_count
+```
+
+Percentages:
+
+```text
+excellent_pct = excellent_count × 100 / total_samples
+good_pct      = good_count × 100 / total_samples
+fair_pct      = fair_count × 100 / total_samples
+poor_pct      = poor_count × 100 / total_samples
+```
+
+Round percentages to two decimal places.
+
+### Current Storage Aggregation Logic
+
+```text
+Load TimePointDB records where:
+  boardId == resolvedBoardId
+  serialNumber == serialNumber
+  timestamp >= startTime
+  timestamp <= endTime
+
+For each record:
+  parse ssid_data
+  for each association:
+    station_id = normalized association.station MAC
+    rssi = association.rssi
+    ignore invalid RSSI samples
+    increment the station_id bucket for excellent/good/fair/poor
+
+For each station_id:
+  total_samples = excellent + good + fair + poor
+  calculate percentages from total_samples
+```
+
+Do not query `wifi_client_history.board_id`, `wifi_client_history.serial_number`, or `wifi_client_history.created`; those fields do not exist in the current schema.
+
+The API should return the final percentages directly. The MCP server should not need to perform additional RSSI summarisation.
+
+---
+
+# 5. `get_gateway_offline_count`
+
+## MCP Tool Signature
+
+```text
+get_gateway_offline_count(
+    serial_number: str,
+    timestamp_till: str,
+    lookback_hours: int
+)
+```
+
+## Recommended API
+
+```http
+GET /api/v1/devices/{serialNumber}/availability-summary
+    ?timestampTill=2026-07-27T12:00:00Z
+    &lookbackHours=24
+```
+
+## Example Request
+
+```http
+GET /api/v1/devices/60cf84f22290/availability-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24
+Authorization: Bearer <token>
+```
+
+## Request Body
+
+```text
+None
+```
+
+## Response
+
+```json
+{
+  "gw_uuid": "60cf84f22290",
+  "fetch_status": "success",
+  "offline_count": 6
+}
+```
+
+## API Logic
+
+This API can use gateway events from the existing `connection` topic.
+
+Analytics currently handles gateway-level events:
+
+```text
+ping
+disconnection
+capabilities
+```
+
+The current code updates:
+
+```text
+connected
+lastConnection
+lastDisconnection
+lastPing
+lastContact
+```
+
+To calculate historical offline counts, transitions must be persisted.
+
+### Storage Table
+
+```text
+device_availability_events
+--------------------------
+id
+board_id
+serial_number
+event_type
+event_time
+reason
+connection_ip
+session_id
+event_id
+metadata
+```
+
+### Required Storage Implementation
+
+Add a dedicated storage class for availability events:
+
+```text
+src/storage/storage_device_availability_events.h
+src/storage/storage_device_availability_events.cpp
+```
+
+Required ORM fields and indexes:
+
+```text
+Fields:
+  id              TEXT primary id
+  board_id        TEXT
+  serial_number   TEXT
+  event_type      TEXT
+  event_time      BIGINT
+  reason          TEXT
+  connection_ip   TEXT
+  session_id      TEXT
+  event_id        TEXT
+  metadata        TEXT
+
+Indexes:
+  availability_serial_time_index:
+    serial_number ASC
+    event_time ASC
+
+  availability_board_serial_time_index:
+    board_id ASC
+    serial_number ASC
+    event_time ASC
+
+  availability_event_id_index:
+    event_id ASC
+```
+
+Add a `DeviceAvailabilityEvent` REST/storage object with `to_json` and `from_json` support in:
+
+```text
+src/RESTObjects/RESTAPI_AnalyticsObjects.h
+src/RESTObjects/RESTAPI_AnalyticsObjects.cpp
+```
+
+Update `StorageService`:
+
+```text
+src/StorageService.h
+  include storage/storage_device_availability_events.h
+  add DeviceAvailabilityEventsDB accessor
+  add std::unique_ptr<DeviceAvailabilityEventsDB>
+
+src/StorageService.cpp
+  construct DeviceAvailabilityEventsDB
+  call DeviceAvailabilityEventsDB->Create()
+  include availability retention cleanup if retention should match board timepoint cleanup
+```
+
+Add a DB upgrade/migration path for the new table. Existing deployments will start with no historical availability events; the API should return `offline_count: 0` for successful empty queries, not infer old events from `lastDisconnection`.
+
+Add the files to `CMakeLists.txt`.
+
+### Ingestion Hook
+
+Persist availability events from connection handling:
+
+```text
+src/APStats.cpp
+  AP::UpdateConnection(...)
+```
+
+Rules:
+
+```text
+On disconnection:
+  store one offline event when the device transitions from connected to disconnected.
+
+On ping/capabilities:
+  store one online event only when the device transitions from disconnected to connected.
+
+Do not store online events for every ping.
+```
+
+The event writer must include `resolvedBoardId`/`board_id`, `serial_number`, `event_type`, and the event timestamp. If the incoming connection message has a stable event id or session id, persist it and use `event_id` for idempotency.
+
+### Store Only State Transitions
+
+Correct:
+
+```text
+offline → online: store online event
+online → offline: store offline event
+```
+
+Incorrect:
+
+```text
+every ping → store online event
+```
+
+Every ping should not be treated as a new online transition.
+
+### Calculation
+
+```text
+offline_count =
+    COUNT(event_type = 'offline')
+```
+
+### Query
+
+```sql
+SELECT COUNT(*) AS offline_count
+FROM device_availability_events
+WHERE board_id = :board_id
+  AND serial_number = :serial_number
+  AND event_type = 'offline'
+  AND event_time >= :start_time
+  AND event_time <= :end_time;
+```
+
+### Success Response with No Offline Events
+
+```json
+{
+  "gw_uuid": "60cf84f22290",
+  "fetch_status": "success",
+  "offline_count": 0
+}
+```
+
+### Internal Error
+
+Use an HTTP error:
+
+```http
+500 Internal Server Error
+```
+
+```json
+{
+  "error": "availability_query_failed",
+  "message": "Unable to retrieve gateway availability history"
+}
+```
+
+Do not return `fetch_status: failed` with HTTP 200 for internal failures.
+
+---
+
+# Repository Implementation Structure
+
+Repository:
+
+```text
+routerarchitects/ra-wlan-cloud-analytics
+```
+
+## OpenAPI
+
+Update:
+
+```text
+openapi/owanalytics.yaml
+```
+
+Add:
+
+```yaml
+/devices/{serialNumber}/memory-summary:
+/devices/{serialNumber}/radio-temperature-summary:
+/devices/{serialNumber}/availability-summary:
+/devices/{serialNumber}/wifi-clients/usage-summary:
+/devices/{serialNumber}/wifi-clients/rssi-summary:
+```
+
+---
+
+## REST Objects
+
+Update:
+
+```text
+src/RESTObjects/RESTAPI_AnalyticsObjects.h
+src/RESTObjects/RESTAPI_AnalyticsObjects.cpp
+```
+
+Add objects:
+
+```cpp
+struct GatewayMemorySummary;
+struct GatewayWifiTemperatureSummary;
+struct ClientBandwidthConsumption;
+struct ClientRssiQuality;
+struct GatewayOfflineSummary;
+```
+
+JSON field names should match the MCP CSV exactly.
+
+---
+
+## REST Handlers
+
+Recommended files:
+
+```text
+src/RESTAPI/RESTAPI_device_metrics_summary_handler.h
+src/RESTAPI/RESTAPI_device_metrics_summary_handler.cpp
+
+src/RESTAPI/RESTAPI_wifi_client_metrics_handler.h
+src/RESTAPI/RESTAPI_wifi_client_metrics_handler.cpp
+```
+
+Device metrics handler:
+
+```text
+memory-summary
+radio-temperature-summary
+availability-summary
+```
+
+Wi-Fi client metrics handler:
+
+```text
+usage-summary
+rssi-summary
+```
+
+All handlers must call a shared serial-resolution helper before storage access:
+
+```cpp
+SerialResolutionResult ResolveSerialNumberContext(
+    RESTAPIHandler* client,
+    const std::string& serialNumber);
+```
+
+The helper must use status-aware OWPROV inventory lookup, read `InventoryTag.venue`, and resolve board ownership with `monitorSubVenues` support. It can either scan candidate board device lists through `SDK::Prov::Venue::GetDevices(..., VenueInfo.monitorSubVenues, ...)` or use a current `serialNumber -> boardId` map maintained by `VenueCoordinator`.
+
+---
+
+## Router Registration
+
+Update:
+
+```text
+src/RESTAPI/RESTAPI_routers.cpp
+```
+
+Register the new handlers in both:
+
+```text
+RESTAPI_Router
+RESTAPI_Router_I
+```
+
+---
+
+## Build Configuration
+
+Update:
+
+```text
+CMakeLists.txt
+```
+
+Add all new handler and storage `.cpp` and `.h` files.
+
+---
+
+## Storage Files
+
+Update:
+
+```text
+src/storage/storage_timepoints.h
+src/storage/storage_timepoints.cpp
+src/storage/storage_wificlients.h
+src/storage/storage_wificlients.cpp
+src/storage/storage_device_availability_events.h
+src/storage/storage_device_availability_events.cpp
+src/StorageService.h
+src/StorageService.cpp
+```
+
+`storage_wificlients.*` only needs changes if the implementation chooses to add `serialNumber` to `wificlienthistory`. The default implementation for gateway-scoped client summaries should aggregate `timepoints.ssid_data` to avoid that migration.
+
+Suggested functions:
+
+```cpp
+bool GetMemorySummary(
+    const std::string& resolvedBoardId,
+    const std::string& serialNumber,
+    uint64_t startTime,
+    uint64_t endTime,
+    AnalyticsObjects::GatewayMemorySummary& result);
+
+bool GetRadioTemperatureSummary(...);
+
+bool GetWifiClientUsageSummary(...);
+
+bool GetWifiClientRssiSummary(...);
+
+bool GetGatewayAvailabilitySummary(...);
+```
+
+---
+
+# Final Mapping
+
+| MCP Tool | Analytics API | Data Source | Implementation Status |
+|---|---|---|---|
+| `get_gateway_free_memory` | `GET /devices/{serialNumber}/memory-summary` | `timepoints.resource_data.memory_free` | Resolve serial to venueId and boardId, then aggregate `timepoints` |
+| `get_gateway_wifi_temp` | `GET /devices/{serialNumber}/radio-temperature-summary` | `timepoints.radio_data[].temperature` | Resolve serial to venueId and boardId, then aggregate `timepoints` |
+| `get_device_bandwidth_consumption` | `GET /devices/{serialNumber}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve serial to venueId and boardId, then reset-safe delta aggregation with pre-window baseline |
+| `get_device_rssi_quality` | `GET /devices/{serialNumber}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve serial to venueId and boardId, then classify RSSI samples |
+| `get_gateway_offline_count` | `GET /devices/{serialNumber}/availability-summary` | Existing gateway `connection` topic | Resolve serial to venueId and boardId, then aggregate persisted offline state transitions |
+
+---
+
+# Recommended Implementation Order
+
+1. `get_gateway_wifi_temp`
+2. `get_device_rssi_quality`
+3. `get_device_bandwidth_consumption`
+4. `get_gateway_free_memory`
+5. `get_gateway_offline_count`

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -559,6 +559,45 @@ Existing rows will not have `resource_data`; treat those rows as missing memory 
 
 Do not represent missing memory fields as `0`. A missing `memory_free` value and a genuine reported zero must remain distinguishable.
 
+Migration coverage rule:
+
+```text
+Define a fixed memory_resource_data_valid_from timestamp as the deployment/migration
+timestamp where timepoints.resource_data.memory_free starts being written
+consistently.
+
+If startTime < memory_resource_data_valid_from:
+  effectiveStartTime = min(memory_resource_data_valid_from, endTime)
+  partial = true
+
+If startTime >= memory_resource_data_valid_from:
+  effectiveStartTime = startTime
+  partial = false
+
+effectiveEndTime = endTime
+```
+
+When the requested range starts before memory_resource_data_valid_from, the API
+may still return `200 OK`, but the aggregate values must represent only
+`[effectiveStartTime, endTime)`. The response must include a coverage header so
+consumers can distinguish a complete-window average from a post-migration-only
+partial average.
+
+Response coverage header:
+
+```http
+X-Analytics-Coverage: {"requested_start":"2026-07-26T12:00:00Z","requested_end":"2026-07-27T12:00:00Z","effective_start":"2026-07-26T12:00:00Z","effective_end":"2026-07-27T12:00:00Z","data_available_from":"2026-07-01T00:00:00Z","partial":false}
+```
+
+Header fields must use RFC3339 UTC timestamps. `requested_start` and
+`requested_end` are the original half-open request window. `effective_start` and
+`effective_end` are the half-open window used for aggregation. `data_available_from`
+is `memory_resource_data_valid_from`. `partial` is `true` when
+`effective_start` is later than `requested_start`. If the entire requested range
+is before `memory_resource_data_valid_from`, `effective_start` and
+`effective_end` must both equal `requested_end`, the aggregate window is empty,
+and the response body uses the normal empty-result values.
+
 ### Ingestion Logic
 
 ```cpp
@@ -586,7 +625,7 @@ Use the current `timepoints` table plus parsed JSON fields:
 Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
-  timestamp >= startTime
+  timestamp >= effectiveStartTime
   timestamp < endTime
 
 For each record:
@@ -616,6 +655,8 @@ Use result.venueId and result.resolvedBoardId
 Parse timestampTill
     ↓
 Calculate start_time
+    ↓
+Calculate effectiveStartTime and X-Analytics-Coverage
     ↓
 Query timepoints and read resource_data.memory_free samples
     ↓
@@ -706,7 +747,7 @@ Do not synthesize a numeric fallback temperature for missing data.
 Do not store a placeholder in wifi_temp for a missing temperature.
 ```
 
-Migration boundary rule:
+Migration coverage rule:
 
 ```text
 Define a fixed temperature_migration_cutover_time as the deployment/migration
@@ -717,14 +758,40 @@ Ignore all earlier records because historical temperature values cannot reliably
 distinguish measured values from synthetic fallback values.
 
 If the requested range starts before temperature_migration_cutover_time:
-  effective_start_time = temperature_migration_cutover_time
-else:
-  effective_start_time = startTime
+  effectiveStartTime = min(temperature_migration_cutover_time, endTime)
+  partial = true
+
+If startTime >= temperature_migration_cutover_time:
+  effectiveStartTime = startTime
+  partial = false
+
+effectiveEndTime = endTime
 
 Do not filter out post-cutover samples only because the measured value is 20°C.
 After the cutover, a present wifi_temp value is treated as a legitimate
 measurement.
 ```
+
+When the requested range starts before temperature_migration_cutover_time, the
+API may still return `200 OK`, but the aggregate values must represent only
+`[effectiveStartTime, endTime)`. The response must include a coverage header so
+consumers can distinguish a complete-window average from a post-migration-only
+partial average.
+
+Response coverage header:
+
+```http
+X-Analytics-Coverage: {"requested_start":"2026-07-26T12:00:00Z","requested_end":"2026-07-27T12:00:00Z","effective_start":"2026-07-26T12:00:00Z","effective_end":"2026-07-27T12:00:00Z","data_available_from":"2026-07-01T00:00:00Z","partial":false}
+```
+
+Header fields must use RFC3339 UTC timestamps. `requested_start` and
+`requested_end` are the original half-open request window. `effective_start` and
+`effective_end` are the half-open window used for aggregation. `data_available_from`
+is `temperature_migration_cutover_time`. `partial` is `true` when
+`effective_start` is later than `requested_start`. If the entire requested range
+is before `temperature_migration_cutover_time`, `effective_start` and
+`effective_end` must both equal `requested_end`, the aggregate window is empty,
+and the response body uses the normal empty-result values.
 
 The current radio-band mapping is:
 
@@ -749,7 +816,7 @@ Use the current `timepoints.radio_data` JSON array:
 Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
-  timestamp >= effective_start_time
+  timestamp >= effectiveStartTime
   timestamp < endTime
 
 For each record:

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -17,16 +17,26 @@ The API contracts match the MCP tool names and response fields from the provided
 Each MCP tool receives:
 
 ```text
-serial_number: str
+router_id: str
 timestamp_till: str
 lookback_hours: int
+```
+
+`router_id` is the gateway serial number value from the CSV. Analytics APIs expose the same value as the path variable `routerId`.
+
+```text
+MCP input:              router_id
+Analytics path variable: routerId
+routerId = router_id
+Internal storage field: serialNumber
+serialNumber = routerId
 ```
 
 The Analytics API should calculate the requested time range as:
 
 ```text
 end_time = parse(timestamp_till)
-start_time = end_time - lookback_hours
+start_time = end_time - (lookback_hours * 3600)
 ```
 
 Example:
@@ -97,29 +107,29 @@ wificlienthistory
   ...
 ```
 
-Gateway-scoped APIs should accept only `serialNumber` publicly. The handler must resolve the internal `boardId` before loading `TimePointDB` records.
+Gateway-scoped APIs should accept only `routerId` publicly. The handler must map `routerId` to the existing internal `serialNumber` field and resolve the internal `boardId` before loading `TimePointDB` records. Do not rename the existing `timepoints.serialNumber` field or its indexes to `routerId`.
 
-### Serial Number Resolution
+### RouterId Resolution
 
-The MCP tool cannot pass `boardId`, so Analytics must resolve it from the gateway serial number.
+The MCP tool cannot pass `boardId`, so Analytics must resolve it from `routerId`, which is the gateway serial number.
 
 Resolution flow:
 
 ```text
-1. Validate serialNumber.
+1. Validate routerId.
 2. Call OWPROV inventory for the serial number with status-aware handling:
-     GET /api/v1/inventory/{serialNumber}
+     GET /api/v1/inventory/{routerId}
 3. Read inventoryTag.venue as venueId.
-4. Find the Analytics board that currently owns serialNumber.
+4. Find the Analytics board that currently owns routerId.
 5. Use that board's BoardInfo.info.id as resolvedBoardId.
-6. Query Analytics storage with resolvedBoardId and serialNumber.
+6. Query Analytics storage with resolvedBoardId and serialNumber = routerId.
 ```
 
 Implementation notes:
 
 ```text
 OWPROV source:
-  /api/v1/inventory/{serialNumber}
+  /api/v1/inventory/{routerId}
 
 OWPROV response field:
   InventoryTag.venue
@@ -144,7 +154,7 @@ For each local BoardInfo record:
       venueDeviceList,
       venueExists)
 
-    if serialNumber is present in venueDeviceList.devices:
+    if routerId is present in venueDeviceList.devices:
       add BoardInfo.info.id as a candidate board
 
 If exactly one candidate exists:
@@ -156,7 +166,7 @@ This mirrors the existing watcher behavior, where board devices are fetched from
 Alternative implementation:
 
 ```text
-Expose a current serialNumber -> boardId map from VenueCoordinator.
+Expose a current routerId -> boardId map from VenueCoordinator.
 The map must be maintained from the same device lists used by VenueWatcher.
 The resolver may use this map instead of scanning OWPROV for every request.
 ```
@@ -174,9 +184,9 @@ OWPROV unavailable or invalid response  -> 502 Bad Gateway
 The resolver must return a status-bearing result, not a boolean, so handlers can map each failure to the correct HTTP response.
 
 ```cpp
-enum class SerialResolutionStatus {
+enum class RouterIdResolutionStatus {
     Success,
-    InvalidSerialNumber,
+    InvalidRouterId,
     InventoryNotFound,
     EmptyVenue,
     BoardNotConfigured,
@@ -185,9 +195,9 @@ enum class SerialResolutionStatus {
     OwprovInvalidResponse
 };
 
-struct SerialResolutionResult {
-    SerialResolutionStatus status = SerialResolutionStatus::OwprovUnavailable;
-    std::string serialNumber;
+struct RouterIdResolutionResult {
+    RouterIdResolutionStatus status = RouterIdResolutionStatus::OwprovUnavailable;
+    std::string routerId;
     std::string venueId;
     std::string resolvedBoardId;
     std::string message;
@@ -198,7 +208,7 @@ Status mapping:
 
 ```text
 Success               -> continue request
-InvalidSerialNumber   -> 400 Bad Request
+InvalidRouterId   -> 400 Bad Request
 InventoryNotFound     -> 404 Not Found
 EmptyVenue            -> 404 Not Found
 BoardNotConfigured    -> 404 Not Found
@@ -215,11 +225,11 @@ Option A:
     SDK::Prov::Device::GetWithStatus(...)
 
 Option B:
-  Call OpenAPIRequestGet(uSERVICE_PROVISIONING, "/api/v1/inventory/{serialNumber}", ...)
-  directly from ResolveSerialNumberContext and inspect the HTTP response status.
+  Call OpenAPIRequestGet(uSERVICE_PROVISIONING, "/api/v1/inventory/{routerId}", ...)
+  directly from ResolveRouterIdContext and inspect the HTTP response status.
 ```
 
-Handlers may cache `serialNumber -> venueId -> boardId` for a short TTL, but must refresh or invalidate the cache when OWPROV reports a different venue.
+Handlers may cache `routerId -> venueId -> boardId` for a short TTL, but must refresh or invalidate the cache when OWPROV reports a different venue.
 
 ---
 
@@ -229,7 +239,7 @@ Handlers may cache `serialNumber -> venueId -> boardId` for a short TTL, but mus
 
 ```text
 get_gateway_free_memory(
-    serial_number: str,
+    router_id: str,
     timestamp_till: str,
     lookback_hours: int
 )
@@ -238,7 +248,7 @@ get_gateway_free_memory(
 ## Recommended API
 
 ```http
-GET /api/v1/devices/{serialNumber}/memory-summary
+GET /api/v1/devices/{routerId}/memory-summary
     ?timestampTill=2026-07-27T12:00:00Z
     &lookbackHours=24
 ```
@@ -341,7 +351,7 @@ Use the current `timepoints` table plus parsed JSON fields:
 ```text
 Load TimePointDB records where:
   boardId == resolvedBoardId
-  serialNumber == serialNumber
+  stored serialNumber == request routerId
   timestamp >= startTime
   timestamp <= endTime
 
@@ -361,11 +371,11 @@ Do not query `device_timepoints.memory_free` unless a separate normalized table 
 ### Handler Flow
 
 ```text
-Validate serialNumber
+Validate routerId
     ↓
-Call ResolveSerialNumberContext(client, serialNumber)
+Call ResolveRouterIdContext(client, routerId)
     ↓
-If status is not Success, map SerialResolutionStatus to HTTP response
+If status is not Success, map RouterIdResolutionStatus to HTTP response
     ↓
 Use result.venueId and result.resolvedBoardId
     ↓
@@ -400,7 +410,7 @@ Use HTTP `200 OK` when the query succeeds but no data exists.
 
 ```text
 get_gateway_wifi_temp(
-    serial_number: str,
+    router_id: str,
     timestamp_till: str,
     lookback_hours: int
 )
@@ -409,7 +419,7 @@ get_gateway_wifi_temp(
 ## Recommended API
 
 ```http
-GET /api/v1/devices/{serialNumber}/radio-temperature-summary
+GET /api/v1/devices/{routerId}/radio-temperature-summary
     ?timestampTill=2026-07-27T12:00:00Z
     &lookbackHours=24
 ```
@@ -471,7 +481,7 @@ Use the current `timepoints.radio_data` JSON array:
 ```text
 Load TimePointDB records where:
   boardId == resolvedBoardId
-  serialNumber == serialNumber
+  stored serialNumber == request routerId
   timestamp >= startTime
   timestamp <= endTime
 
@@ -526,7 +536,7 @@ if (radio.band == 5) {
 
 ```text
 get_device_bandwidth_consumption(
-    serial_number: str,
+    router_id: str,
     timestamp_till: str,
     lookback_hours: int
 )
@@ -535,7 +545,7 @@ get_device_bandwidth_consumption(
 ## Recommended API
 
 ```http
-GET /api/v1/devices/{serialNumber}/wifi-clients/usage-summary
+GET /api/v1/devices/{routerId}/wifi-clients/usage-summary
     ?timestampTill=2026-07-27T12:00:00Z
     &lookbackHours=24
 ```
@@ -592,7 +602,7 @@ radio information
 Alternative implementation:
 
 ```text
-If wificlienthistory is preferred for performance, first add serialNumber to:
+If wificlienthistory is preferred for performance, first add the gateway `serialNumber` to:
   AnalyticsObjects::WifiClientHistory
   WifiClientHistoryDBRecordType
   storage_wificlients.cpp fields and converters
@@ -688,9 +698,9 @@ fmt::format("{:.2f} Mb", value);
 ### Query Flow
 
 ```text
-Resolve boardId from serialNumber
+Resolve boardId from routerId
     ↓
-Load TimePointDB records for resolvedBoardId and serialNumber
+Load TimePointDB records for resolvedBoardId and stored serialNumber == request routerId
     ↓
 Include records from startTime through endTime
     ↓
@@ -717,7 +727,7 @@ Return array
 
 ```text
 get_device_rssi_quality(
-    serial_number: str,
+    router_id: str,
     timestamp_till: str,
     lookback_hours: int
 )
@@ -726,7 +736,7 @@ get_device_rssi_quality(
 ## Recommended API
 
 ```http
-GET /api/v1/devices/{serialNumber}/wifi-clients/rssi-summary
+GET /api/v1/devices/{routerId}/wifi-clients/rssi-summary
     ?timestampTill=2026-07-27T12:00:00Z
     &lookbackHours=24
 ```
@@ -828,7 +838,7 @@ Round percentages to two decimal places.
 ```text
 Load TimePointDB records where:
   boardId == resolvedBoardId
-  serialNumber == serialNumber
+  stored serialNumber == request routerId
   timestamp >= startTime
   timestamp <= endTime
 
@@ -845,7 +855,7 @@ For each station_id:
   calculate percentages from total_samples
 ```
 
-Do not query `wifi_client_history.board_id`, `wifi_client_history.serial_number`, or `wifi_client_history.created`; those fields do not exist in the current schema.
+Do not query `wifi_client_history.board_id`, `wifi_client_history.serialNumber`, or `wifi_client_history.created`; those fields do not exist in the current schema.
 
 The API should return the final percentages directly. The MCP server should not need to perform additional RSSI summarisation.
 
@@ -857,7 +867,7 @@ The API should return the final percentages directly. The MCP server should not 
 
 ```text
 get_gateway_offline_count(
-    serial_number: str,
+    router_id: str,
     timestamp_till: str,
     lookback_hours: int
 )
@@ -866,7 +876,7 @@ get_gateway_offline_count(
 ## Recommended API
 
 ```http
-GET /api/v1/devices/{serialNumber}/availability-summary
+GET /api/v1/devices/{routerId}/availability-summary
     ?timestampTill=2026-07-27T12:00:00Z
     &lookbackHours=24
 ```
@@ -925,7 +935,7 @@ device_availability_events
 --------------------------
 id
 board_id
-serial_number
+serialNumber
 event_type
 event_time
 reason
@@ -950,7 +960,7 @@ Required ORM fields and indexes:
 Fields:
   id              TEXT primary id
   board_id        TEXT
-  serial_number   TEXT
+  serialNumber    TEXT
   event_type      TEXT
   event_time      BIGINT
   reason          TEXT
@@ -961,12 +971,12 @@ Fields:
 
 Indexes:
   availability_serial_time_index:
-    serial_number ASC
+    serialNumber ASC
     event_time ASC
 
   availability_board_serial_time_index:
     board_id ASC
-    serial_number ASC
+    serialNumber ASC
     event_time ASC
 
   availability_event_id_index:
@@ -1019,7 +1029,7 @@ On ping/capabilities:
 Do not store online events for every ping.
 ```
 
-The event writer must include `resolvedBoardId`/`board_id`, `serial_number`, `event_type`, and the event timestamp. If the incoming connection message has a stable event id or session id, persist it and use `event_id` for idempotency.
+The event writer must include `resolvedBoardId`/`board_id`, `serialNumber` set from request `routerId`, `event_type`, and the event timestamp. If the incoming connection message has a stable event id or session id, persist it and use `event_id` for idempotency.
 
 ### Store Only State Transitions
 
@@ -1051,7 +1061,7 @@ offline_count =
 SELECT COUNT(*) AS offline_count
 FROM device_availability_events
 WHERE board_id = :board_id
-  AND serial_number = :serial_number
+  AND serialNumber = :router_id
   AND event_type = 'offline'
   AND event_time >= :start_time
   AND event_time <= :end_time;
@@ -1105,11 +1115,11 @@ openapi/owanalytics.yaml
 Add:
 
 ```yaml
-/devices/{serialNumber}/memory-summary:
-/devices/{serialNumber}/radio-temperature-summary:
-/devices/{serialNumber}/availability-summary:
-/devices/{serialNumber}/wifi-clients/usage-summary:
-/devices/{serialNumber}/wifi-clients/rssi-summary:
+/devices/{routerId}/memory-summary:
+/devices/{routerId}/radio-temperature-summary:
+/devices/{routerId}/availability-summary:
+/devices/{routerId}/wifi-clients/usage-summary:
+/devices/{routerId}/wifi-clients/rssi-summary:
 ```
 
 ---
@@ -1167,12 +1177,12 @@ rssi-summary
 All handlers must call a shared serial-resolution helper before storage access:
 
 ```cpp
-SerialResolutionResult ResolveSerialNumberContext(
+RouterIdResolutionResult ResolveRouterIdContext(
     RESTAPIHandler* client,
-    const std::string& serialNumber);
+    const std::string& routerId);
 ```
 
-The helper must use status-aware OWPROV inventory lookup, read `InventoryTag.venue`, and resolve board ownership with `monitorSubVenues` support. It can either scan candidate board device lists through `SDK::Prov::Venue::GetDevices(..., VenueInfo.monitorSubVenues, ...)` or use a current `serialNumber -> boardId` map maintained by `VenueCoordinator`.
+The helper must use status-aware OWPROV inventory lookup, read `InventoryTag.venue`, and resolve board ownership with `monitorSubVenues` support. It can either scan candidate board device lists through `SDK::Prov::Venue::GetDevices(..., VenueInfo.monitorSubVenues, ...)` or use a current `routerId -> boardId` map maintained by `VenueCoordinator`.
 
 ---
 
@@ -1220,14 +1230,14 @@ src/StorageService.h
 src/StorageService.cpp
 ```
 
-`storage_wificlients.*` only needs changes if the implementation chooses to add `serialNumber` to `wificlienthistory`. The default implementation for gateway-scoped client summaries should aggregate `timepoints.ssid_data` to avoid that migration.
+`storage_wificlients.*` only needs changes if the implementation chooses to add gateway `serialNumber` to `wificlienthistory`. The default implementation for gateway-scoped client summaries should aggregate `timepoints.ssid_data` to avoid that migration.
 
 Suggested functions:
 
 ```cpp
 bool GetMemorySummary(
     const std::string& resolvedBoardId,
-    const std::string& serialNumber,
+    const std::string& routerId,
     uint64_t startTime,
     uint64_t endTime,
     AnalyticsObjects::GatewayMemorySummary& result);
@@ -1247,11 +1257,11 @@ bool GetGatewayAvailabilitySummary(...);
 
 | MCP Tool | Analytics API | Data Source | Implementation Status |
 |---|---|---|---|
-| `get_gateway_free_memory` | `GET /devices/{serialNumber}/memory-summary` | `timepoints.resource_data.memory_free` | Resolve serial to venueId and boardId, then aggregate `timepoints` |
-| `get_gateway_wifi_temp` | `GET /devices/{serialNumber}/radio-temperature-summary` | `timepoints.radio_data[].temperature` | Resolve serial to venueId and boardId, then aggregate `timepoints` |
-| `get_device_bandwidth_consumption` | `GET /devices/{serialNumber}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve serial to venueId and boardId, then reset-safe delta aggregation with pre-window baseline |
-| `get_device_rssi_quality` | `GET /devices/{serialNumber}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve serial to venueId and boardId, then classify RSSI samples |
-| `get_gateway_offline_count` | `GET /devices/{serialNumber}/availability-summary` | Existing gateway `connection` topic | Resolve serial to venueId and boardId, then aggregate persisted offline state transitions |
+| `get_gateway_free_memory` | `GET /devices/{routerId}/memory-summary` | `timepoints.resource_data.memory_free` | Resolve routerId to venueId and boardId, then aggregate `timepoints` |
+| `get_gateway_wifi_temp` | `GET /devices/{routerId}/radio-temperature-summary` | `timepoints.radio_data[].temperature` | Resolve routerId to venueId and boardId, then aggregate `timepoints` |
+| `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then reset-safe delta aggregation with pre-window baseline |
+| `get_device_rssi_quality` | `GET /devices/{routerId}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve routerId to venueId and boardId, then classify RSSI samples |
+| `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic | Resolve routerId to venueId and boardId, then aggregate persisted offline state transitions |
 
 ---
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -559,45 +559,6 @@ Existing rows will not have `resource_data`; treat those rows as missing memory 
 
 Do not represent missing memory fields as `0`. A missing `memory_free` value and a genuine reported zero must remain distinguishable.
 
-Migration coverage rule:
-
-```text
-Define a fixed memory_resource_data_valid_from timestamp as the deployment/migration
-timestamp where timepoints.resource_data.memory_free starts being written
-consistently.
-
-If startTime < memory_resource_data_valid_from:
-  effectiveStartTime = min(memory_resource_data_valid_from, endTime)
-  partial = true
-
-If startTime >= memory_resource_data_valid_from:
-  effectiveStartTime = startTime
-  partial = false
-
-effectiveEndTime = endTime
-```
-
-When the requested range starts before memory_resource_data_valid_from, the API
-may still return `200 OK`, but the aggregate values must represent only
-`[effectiveStartTime, endTime)`. The response must include a coverage header so
-consumers can distinguish a complete-window average from a post-migration-only
-partial average.
-
-Response coverage header:
-
-```http
-X-Analytics-Coverage: {"requested_start":"2026-07-26T12:00:00Z","requested_end":"2026-07-27T12:00:00Z","effective_start":"2026-07-26T12:00:00Z","effective_end":"2026-07-27T12:00:00Z","data_available_from":"2026-07-01T00:00:00Z","partial":false}
-```
-
-Header fields must use RFC3339 UTC timestamps. `requested_start` and
-`requested_end` are the original half-open request window. `effective_start` and
-`effective_end` are the half-open window used for aggregation. `data_available_from`
-is `memory_resource_data_valid_from`. `partial` is `true` when
-`effective_start` is later than `requested_start`. If the entire requested range
-is before `memory_resource_data_valid_from`, `effective_start` and
-`effective_end` must both equal `requested_end`, the aggregate window is empty,
-and the response body uses the normal empty-result values.
-
 ### Ingestion Logic
 
 ```cpp
@@ -625,7 +586,7 @@ Use the current `timepoints` table plus parsed JSON fields:
 Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
-  timestamp >= effectiveStartTime
+  timestamp >= startTime
   timestamp < endTime
 
 For each record:
@@ -655,8 +616,6 @@ Use result.venueId and result.resolvedBoardId
 Parse timestampTill
     ↓
 Calculate start_time
-    ↓
-Calculate effectiveStartTime and X-Analytics-Coverage
     ↓
 Query timepoints and read resource_data.memory_free samples
     ↓
@@ -747,7 +706,7 @@ Do not synthesize a numeric fallback temperature for missing data.
 Do not store a placeholder in wifi_temp for a missing temperature.
 ```
 
-Migration coverage rule:
+Migration boundary rule:
 
 ```text
 Define a fixed temperature_migration_cutover_time as the deployment/migration
@@ -758,40 +717,14 @@ Ignore all earlier records because historical temperature values cannot reliably
 distinguish measured values from synthetic fallback values.
 
 If the requested range starts before temperature_migration_cutover_time:
-  effectiveStartTime = min(temperature_migration_cutover_time, endTime)
-  partial = true
-
-If startTime >= temperature_migration_cutover_time:
-  effectiveStartTime = startTime
-  partial = false
-
-effectiveEndTime = endTime
+  effective_start_time = temperature_migration_cutover_time
+else:
+  effective_start_time = startTime
 
 Do not filter out post-cutover samples only because the measured value is 20°C.
 After the cutover, a present wifi_temp value is treated as a legitimate
 measurement.
 ```
-
-When the requested range starts before temperature_migration_cutover_time, the
-API may still return `200 OK`, but the aggregate values must represent only
-`[effectiveStartTime, endTime)`. The response must include a coverage header so
-consumers can distinguish a complete-window average from a post-migration-only
-partial average.
-
-Response coverage header:
-
-```http
-X-Analytics-Coverage: {"requested_start":"2026-07-26T12:00:00Z","requested_end":"2026-07-27T12:00:00Z","effective_start":"2026-07-26T12:00:00Z","effective_end":"2026-07-27T12:00:00Z","data_available_from":"2026-07-01T00:00:00Z","partial":false}
-```
-
-Header fields must use RFC3339 UTC timestamps. `requested_start` and
-`requested_end` are the original half-open request window. `effective_start` and
-`effective_end` are the half-open window used for aggregation. `data_available_from`
-is `temperature_migration_cutover_time`. `partial` is `true` when
-`effective_start` is later than `requested_start`. If the entire requested range
-is before `temperature_migration_cutover_time`, `effective_start` and
-`effective_end` must both equal `requested_end`, the aggregate window is empty,
-and the response body uses the normal empty-result values.
 
 The current radio-band mapping is:
 
@@ -816,7 +749,7 @@ Use the current `timepoints.radio_data` JSON array:
 Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
-  timestamp >= effectiveStartTime
+  timestamp >= effective_start_time
   timestamp < endTime
 
 For each record:

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -73,11 +73,124 @@ Validation rules:
 ```text
 timestampTill must parse as a valid timestamp.
 lookbackHours must be greater than 0.
-lookbackHours should have a bounded maximum, for example 24 * 31.
+maxLookbackHours = floor(configured monitoringDuration / 3600).
+lookbackHours must be less than or equal to maxLookbackHours.
 startTime must be less than endTime.
 ```
 
-Return `400 Bad Request` for invalid timestamps, unsupported timezones, non-positive `lookbackHours`, or values above the configured maximum. Internally, query `timepoints.timestamp` and `wificlienthistory.timestamp` using epoch seconds.
+All APIs in this document derive `maxLookbackHours` from the configured `monitoringDuration` for the resolved router ownership scope. All APIs share this limit unless an endpoint section explicitly names a stricter limit. No endpoint currently defines a separate limit.
+
+For a one-year monitoring configuration, `maxLookbackHours` is `365 * 24` only when the configured monitoring duration is exactly 365 days. Do not assume every calendar year is 8760 hours; use the configured duration and effective retention timestamps when validating the request.
+
+Return `400 Bad Request` for invalid timestamps, unsupported timezones, non-positive `lookbackHours`, or values above the applicable maximum. Internally, query `timepoints.timestamp` and `wificlienthistory.timestamp` using epoch seconds.
+
+### Monitoring Configuration
+
+Handlers must load the monitoring configuration for the resolved router ownership scope before querying metric storage.
+
+```text
+monitoringDuration = configured monitoring retention duration
+retentionEnd = min(currentTime, monitoringConfigurationExpiry)
+retentionStart = retentionEnd - monitoringDuration
+
+If monitoring has been enabled for less time than monitoringDuration:
+  retentionStart = max(monitoringEnabledAt, retentionEnd - monitoringDuration)
+```
+
+Use the configured duration and effective retention timestamps instead of calendar assumptions so leap years, partial-year retention, recently enabled monitoring, and changed retention policies behave consistently.
+
+The requested half-open range must fit inside the configured retention window:
+
+```text
+startTime >= retentionStart
+endTime <= retentionEnd
+```
+
+If the requested range is outside the configured retention window, return `400 Bad Request` with `error: "lookback_outside_retention"`.
+
+When monitoring is disabled:
+
+```text
+stop ingesting new metric and availability records
+retain existing records until their existing expiry timestamp
+return 409 Conflict for all summary requests
+```
+
+Error response:
+
+```json
+{
+  "error": "monitoring_disabled",
+  "message": "Monitoring is disabled for this router scope"
+}
+```
+
+When monitoring is not configured for the resolved router scope, return:
+
+```http
+404 Not Found
+```
+
+```json
+{
+  "error": "monitoring_not_configured",
+  "message": "Monitoring is not configured for this router scope"
+}
+```
+
+### Time Window Semantics
+
+All summary APIs must use a half-open time interval:
+
+```text
+[startTime, endTime)
+
+timestamp >= startTime
+timestamp < endTime
+```
+
+`timestampTill` is the exclusive upper bound. This prevents adjacent requests from double-counting samples or events at the shared boundary.
+
+Example:
+
+```text
+Request 1: 10:00 <= timestamp < 11:00
+Request 2: 11:00 <= timestamp < 12:00
+```
+
+A sample exactly at `11:00` belongs only to Request 2.
+
+### Authorization
+
+All device metric handlers must enforce authorization before returning data:
+
+```text
+1. Authenticate the bearer token.
+   If the token is missing, invalid, or expired, return 401 Unauthorized.
+2. Resolve the caller's accessible entity, venue, and board scope from the token.
+3. Resolve routerId to its current router ownership context.
+4. Verify that the resolved router belongs to a board or venue the caller may read.
+5. Return 404 Not Found when the router exists but the caller cannot access it.
+6. Return 404 Not Found when the router does not exist.
+```
+
+Required permission:
+
+```text
+analytics.gateway_metrics.read
+```
+
+The permission is evaluated against the resolved board first, then the resolved venue, then the parent entity. Child-venue access is allowed only when the caller's venue permission explicitly includes descendant venues according to the same venue hierarchy rules used by OWPROV and `VenueCoordinator`; otherwise access is limited to the exact resolved venue or board.
+
+Authorization must not rely on the caller-supplied `routerId` alone. A caller must not be able to request an arbitrary gateway serial number and retrieve metrics without proving access to the router's current ownership scope. The external API intentionally returns `404 Not Found` for both nonexistent routers and routers outside the caller's authorized scope to avoid exposing router existence. Internal logs and metrics should preserve the exact reason.
+
+For historical availability, authorize by current router ownership before querying `device_availability_events` by `serialNumber`. The event-time `board_id` field is historical context only and must not be the sole authorization source. If current ownership cannot be resolved for a non-operator caller, do not serve serial-number-only availability history. A privileged operator-level permission may bypass current ownership resolution only if explicitly implemented and audited.
+
+Privileged operator bypass, if implemented, must use a separate permission:
+
+```text
+analytics.gateway_metrics.read_any
+```
 
 ### Current Storage Model
 
@@ -117,16 +230,21 @@ Resolution flow:
 
 ```text
 1. Validate routerId.
-2. Check the request-scoped routerId resolution cache.
-3. Resolve board ownership from the maintained routerId -> boardId map.
-4. If the map has a current entry, use it as resolvedBoardId.
-5. On cache/map miss, call OWPROV inventory with status-aware handling:
+2. Read the current VenueCoordinator ownershipVersion.
+3. Check the process-level router resolution cache.
+4. Use an unexpired positive cache entry only if its ownershipVersion matches
+   the current VenueCoordinator ownershipVersion.
+5. Resolve board ownership from the maintained routerId -> boardId map.
+6. If the map has a current entry, use it as resolvedBoardId.
+7. On cache/map miss or expired cache entry, call OWPROV inventory with status-aware handling:
      GET /api/v1/inventory/{routerId}
-6. Read inventoryTag.venue as venueId.
-7. Use the OWPROV venue result to verify or refresh board ownership.
-8. Store the resolved result in the request-scoped cache.
-9. Query Analytics storage with resolvedBoardId and serialNumber = routerId.
+8. Read inventoryTag.venue as venueId.
+9. Use the OWPROV venue result to verify or refresh board ownership.
+10. Store the resolved result in the process-level cache.
+11. Query Analytics storage with resolvedBoardId and serialNumber = routerId.
 ```
+
+Separate MCP metric calls are separate HTTP requests. They do not share an HTTP request context, so router resolution reuse across different metric endpoints must come from the maintained `VenueCoordinator` ownership map or the process-level cache, not from request-scoped state.
 
 Implementation notes:
 
@@ -157,6 +275,10 @@ If exactly one current board mapping exists:
   resolvedBoardId = mapped boardId
   return Success
 
+If multiple current board mappings exist:
+  return MultipleBoards
+  log a configuration error
+
 If no mapping exists:
   perform status-aware OWPROV inventory lookup
   read InventoryTag.venue
@@ -165,6 +287,8 @@ If no mapping exists:
 ```
 
 This mirrors the existing watcher behavior, where board devices are fetched from OWPROV with the board venue's `monitorSubVenues` setting.
+
+A router must have exactly one authoritative board mapping. Never resolve multiple candidates by list order, oldest board, most recently updated board, or direct venue preference. If multiple active mappings exist, return `409 Conflict` and log a configuration error.
 
 Refresh algorithm for cache/map misses:
 
@@ -184,9 +308,11 @@ For each local BoardInfo record that can own the inventory venue:
 If exactly one candidate exists:
   resolvedBoardId = candidate board
   update routerId -> boardId map
-```
 
-Request-scoped reuse is required. A single MCP request that asks for multiple metrics for the same router must resolve `routerId` once, then reuse the same `RouterIdResolutionResult` for all handlers in that request. For example, five MCP metric queries in one request must not repeat the full resolution process five times.
+If more than one candidate exists:
+  return MultipleBoards
+  do not choose a candidate by list order or heuristic tie-breaker
+```
 
 Failure handling:
 
@@ -194,8 +320,8 @@ Failure handling:
 OWPROV inventory not found              -> 404 Not Found
 Inventory exists but venue is empty     -> 404 Not Found
 No Analytics board configured for venue -> 404 Not Found
-Multiple matching boards                -> 409 Conflict unless deterministic ownership exists
-OWPROV unavailable or invalid response  -> 502 Bad Gateway
+Multiple matching boards                -> 409 Conflict
+OWPROV unavailable or invalid response  -> 502 Bad Gateway after cache fallback is exhausted
 ```
 
 The resolver must return a status-bearing result, not a boolean, so handlers can map each failure to the correct HTTP response.
@@ -208,6 +334,9 @@ enum class RouterIdResolutionStatus {
     EmptyVenue,
     BoardNotConfigured,
     MultipleBoards,
+    AccessDenied,
+    MonitoringNotConfigured,
+    MonitoringDisabled,
     OwprovUnavailable,
     OwprovInvalidResponse
 };
@@ -217,6 +346,8 @@ struct RouterIdResolutionResult {
     std::string routerId;
     std::string venueId;
     std::string resolvedBoardId;
+    uint64_t resolvedAt = 0;
+    uint64_t ownershipVersion = 0;
     std::string message;
 };
 ```
@@ -225,11 +356,14 @@ Status mapping:
 
 ```text
 Success               -> continue request
-InvalidRouterId   -> 400 Bad Request
+InvalidRouterId       -> 400 Bad Request
 InventoryNotFound     -> 404 Not Found
 EmptyVenue            -> 404 Not Found
 BoardNotConfigured    -> 404 Not Found
 MultipleBoards        -> 409 Conflict
+AccessDenied          -> 404 Not Found
+MonitoringNotConfigured -> 404 Not Found
+MonitoringDisabled    -> 409 Conflict
 OwprovUnavailable     -> 502 Bad Gateway
 OwprovInvalidResponse -> 502 Bad Gateway
 ```
@@ -246,7 +380,80 @@ Option B:
   directly from ResolveRouterIdContext and inspect the HTTP response status.
 ```
 
-Handlers may keep a short-lived process cache for `routerId -> venueId -> boardId`, but it is secondary to the maintained `VenueCoordinator` ownership map. Any cache must refresh or invalidate entries when OWPROV reports a different venue or when `VenueCoordinator` reports changed board membership.
+Router resolution process cache:
+
+```text
+Scope:
+  thread-safe, process-level cache shared by all REST handlers
+
+Key:
+  routerId
+
+Positive value:
+  venueId
+  boardId
+  resolvedAt
+  ownershipVersion
+
+Negative value:
+  resolution status
+  resolvedAt
+  ownershipVersion when available
+
+Positive TTL:
+  5 minutes, absolute from resolvedAt
+
+Negative TTL:
+  30 seconds or less, absolute from resolvedAt
+
+Maximum size:
+  10000 routerId entries per process
+
+Eviction:
+  expire entries by TTL first, then evict least-recently-used entries when the
+  maximum size is reached
+
+On unexpired positive cache hit:
+  return cached venueId and boardId if ownershipVersion still matches the
+  current VenueCoordinator ownershipVersion
+
+On expired entry:
+  resolve again before serving the request
+
+On OWPROV failure:
+  an unexpired positive local ownership entry may be used if ownershipVersion
+  still matches
+  an expired entry must not be extended silently
+  if no usable unexpired entry exists, return OwprovUnavailable or
+  OwprovInvalidResponse according to the failure
+
+Negative-result caching:
+  cache InventoryNotFound, EmptyVenue, BoardNotConfigured, MultipleBoards, and
+  MonitoringNotConfigured for the negative TTL
+  do not cache OwprovUnavailable or OwprovInvalidResponse as ownership facts
+
+Invalidation:
+  invalidate the routerId entry immediately when OWPROV reports a different
+  venue for the router
+  invalidate affected routerId entries when VenueCoordinator detects board
+  membership changes
+  invalidate affected routerId entries on board deletion or board venue
+  reconfiguration
+  invalidate affected routerId entries when board configuration changes
+  invalidate affected routerId entries when venue monitoring settings change
+  invalidate the routerId entry when router assignment changes
+  invalidate the routerId entry when the router is removed
+  invalidate the routerId entry when ownershipVersion changes
+
+Concurrency:
+  cache reads and writes must be synchronized
+  concurrent misses for the same routerId should coalesce to one refresh when
+  practical
+  if coalescing is not implemented, racing refreshes must not publish older
+  ownershipVersion results over newer results
+```
+
+The cache is secondary to `VenueCoordinator` ownership. A cache hit must not override a newer `VenueCoordinator` ownershipVersion.
 
 ---
 
@@ -312,10 +519,10 @@ Add raw memory fields to the device time-point model and persist them with each 
 
 ```cpp
 struct DeviceResourceTimePoint {
-    uint64_t memory_free = 0;
-    uint64_t memory_total = 0;
-    uint64_t memory_cached = 0;
-    uint64_t memory_buffered = 0;
+    std::optional<uint64_t> memory_free;
+    std::optional<uint64_t> memory_total;
+    std::optional<uint64_t> memory_cached;
+    std::optional<uint64_t> memory_buffered;
 };
 
 struct DeviceTimePoint {
@@ -350,14 +557,24 @@ src/APStats.cpp
 
 Existing rows will not have `resource_data`; treat those rows as missing memory samples rather than zero free memory.
 
+Do not represent missing memory fields as `0`. A missing `memory_free` value and a genuine reported zero must remain distinguishable.
+
 ### Ingestion Logic
 
 ```cpp
 AnalyticsObjects::DeviceResourceTimePoint resource;
-GetJSON("free", memory, resource.memory_free, uint64_t{0});
-GetJSON("total", memory, resource.memory_total, uint64_t{0});
-GetJSON("cached", memory, resource.memory_cached, uint64_t{0});
-GetJSON("buffered", memory, resource.memory_buffered, uint64_t{0});
+if (memory.has("free")) {
+    resource.memory_free = memory["free"].as<uint64_t>();
+}
+if (memory.has("total")) {
+    resource.memory_total = memory["total"].as<uint64_t>();
+}
+if (memory.has("cached")) {
+    resource.memory_cached = memory["cached"].as<uint64_t>();
+}
+if (memory.has("buffered")) {
+    resource.memory_buffered = memory["buffered"].as<uint64_t>();
+}
 DTP.resource_data = resource;
 ```
 
@@ -370,12 +587,12 @@ Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
   timestamp >= startTime
-  timestamp <= endTime
+  timestamp < endTime
 
 For each record:
   read record.resource_data.memory_free
   ignore missing resource_data
-  ignore memory_free when memory_total is 0 and the sample came from a missing memory block
+  include the sample only when memory_free is present
 
 Return:
   min_memfree = min(memory_free samples)
@@ -469,40 +686,44 @@ None
 
 ## API Logic
 
-Analytics already stores:
+Analytics should store a nullable Wi-Fi temperature value per radio:
 
 ```text
 radios[].band
-radios[].temperature
+radios[].wifi_temp
 ```
-
-Temperature samples need explicit validity handling. Current ingestion in `APStats.cpp` defaults a missing radio temperature to `20` and also rewrites a reported `0` to `20`. Those fallback values must not be treated as genuine measurements.
 
 Required ingestion rule:
 
 ```text
-If radios[].temperature is present, non-null, and accepted as a measured value:
-  store the measured temperature
-  store temperature_valid = true
+If the source radio temperature is present and non-null:
+  store radios[].wifi_temp = source temperature
 
-If radios[].temperature is missing, null, or rejected as invalid:
-  keep temperature missing/null
-  store temperature_valid = false
+If the source radio temperature is missing or null:
+  omit radios[].wifi_temp or store radios[].wifi_temp = null
 
 Do not synthesize a numeric fallback temperature for missing data.
-Do not store 20, 0, or any other placeholder for a missing temperature.
-For all newly ingested records, temperature_valid must be present.
+Do not store a placeholder in wifi_temp for a missing temperature.
 ```
 
-Historical data rule:
+Migration boundary rule:
 
 ```text
-Existing stored temperature == 20 is ambiguous because it may be either:
-  a genuine measured 20, or
-  the synthetic fallback for missing/zero input
+Define a fixed temperature_migration_cutover_time as the deployment/migration
+timestamp where radios[].wifi_temp starts being written consistently.
 
-Unless a migration can prove the value came from a real measured source, do not use
-historical 20 values in min/max/average temperature summaries.
+Only use temperature records created at or after temperature_migration_cutover_time.
+Ignore all earlier records because historical temperature values cannot reliably
+distinguish measured values from synthetic fallback values.
+
+If the requested range starts before temperature_migration_cutover_time:
+  effective_start_time = temperature_migration_cutover_time
+else:
+  effective_start_time = startTime
+
+Do not filter out post-cutover samples only because the measured value is 20°C.
+After the cutover, a present wifi_temp value is treated as a legitimate
+measurement.
 ```
 
 The current radio-band mapping is:
@@ -528,15 +749,15 @@ Use the current `timepoints.radio_data` JSON array:
 Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
-  timestamp >= startTime
-  timestamp <= endTime
+  timestamp >= effective_start_time
+  timestamp < endTime
 
 For each record:
   parse radio_data
   for each radio in radio_data:
     if radio.band is 2 or 5:
-      if radio.temperature_valid is true and radio.temperature is present:
-        add radio.temperature to that band's sample list
+      if radio.wifi_temp is present and non-null:
+        add radio.wifi_temp to that band's sample list
 
 For each band:
   min_temperature = min(samples)
@@ -547,13 +768,8 @@ For each band:
 A valid temperature sample is:
 
 ```text
-New records:
-  temperature is present and non-null
-  and temperature_valid == true
-
-Historical records from the current ingestion behavior:
-  temperature is present
-  and temperature != 20
+record timestamp is at or after temperature_migration_cutover_time
+radio.wifi_temp is present and non-null
 ```
 
 If all samples for a band are invalid or missing, return `null` for that band's min, max, and average fields.
@@ -630,15 +846,25 @@ None
 [
   {
     "mac": "e2:51:95:ed:0f:28",
+    "rx_bytes": 106487500,
+    "tx_bytes": 3851250,
+    "total_bytes": 110338750,
     "data_consume_rx": "851.9 Mb",
     "data_consume_tx": "30.81 Mb",
-    "total_data_usage": "882.71 Mb"
+    "total_data_usage": "882.71 Mb",
+    "usage_accuracy": "exact",
+    "incomplete": false
   },
   {
     "mac": "28:39:26:a1:7c:a5",
+    "rx_bytes": 30071250,
+    "tx_bytes": 16486250,
+    "total_bytes": 46557500,
     "data_consume_rx": "240.57 Mb",
     "data_consume_tx": "131.89 Mb",
-    "total_data_usage": "372.46 Mb"
+    "total_data_usage": "372.46 Mb",
+    "usage_accuracy": "lower_bound",
+    "incomplete": true
   }
 ]
 ```
@@ -687,34 +913,82 @@ baseline = last sample before start_time for the same stream_key, if available
 first in-window delta:
   if baseline exists:
     counterDelta(first.rx_bytes, baseline.rx_bytes)
+    counterDelta(first.tx_bytes, baseline.tx_bytes)
+  else if this is a confirmed new association/session that began within the window:
+    first.rx_bytes
+    first.tx_bytes
   else:
     0
 
 subsequent deltas:
   counterDelta(current.rx_bytes, previous.rx_bytes)
+  counterDelta(current.tx_bytes, previous.tx_bytes)
 
 data_consume_rx = SUM(reset-safe rx_bytes deltas)
 data_consume_tx = SUM(reset-safe tx_bytes deltas)
 total_data_usage = data_consume_rx + data_consume_tx
+
+usage_accuracy = exact when no contributing stream is incomplete, otherwise lower_bound
+incomplete = true when usage_accuracy is lower_bound
 ```
 
-Calculate counter deltas per `stream_key`. After stream-level deltas are calculated, aggregate the resulting RX/TX deltas by station MAC for the response.
+Calculate counter deltas independently for RX and TX per `stream_key`. After stream-level deltas are calculated, aggregate the resulting RX/TX deltas by station MAC for the response. If any stream contributing to a station MAC is incomplete/estimated, that station's usage is incomplete/estimated.
+
+Usage accuracy contract:
+
+```text
+Returned usage is exact only when every stream has enough information to account
+for the requested window:
+  a pre-window baseline exists for an ongoing stream, or
+  the stream is confirmed to have begun within the requested window, or
+  any counter rollover is confirmed and handled with rollover arithmetic.
+
+When a stream lacks a pre-window baseline, has no reliable session/association
+start, or has an ambiguous counter decrease, the returned usage is a lower-bound
+estimate. The algorithm must avoid overcounting unknown traffic, so it adds zero
+for ambiguous intervals and treats the result as incomplete/estimated.
+
+The response must expose `usage_accuracy` per client:
+  exact: all contributing streams are fully accounted for
+  lower_bound: at least one contributing stream used a conservative zero delta
+    for an ambiguous interval or missing baseline
+
+When `usage_accuracy` is `lower_bound`, the reported byte and formatted usage
+values are the safely observed minimum. Actual usage may be higher.
+```
+
+A fixed-width rollover is confirmed only when the counter width is known for that source and the observed decrease is consistent with a rollover for that counter. If the counter width is unknown, or the decrease could also be a reset/reconnect/stale sample, treat it as ambiguous.
 
 ### Reset-Safe Delta Logic
 
 ```cpp
-uint64_t counterDelta(uint64_t current, uint64_t previous,
-                      bool confirmedFixedWidthRollover,
-                      uint64_t counterMax) {
+struct CounterDeltaResult {
+    uint64_t delta;
+    bool incomplete;
+};
+
+CounterDeltaResult counterDelta(uint64_t current,
+                                uint64_t previous,
+                                bool confirmedNewSession,
+                                bool newSessionStartedInWindow,
+                                bool confirmedFixedWidthRollover,
+                                uint64_t counterMax) {
     if (current >= previous) {
-        return current - previous;
+        return {current - previous, false};
+    }
+
+    if (confirmedNewSession) {
+        if (newSessionStartedInWindow) {
+            return {current, false};
+        }
+        return {0, true};
     }
 
     if (confirmedFixedWidthRollover) {
-        return (counterMax - previous) + current + 1;
+        return {(counterMax - previous) + current + 1, false};
     }
 
-    return 0;
+    return {0, true};
 }
 ```
 
@@ -745,13 +1019,46 @@ When no session identifier is available:
   but use BSSID/SSID/band/radio changes as stream boundaries when possible.
 
 If current < previous:
-  if fixed-width rollover is known and can be confirmed:
+  if a new association/session is confirmed:
+    if the new session start time is within [startTime, endTime):
+      add current as post-session-start traffic
+    else:
+      treat current as the new baseline, add delta 0, and mark the result
+      incomplete/estimated
+  else if fixed-width rollover is known and can be confirmed:
     apply rollover math
   else:
-    treat current as the new baseline and add delta 0
+    treat current as the new baseline, add delta 0, and mark the result
+    incomplete/estimated
 ```
 
-Without the pre-window baseline for the same calculated stream, the first sample inside the requested window can include traffic that occurred before `start_time`. Do not add the first in-window cumulative counter directly unless it is known to be a fresh association/reset for that same stream.
+Without the pre-window baseline for the same calculated stream, the first sample inside the requested window can include traffic that occurred before `start_time`. Do not add the first in-window cumulative counter directly unless it is known to be a fresh association/session that started inside the requested window. If the stream may have started before `start_time`, add zero for the first sample and mark the result incomplete/estimated.
+
+A new association/session is confirmed only when the source provides reliable session identity or timing evidence. For example, a session id change, association id change, or connected-duration reset may prove a new session if it also proves the session start time is within the requested window. BSSID, SSID, band, or radio changes define separate calculation streams, but they do not by themselves prove that the new cumulative counter started inside the requested window.
+
+Example:
+
+```text
+10:00 rx_bytes = 1000
+10:05 rx_bytes = 1500
+10:10 rx_bytes = 200
+
+Delta 10:00 -> 10:05 = 500
+
+If 10:10 is a confirmed new session that started inside the request window:
+  add 200
+  total rx_bytes = 700
+  usage_accuracy = exact, unless another stream is incomplete
+
+If 10:10 is an ambiguous decrease:
+  add 0
+  total rx_bytes = 500
+  usage_accuracy = lower_bound
+
+If previous = 9900, current = 100, counterMax = 9999, and rollover is confirmed:
+  delta = (9999 - 9900) + 100 + 1
+  delta = 200
+```
 
 ### Incorrect Calculation
 
@@ -801,7 +1108,7 @@ Resolve boardId from routerId
     ↓
 Load TimePointDB records for resolvedBoardId and stored serialNumber == request routerId
     ↓
-Include records from startTime through endTime
+Include records from startTime up to but not including endTime
     ↓
 Also load the latest pre-window association sample for each calculated stream_key
     ↓
@@ -939,7 +1246,7 @@ Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
   timestamp >= startTime
-  timestamp <= endTime
+  timestamp < endTime
 
 For each record:
   parse ssid_data
@@ -1155,7 +1462,7 @@ src/StorageService.cpp
   include availability retention cleanup if retention should match board timepoint cleanup
 ```
 
-Add a DB upgrade/migration path for the new table. Existing deployments will start with no historical availability events; the API should return `offline_count: 0` for successful empty queries, not infer old events from `lastDisconnection`.
+Add a DB upgrade/migration path for the new table. Existing deployments will start with no historical availability events. Define a fixed `availabilityValidFrom` timestamp as the deployment/migration time when availability-event persistence starts. The API should return `offline_count: 0` only for successful empty queries whose requested range starts at or after `availabilityValidFrom`; do not infer old events from `lastDisconnection`.
 
 Add the files to `CMakeLists.txt`.
 
@@ -1414,6 +1721,24 @@ offline_count =
     COUNT(event_type = 'offline')
 ```
 
+Availability migration boundary:
+
+```text
+availabilityValidFrom = deployment timestamp when device_availability_events
+persistence became active
+
+If startTime < availabilityValidFrom:
+  reject the request
+  do not query device_availability_events
+  do not return offline_count: 0
+
+If startTime >= availabilityValidFrom:
+  query device_availability_events normally
+```
+
+Rejecting pre-cutover ranges prevents a successful zero response from meaning either
+"no outages occurred" or "Analytics was not collecting availability events yet."
+
 ### Query
 
 ```sql
@@ -1422,10 +1747,25 @@ FROM device_availability_events
 WHERE serialNumber = :router_id
   AND event_type = 'offline'
   AND event_time >= :start_time
-  AND event_time <= :end_time;
+  AND event_time < :end_time;
 ```
 
 Do not require `board_id = :resolvedBoardId` for the availability count. `board_id` is nullable event-time context and can differ from the router's current board after reassignment. The durable query identity for gateway availability history is `serialNumber`.
+
+### Range Before Availability Cutover
+
+Use an HTTP error:
+
+```http
+400 Bad Request
+```
+
+```json
+{
+  "error": "availability_range_before_cutover",
+  "message": "Availability history is only available for ranges starting at or after availabilityValidFrom"
+}
+```
 
 ### Success Response with No Offline Events
 
@@ -1503,7 +1843,7 @@ struct ClientRssiQuality;
 struct GatewayOfflineSummary;
 ```
 
-JSON field names should match the MCP CSV exactly.
+JSON field names should match the MCP CSV where the API is directly returning MCP fields. `usage-summary` additionally returns raw byte totals and usage accuracy fields so callers can distinguish exact usage from lower-bound estimates.
 
 ---
 
@@ -1551,9 +1891,9 @@ usage-summary
 rssi-summary
 ```
 
-The helper must use the current `routerId -> boardId` map maintained by `VenueCoordinator` as the primary ownership source. OWPROV inventory lookup must be status-aware and is used to verify or refresh ownership on cache/map misses. Any refresh path must read `InventoryTag.venue` and resolve board ownership with `monitorSubVenues` support, using candidate board device lists through `SDK::Prov::Venue::GetDevices(..., VenueInfo.monitorSubVenues, ...)` when needed. A single MCP request must reuse one `RouterIdResolutionResult` for repeated metrics targeting the same `routerId`.
+The helper must use the current `routerId -> boardId` map maintained by `VenueCoordinator` as the primary ownership source. OWPROV inventory lookup must be status-aware and is used to verify or refresh ownership on cache/map misses. Any refresh path must read `InventoryTag.venue` and resolve board ownership with `monitorSubVenues` support, using candidate board device lists through `SDK::Prov::Venue::GetDevices(..., VenueInfo.monitorSubVenues, ...)` when needed.
 
-`availability-summary` is the exception. It must validate `routerId` and authorization, but it must not require successful current `resolvedBoardId` resolution before reading availability storage. Request-time resolution may be used only for current context or authorization hints. The historical count must query availability storage by durable `serialNumber`, not by mandatory current `resolvedBoardId`.
+`availability-summary` is the storage-query exception, not an authorization exception. It must authenticate the caller, resolve current router ownership, and verify the caller has `analytics.gateway_metrics.read` on the resolved board, venue, or parent entity before querying availability storage. After authorization succeeds, the historical count must query availability storage by durable `serialNumber`, not by mandatory current `resolvedBoardId`. Event-time `board_id` is historical context only and must not authorize the request by itself.
 
 ---
 
@@ -1631,7 +1971,7 @@ bool GetGatewayAvailabilitySummary(...);
 | MCP Tool | Analytics API | Data Source | Implementation Status |
 |---|---|---|---|
 | `get_gateway_free_memory` | `GET /devices/{routerId}/memory-summary` | `timepoints.resource_data.memory_free` | Resolve routerId to venueId and boardId, then aggregate `timepoints` |
-| `get_gateway_wifi_temp` | `GET /devices/{routerId}/radio-temperature-summary` | `timepoints.radio_data[].temperature` | Resolve routerId to venueId and boardId, then aggregate `timepoints` |
+| `get_gateway_wifi_temp` | `GET /devices/{routerId}/radio-temperature-summary` | `timepoints.radio_data[].wifi_temp` | Resolve routerId to venueId and boardId, then aggregate present Wi-Fi temperature samples from `timepoints` |
 | `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then reset-safe delta aggregation with pre-window baseline |
 | `get_device_rssi_quality` | `GET /devices/{routerId}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve routerId to venueId and boardId, then classify RSSI samples |
 | `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic plus `device_availability_events` | Use routerId as durable serialNumber, persist restart-safe state transitions, then count offline events by serialNumber |

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -8,6 +8,11 @@ This document defines the request format, response format, and implementation lo
 - `get_device_rssi_quality`
 - `get_gateway_offline_count`
 
+The specification is structured across three distinct component layers:
+1. **Public API Contract Specifications**: External OpenAPI schemas (`openapi/owanalytics.yaml`) defining HTTP requests, parameter validation, and response envelopes.
+2. **Persistence & Pipeline Architecture Design**: Internal storage structures (`device_availability_events`, `device_availability_state`), Kafka event consumption/ordering, and cutover semantics.
+3. **Test Specifications Matrix**: Independent verification matrix documented in `analytics_mcp_api_test_cases.md`.
+
 The API contracts match the MCP tool names and response fields from the provided CSV.
 
 ---
@@ -32,7 +37,7 @@ Internal storage field: serialNumber
 serialNumber = routerId
 ```
 
-Public `routerId` validation should require the supported OWPROV gateway serial form: 12 to 29 hexadecimal characters, for example `dc6279652334`. This intentionally rejects path dot-segments such as `.` and `..`, path separators, UUID punctuation, and punctuation-only values before OWPROV ownership resolution. After syntax validation, OWPROV ownership resolution determines whether the serial exists and belongs to the caller's scope.
+Public `routerId` validation requires a path-safe string: 1 to 64 alphanumeric characters, hyphens, or underscores (matching `^[a-zA-Z0-9_-]+$`). Syntax validation intentionally rejects path dot-segments such as `.` and `..`, path separators (`/`, `\`), spaces, control characters, and URL-encoded path separators (`%2F`) before OWPROV ownership resolution. Any path-safe serial format (whether hexadecimal or non-hex serial string) passes syntax validation and is sent to OWPROV, letting OWPROV serve as the authoritative entity for verifying serial existence.
 
 The Analytics API should calculate the requested time range as:
 
@@ -1253,7 +1258,7 @@ Example detailed response for the same calculated result:
 }
 ```
 
-When a client is observed but no usage interval can be calculated, such as when
+When a client is observed in-window (`[startTime, endTime)`) but no usage interval can be calculated, such as when
 only one cumulative-counter sample exists in or bounding the requested range,
 return the safely provable minimum with no calculation segments:
 
@@ -1444,9 +1449,7 @@ returned usage is a lower-bound estimate. The algorithm must avoid overcounting
 unknown traffic, so it adds only safely provable nonnegative consecutive segment
 deltas inside the requested range and treats the result as incomplete/estimated.
 If no positive interval can be safely proven, return 0 bytes for that stream with
-`lower_bound`. Include a client in the response when it has at least one
-qualifying sample in or bounding the requested interval, even if the safely
-provable lower-bound delta is 0. If no differential segment can be calculated
+`lower_bound`. Include a client in `items[]` and count it in `totalClients` only when it has at least one in-window observation (`[startTime, endTime)`) or proven session overlap during the requested interval, even if the safely provable lower-bound delta is 0. Outside-window bounding samples (e.g. pre-window baseline or post-window fallback samples) are used exclusively as boundary calculation aids for clients that have proven in-window presence or session overlap. A station MAC with only outside-window samples and no in-window observation or session overlap during `[startTime, endTime)` must be excluded from `items[]` and `totalClients`. If no differential segment can be calculated
 for that client, return `segment_count: 0` and `boundary_fallback_used: false`;
 do not create a segment with fabricated effective or actual boundary timestamps.
 If details are enabled, return `calculation_segments: []` for that client.
@@ -1649,6 +1652,8 @@ Formatting:
 ```cpp
 fmt::format("{:.2f} MB", value);
 ```
+
+This uses standard floating point formatting semantics (formatting two decimal places with the `" MB"` suffix) rather than tying calculations to a custom round-half-up implementation.
 
 ### Query Flow
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -1466,10 +1466,10 @@ Usage accuracy contract:
 
 ```text
 Returned usage is exact only when every contributing calculation segment has
-authoritative effective-boundary evidence:
+authoritative boundary evidence matching effective boundaries exactly:
   effective_start = max(requested_start, proven_session_start), and
   effective_end = min(requested_end, proven_session_end), and
-  authoritative counter evidence exists at effective_start and effective_end,
+  actual_start_time == effective_start and actual_end_time == effective_end,
   and every counter reset, rollover, or session transition is unambiguously proven
   and accounted for using independent segment differentials or verified rollover arithmetic.
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -1274,6 +1274,8 @@ return the safely provable minimum with no calculation segments:
       "total_data_usage": "0.00 MB",
       "usage_accuracy": "lower_bound",
       "incomplete": true,
+      "segment_count": 0,
+      "boundary_fallback_used": false,
       "calculation_segments": []
     }
   ],
@@ -1370,10 +1372,13 @@ samples between start_sample and end_sample:
   do not sum raw cumulative values as usage
   do sum proven segment deltas when resets or session splits are confirmed
 
-data_consume_rx = SUM(stream rx_bytes segment differentials or lower-bound deltas)
-data_consume_tx = SUM(stream tx_bytes segment differentials or lower-bound deltas)
-total_data_usage = data_consume_rx + data_consume_tx
+rx_bytes    = SUM(stream rx_bytes segment differentials or lower-bound deltas)
+tx_bytes    = SUM(stream tx_bytes segment differentials or lower-bound deltas)
 total_bytes = rx_bytes + tx_bytes
+
+data_consume_rx  = format_bytes(rx_bytes)
+data_consume_tx  = format_bytes(tx_bytes)
+total_data_usage = format_bytes(total_bytes)
 
 stream accuracy =
   exact when the segment has authoritative counter evidence at effective_start
@@ -2012,13 +2017,13 @@ Indexes:
   availability_serial_time_index:
     serialNumber ASC
     event_time ASC
-    source_sequence ASC
+    source_sequence ASC NULLS FIRST
 
   availability_board_serial_time_index:
     board_id ASC
     serialNumber ASC
     event_time ASC
-    source_sequence ASC
+    source_sequence ASC NULLS FIRST
 
 Unique constraints:
   availability_idempotency_key_unique:
@@ -2027,6 +2032,14 @@ Unique constraints:
 Optional indexes:
   availability_event_id_index:
     event_id ASC
+```
+
+SQL composite ordering semantics:
+
+```text
+When querying device_availability_events by (event_time, source_sequence):
+- Ascending queries use ORDER BY event_time ASC, source_sequence ASC NULLS FIRST so unsequenced events (source_sequence = NULL) at a timestamp sort before sequenced events at the same timestamp.
+- Descending queries use ORDER BY event_time DESC, source_sequence DESC NULLS LAST so the event with the highest sequence number at a timestamp sorts first, and unsequenced events sort last.
 ```
 
 `event_id` stores the normalized source event id when the payload provides one, using `payload.ping.uuid`, `payload.uuid`, or `payload.disconnection.uuid` only when that `uuid` is stable for the same logical source event.
@@ -2696,11 +2709,20 @@ Use an HTTP error:
 An exact zero is valid only when availability coverage proves the complete requested interval up to `endTime`: `coverageStart <= startTime`, `processedThrough >= endTime`, `ingestionGapKnown = false`, and `proofSource != "unavailable"`. When `processedThrough < endTime` (even if `processedThrough >= endTime - allowedIngestionDelaySeconds`), the requested interval is not fully covered up to `endTime` and a zero matching event count must be reported as partial/lower-bound (`meta.coverage = "partial"`), or as unavailable with `offline_count: null` when no coverage proof exists.
 
 For the availability endpoint, `sampleCount` is retained for response-shape
-consistency with the other summary APIs and means the number of offline
-transition rows contributing to `offline_count`. `offlineEventCount` is the
-availability-specific alias for the same value. Online transition rows may
-contribute to `observedWindow` and `sourceWindow`, but they do not contribute to
-`sampleCount`, `offlineEventCount`, or `offline_count`.
+consistency with the other summary APIs. When `meta.coverage` is `"full"` or `"partial"`, `sampleCount` is defined as:
+
+```text
+sampleCount = offlineEventCount = offline_count
+```
+
+`sampleCount` is the number of offline transition rows in `device_availability_events`
+contributing to `offline_count`. Online recovery transition rows (`event_type = 'online'`)
+are stored in transition history for state tracking and `observedWindow` / `sourceWindow`
+bounds, but they do not contribute to `sampleCount`, `offlineEventCount`, or `offline_count`.
+For `"full"` or `"partial"` coverage, `sampleCount` always equals `offlineEventCount`.
+
+When `meta.coverage = "none"` and `meta.accuracy = "not_applicable"`, `sampleCount`, `offlineEventCount`,
+and `offline_count` are all `null`.
 
 `boundarySamplesUsed.beforeStart` is `true` only when a pre-start boundary event
 was actually selected. Event counting does not require a pre-start boundary

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -64,11 +64,13 @@ All REST handlers must enforce request validation in three distinct sequential p
    - Resolve `routerId` to `boardId` via local cache / OWPROV -> HTTP `404 not_found` if router serial does not exist in OWPROV.
    - Load router scope monitoring configuration (`monitoringDuration`) to derive `maxLookbackHours = floor(monitoringDuration / 3600)`.
 
-3. **Phase 3: Duration, Retention & Domain Cutover Validation**
-   - Validate duration against scope maximum: `lookbackHours > maxLookbackHours` -> HTTP `400 invalid_lookback_hours`.
-   - Validate requested range against data retention window: requested window outside retention -> HTTP `400 lookback_outside_retention`.
-   - Validate `start_time` against temperature cutover threshold (`start_time < temperatureMigrationCutoverTime`) -> HTTP `400 temperature_range_before_cutover`.
-   - Validate `start_time` against availability cutover threshold (`start_time < availabilityValidFrom`) -> HTTP `400 availability_range_before_cutover`.
+3. **Phase 3: Duration, Retention & Endpoint Cutover Validation**
+   - Validate duration against scope maximum (all endpoints): `lookbackHours > maxLookbackHours` -> HTTP `400 invalid_lookback_hours`.
+   - Validate requested range against data retention window (all endpoints): requested window outside retention -> HTTP `400 lookback_outside_retention`.
+   - Validate endpoint-specific domain cutover thresholds:
+     - `radio-temperature-summary` endpoint only: `start_time < temperatureMigrationCutoverTime` -> HTTP `400 temperature_range_before_cutover`.
+     - `availability-summary` endpoint only: `start_time < availabilityValidFrom` -> HTTP `400 availability_range_before_cutover`.
+     - `memory-summary`, `rssi-summary`, and `bandwidth-consumption` endpoints: no domain cutover validation unless explicitly defined by that endpoint.
 
 Example:
 
@@ -1463,13 +1465,13 @@ Client MAC values in API responses must be normalized canonical lowercase colon-
 Usage accuracy contract:
 
 ```text
-Returned usage is exact only when every contributing segment has enough
-information to account for its overlap with the requested window:
+Returned usage is exact only when every contributing calculation segment has
+authoritative effective-boundary evidence:
   effective_start = max(requested_start, proven_session_start), and
   effective_end = min(requested_end, proven_session_end), and
-  authoritative counter evidence exists exactly at effective_start and
-  effective_end, and any counter rollover is confirmed and handled with
-  rollover arithmetic.
+  authoritative counter evidence exists at effective_start and effective_end,
+  and every counter reset, rollover, or session transition is unambiguously proven
+  and accounted for using independent segment differentials or verified rollover arithmetic.
 
 Returned usage is bounded_interval when exact boundary samples are unavailable but
 the latest available starting sample at or before `effective_start` and the
@@ -2786,7 +2788,7 @@ Use an HTTP error:
 }
 ```
 
-An exact zero is valid only when availability coverage proves the complete requested interval up to `endTime`: `coverageStart <= startTime`, `processedThrough >= endTime`, `ingestionGapKnown = false`, and `proofSource != "unavailable"`. When `processedThrough < endTime` (even if `processedThrough >= endTime - allowedIngestionDelaySeconds`), the requested interval is not fully covered up to `endTime` and a zero matching event count must be reported as partial/lower-bound (`meta.coverage = "partial"`), or as unavailable with `offline_count: null` when no coverage proof exists.
+An exact zero is valid only when availability coverage proves the complete requested interval up to `endTime`: `coverageStart <= startTime`, `stateKnownFrom <= startTime`, `processedThrough >= endTime`, `ingestionGapKnown = false`, and `proofSource != "unavailable"`. When `processedThrough < endTime` (even if `processedThrough >= endTime - allowedIngestionDelaySeconds`), the requested interval is not fully covered up to `endTime` and a zero matching event count must be reported as partial/lower-bound (`meta.coverage = "partial"`), or as unavailable with `offline_count: null` when no coverage proof exists.
 
 For the availability endpoint, `sampleCount` is retained for response-shape
 consistency with the other summary APIs. When `meta.coverage` is `"full"` or `"partial"`, `sampleCount` is defined as:

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -1217,6 +1217,40 @@ Example detailed response for the same calculated result:
 }
 ```
 
+When a client is observed but no usage interval can be calculated, such as when
+only one cumulative-counter sample exists in or bounding the requested range,
+return the safely provable minimum with no calculation segments:
+
+```json
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-08-05T12:00:00Z",
+    "endTime": "2026-08-05T13:00:00Z"
+  },
+  "resultTimeWindow": {
+    "earliestActualStartTime": null,
+    "latestActualEndTime": null,
+    "boundaryFallbackUsed": false
+  },
+  "items": [
+    {
+      "mac": "e2:51:95:ed:0f:28",
+      "rx_bytes": 0,
+      "tx_bytes": 0,
+      "total_bytes": 0,
+      "data_consume_rx": "0.00 MB",
+      "data_consume_tx": "0.00 MB",
+      "total_data_usage": "0.00 MB",
+      "usage_accuracy": "lower_bound",
+      "incomplete": true,
+      "calculation_segments": []
+    }
+  ],
+  "totalClients": 1,
+  "truncated": false
+}
+```
+
 ## API Logic
 
 For gateway-scoped results, use `timepoints.ssid_data[].associations[]` because `wificlienthistory` currently does not store the gateway `serialNumber`.

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -32,6 +32,8 @@ Internal storage field: serialNumber
 serialNumber = routerId
 ```
 
+Public `routerId` validation should require the supported OWPROV gateway serial form: 12 to 29 hexadecimal characters, for example `dc6279652334`. This intentionally rejects path dot-segments such as `.` and `..`, path separators, UUID punctuation, and punctuation-only values before OWPROV ownership resolution. After syntax validation, OWPROV ownership resolution determines whether the serial exists and belongs to the caller's scope.
+
 The Analytics API should calculate the requested time range as:
 
 ```text
@@ -112,18 +114,21 @@ per-segment actual sample timestamps are included only when
 
 ### Time Conversion and Validation
 
-The public MCP-facing parameters use ISO-8601/RFC3339 time, but the existing Analytics API style uses integer `fromDate` and `endDate` timestamps. Handlers should convert the request as:
+The public MCP-facing parameters use ISO-8601/RFC3339 UTC time, but the existing Analytics API style uses integer `fromDate` and `endDate` timestamps. Handlers should convert the request as:
 
 ```text
-timestampTill: RFC3339 UTC string, for example 2026-07-27T12:00:00Z
+timestampTill: RFC3339 UTC string ending with 'Z', for example 2026-07-27T12:00:00Z
 endTime:       Unix epoch seconds parsed from timestampTill
 startTime:     endTime - (lookbackHours * 3600)
 ```
 
+Timezone Requirement:
+`timestampTill` MUST use the UTC `Z` suffix format (e.g., `2026-07-27T12:00:00Z`). Explicit numeric timezone offsets (such as `+05:30` or `-08:00`) and timestamps without a timezone designator are unsupported and MUST be rejected with `400 Bad Request` and `error: "invalid_timestamp"`.
+
 Validation rules:
 
 ```text
-timestampTill must parse as a valid timestamp.
+timestampTill must parse as a valid UTC timestamp ending with 'Z'.
 lookbackHours must be greater than 0.
 maxLookbackHours = floor(configured monitoringDuration / 3600).
 lookbackHours must be less than or equal to maxLookbackHours.
@@ -134,7 +139,7 @@ All APIs in this document derive `maxLookbackHours` from the configured `monitor
 
 For a one-year monitoring configuration, `maxLookbackHours` is `365 * 24` only when the configured monitoring duration is exactly 365 days. Do not assume every calendar year is 8760 hours; use the configured duration and effective retention timestamps when validating the request.
 
-Return `400 Bad Request` for invalid timestamps, unsupported timezones, non-positive `lookbackHours`, or values above the applicable maximum. Internally, query `timepoints.timestamp` and `wificlienthistory.timestamp` using epoch seconds.
+Return `400 Bad Request` with `error: "invalid_timestamp"` for invalid timestamps, unsupported timezone formats/offsets, non-positive `lookbackHours`, or values above the applicable maximum. Internally, query `timepoints.timestamp` and `wificlienthistory.timestamp` using epoch seconds.
 
 ### Monitoring Configuration
 
@@ -681,6 +686,12 @@ Return:
   avg_memfree = sum(memory_free samples) / sample_count
 ```
 
+Memory values are bytes and must be nonnegative. For successful responses with samples, the invariant is:
+
+```text
+min_memfree <= avg_memfree <= max_memfree
+```
+
 Do not query `device_timepoints.memory_free` unless a separate normalized table and migration are introduced.
 
 ### Handler Flow
@@ -773,6 +784,8 @@ Analytics should store a nullable Wi-Fi temperature value per radio:
 radios[].band
 radios[].wifi_temp
 ```
+
+`radios[].wifi_temp` and all `*_wifi_temp_*` response fields use degrees Celsius.
 
 Required ingestion rule:
 
@@ -1346,6 +1359,7 @@ samples between start_sample and end_sample:
 data_consume_rx = SUM(stream rx_bytes segment differentials or lower-bound deltas)
 data_consume_tx = SUM(stream tx_bytes segment differentials or lower-bound deltas)
 total_data_usage = data_consume_rx + data_consume_tx
+total_bytes = rx_bytes + tx_bytes
 
 stream accuracy =
   exact when the segment has authoritative counter evidence at effective_start
@@ -1374,6 +1388,8 @@ segment objects. When `includeCalculationDetails=true`, the detailed
 `calculation_segments[]` array must satisfy the same byte-sum invariants. If
 any segment contributing to a station MAC is lower_bound, that station's usage
 is lower_bound.
+
+Client MAC values in API responses must be normalized colon-separated MAC addresses matching `^[A-Fa-f0-9]{2}(:[A-Fa-f0-9]{2}){5}$`.
 
 Usage accuracy contract:
 
@@ -1579,7 +1595,7 @@ A client moving between BSSIDs should remain one client in the final response un
 
 ### Unit Conversion
 
-The MCP output expects strings such as:
+The API returns raw byte counters plus display-only strings such as:
 
 ```text
 106.49 MB
@@ -1786,6 +1802,8 @@ poor_pct      = poor_count × 100 / total_samples
 
 Round percentages to two decimal places.
 
+The four percentage fields are constrained to `0 <= value <= 100`. Because each percentage is independently rounded to two decimal places, the four values may sum to slightly below or above exactly `100`.
+
 ### Current Storage Aggregation Logic
 
 ```text
@@ -1906,8 +1924,6 @@ Add a dedicated storage class for availability events:
 ```text
 src/storage/storage_device_availability_events.h
 src/storage/storage_device_availability_events.cpp
-src/storage/storage_device_availability_state.h
-src/storage/storage_device_availability_state.cpp
 ```
 
 Required ORM fields and indexes:
@@ -1983,6 +1999,10 @@ Constraints:
   current_state must be one of: online, offline, unknown
 ```
 
+`device_availability_events` stores only online/offline transition history. `device_availability_state` stores the authoritative current state and the latest accepted source availability event time.
+
+`last_event_time` is the source-event ordering watermark. It must be populated from the normalized Kafka source timestamp (`event_time`) and used for stale/out-of-order detection. `DeviceInfo.lastContact` may remain local contact or processing metadata, but it must not be used to order source events because Kafka delivery can be delayed.
+
 Add a `DeviceAvailabilityEvent` REST/storage object with `to_json` and `from_json` support in:
 
 ```text
@@ -2049,23 +2069,28 @@ On ping/capabilities:
 Do not store online events for every ping.
 ```
 
-Bootstrap rule when no persisted state exists:
+Bootstrap rule when no `device_availability_state` row exists:
 
 ```text
 First observed disconnection:
   insert one offline event
-  set current_state = offline
+  insert state row with current_state = offline
+  set last_event_time = event_time
+  set last_idempotency_key = idempotency_key
 
 First observed ping/capabilities:
-  set current_state = online
-  do not insert an online event
+  insert state row with current_state = online
+  set last_event_time = event_time
+  set last_idempotency_key = idempotency_key
+  do not insert an online transition event
 
 First observed unrecognized connection message:
-  set current_state = unknown
+  insert or update state row with current_state = unknown only when useful
+  set last_event_time only from a valid source timestamp
   do not insert a counted event
 ```
 
-In-memory transition checking is only an optimization. It is not sufficient for correctness because Kafka can redeliver messages and the service can restart after losing in-memory state. Transition detection must use `device_availability_state` or derive the latest known state from `device_availability_events` under the same transaction before writing. Duplicate connection messages must be rejected by storage-level idempotency before they can affect `offline_count`.
+In-memory transition checking is only an optimization. It is not sufficient for correctness because Kafka can redeliver messages and the service can restart after losing in-memory state. Transition detection must use `device_availability_state.current_state` and `device_availability_state.last_event_time` under the same transaction before writing `device_availability_events`. Duplicate connection messages must be rejected by source timestamp validation and storage-level idempotency before they can affect `offline_count`.
 
 Normalize connection messages before transition processing:
 
@@ -2138,6 +2163,20 @@ Else:
 
 Treat `uuid` as a source event id only if it is stable for the same logical connection message across Kafka redelivery and unique within the source namespace identified by `system.host` and `system.id`. If `uuid` is only a random per-delivery value, do not use it as `source_event_id`.
 
+Example for exact Kafka redelivery protection, after verifying that `payload.ping.uuid` remains stable for the same logical redelivered message:
+
+```text
+hash(
+  system.host +
+  system.id +
+  serialNumber +
+  message_type +
+  payload.ping.uuid
+)
+```
+
+Do not use `system.id` alone as the logical event id; it identifies the producing system, not one individual ping.
+
 Minimum fields for derived idempotency keys:
 
 ```text
@@ -2178,48 +2217,75 @@ Atomic transition and insert rule:
 
 ```text
 For each valid connection message:
-  begin transaction
-  load the persisted state row for serialNumber with write/transaction isolation
+  BEGIN
+
+  acquire a serialNumber-scoped transaction lock before reading state
+  load device_availability_state row for serialNumber with write isolation
   if no state row exists:
+    atomically create or lock the serialNumber state slot using one of:
+      INSERT ... ON CONFLICT ... DO UPDATE/NOTHING followed by SELECT ... FOR UPDATE
+      PostgreSQL advisory transaction lock
+      serializable transaction with retry
     treat previous state as unknown
-  determine the new state from the message
-  if state row exists and event_time is older than last_event_time:
+
+  if event_time < last_event_time:
     treat the message as stale
     do not insert an availability event
     do not update device_availability_state
-    commit transaction
+    COMMIT
     stop processing this message
-  if state row exists and event_time equals last_event_time and no reliable tie-breaker proves this event is later:
+
+  if event_time == last_event_time and no deterministic source tie-breaker proves this message is later:
     treat the message as duplicate or non-advancing
-    do not insert a counted availability event
+    do not insert an availability event
     do not update device_availability_state
-    commit transaction
+    COMMIT
     stop processing this message
-  if previous state is unknown:
-    if new state is offline:
-      insert one offline event with conflict-safe semantics
+
+  determine incomingState from message_type:
+    ping or capabilities -> online
+    disconnection -> offline
+
+  if incomingState is online:
+    if current_state is offline:
+      INSERT online transition event with conflict-safe semantics
+      if the insert created a row:
+        update device_availability_state:
+          current_state = online
+          last_event_time = event_time
+          last_idempotency_key = idempotency_key
+          updated_at = processing time
+      else:
+        treat as duplicate and do not update state
+    else if current_state is online:
+      update device_availability_state metadata, last_event_time, last_idempotency_key, and updated_at
+      do not insert a transition event
+    else:
+      update device_availability_state to online and last_event_time
+      do not insert an initial online transition event
+
+  if incomingState is offline:
+    if current_state is online:
+      INSERT offline transition event with conflict-safe semantics
+      if the insert created a row:
+        update device_availability_state:
+          current_state = offline
+          last_event_time = event_time
+          last_idempotency_key = idempotency_key
+          updated_at = processing time
+      else:
+        treat as duplicate and do not update state
+    else if current_state is offline:
+      update device_availability_state metadata, last_event_time, last_idempotency_key, and updated_at
+      do not insert a transition event
+    else:
+      INSERT offline transition event with conflict-safe semantics
       if the insert created a row:
         update device_availability_state to offline and last_event_time
       else:
-        do not update device_availability_state
-    else if new state is online:
-      update device_availability_state to online and last_event_time
-      do not insert an online event
-    else:
-      update device_availability_state to unknown and last_event_time
-      do not insert a counted event
-  else if previous state differs from new state:
-    insert availability event with conflict-safe semantics:
-      INSERT ... ON CONFLICT(idempotency_key) DO NOTHING
-    if the insert created a row:
-      update device_availability_state to the new state and last_event_time
-    else:
-      treat it as a duplicate
-      do not update device_availability_state
-  else if previous state equals new state:
-    update last contact metadata only when event_time is newer than last_event_time
-    do not insert a counted transition event
-  commit transaction
+        do not update state
+
+  COMMIT
 
 or the equivalent database-specific "insert if absent" operation.
 
@@ -2228,20 +2294,45 @@ the unique idempotency constraint must not be treated as new offline transitions
 must not move `device_availability_state` backward or forward.
 ```
 
+Equivalent transaction shape:
+
+```text
+BEGIN;
+
+Acquire a serialNumber-scoped transaction lock.
+Atomically create or lock the device_availability_state row for :serialNumber.
+Read:
+  current_state
+  last_event_time
+  last_idempotency_key
+
+-- Validate timestamp and determine whether state changed.
+-- Insert into device_availability_events only if state changed.
+
+Update device_availability_state only when timestamp and idempotency checks allow it:
+  current_state = :newState
+  last_event_time = :eventTime
+  last_idempotency_key = :idempotencyKey
+  updated_at = :processingTime
+  board_id = :boardId when known, otherwise keep existing or NULL according to metadata policy
+  metadata = source and processing metadata
+
+COMMIT;
+```
+
 Staleness rule:
 
 ```text
-An event is stale when its event_time is older than the persisted state's
-last_event_time for the same serialNumber. An event with the same event_time is
-non-advancing unless a deterministic source tie-breaker proves it happened later.
+An event is stale when its source event_time is older than the persisted
+device_availability_state.last_event_time for the same serialNumber.
 
 Stale or non-advancing events must not insert counted availability events and must
 not update device_availability_state, even if their idempotency_key has not been
 seen before.
 
-For equal timestamps, use deterministic tie-breakers if the source provides them.
-If no reliable tie-breaker exists, process at most one state-changing event for that
-serialNumber and timestamp.
+An event with the same event_time is non-advancing unless a deterministic source
+tie-breaker proves it occurred later. Exact Kafka redelivery should be ignored by
+the idempotency key.
 ```
 
 ### Store Only State Transitions
@@ -2259,7 +2350,57 @@ Incorrect:
 every ping → store online event
 ```
 
-Every ping should not be treated as a new online transition.
+Every ping should not be treated as a new online transition. However, every newer source ping must still update `device_availability_state.last_event_time` and metadata.
+
+Ping handling:
+
+```text
+current_state=online  + ping -> update last_event_time and metadata only
+current_state=offline + ping after a prior offline state -> insert online event, set current_state=online, update last_event_time
+no state row + ping -> create current_state=online, update last_event_time, do not insert an online event
+```
+
+Disconnection handling:
+
+```text
+current_state=online  + disconnection -> insert offline event, set current_state=offline, update last_event_time
+current_state=offline + disconnection -> update last_event_time and metadata only when the source message is newer; do not insert another offline event
+no state row + disconnection -> create current_state=offline, update last_event_time, insert one offline event
+```
+
+Example:
+
+```text
+12:00 first ping initializes current_state=online with no transition event
+12:10 ping received
+```
+
+At `12:10`, no new event is inserted, but `device_availability_state` becomes:
+
+```text
+current_state = online
+last_event_time = 12:10
+updated_at = processing time for the 12:10 ping
+```
+
+If a delayed disconnection with source time `12:05` then arrives, it is ignored because `12:05 < last_event_time 12:10`, regardless of when Analytics processes the delayed Kafka message.
+
+Kafka delay example:
+
+```text
+Ping source time:          12:00
+Ping processed:            12:05
+Disconnection source time: 12:03
+Disconnection processed:   12:06
+```
+
+The `12:03` disconnection is not stale because it is newer than `device_availability_state.last_event_time = 12:00`. It must not be rejected by comparing against processing-time `DeviceInfo.lastContact = 12:05`.
+
+Review conclusion:
+
+```text
+The implementation requires `device_availability_state` unless a future design explicitly names an existing persistent table with the same fields and locking guarantees. `last_event_time` must be updated for every newer ping, capabilities, or disconnection message, even when no availability transition event is inserted. `DeviceInfo.lastContact` remains contact/processing metadata and is not the source-event ordering field.
+```
 
 ### Calculation
 
@@ -2339,7 +2480,7 @@ Use an HTTP error:
 }
 ```
 
-Do not return `fetch_status: failed` with HTTP 200 for internal failures.
+HTTP 200 represents a successful retrieval. Do not return a success-shaped HTTP 200 response for internal failures; return the appropriate HTTP error instead.
 
 ---
 
@@ -2386,7 +2527,9 @@ Add objects:
 struct GatewayMemorySummary;
 struct GatewayWifiTemperatureSummary;
 struct ClientBandwidthConsumption;
+struct ClientBandwidthConsumptionResponse;
 struct ClientRssiQuality;
+struct ClientRssiQualityResponse;
 struct GatewayOfflineSummary;
 ```
 
@@ -2521,7 +2664,7 @@ bool GetGatewayAvailabilitySummary(...);
 | `get_gateway_wifi_temp` | `GET /devices/{routerId}/radio-temperature-summary` | `timepoints.radio_data[].wifi_temp` | Resolve routerId to venueId and boardId, then aggregate present Wi-Fi temperature samples from `timepoints` |
 | `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then calculate reset-safe cumulative-counter differentials with concise quality metadata by default; include segment provenance only when `includeCalculationDetails=true` |
 | `get_device_rssi_quality` | `GET /devices/{routerId}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve routerId to venueId and boardId, then classify RSSI samples |
-| `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic plus `device_availability_events` | Use routerId as durable serialNumber, persist restart-safe state transitions, then count offline events by serialNumber |
+| `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic plus `device_availability_events` and `device_availability_state` | Use routerId as durable serialNumber, use `device_availability_state.current_state` and `last_event_time` for restart-safe transition detection, then count offline events by serialNumber |
 
 ---
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -818,24 +818,29 @@ Do not synthesize a numeric fallback temperature for missing data.
 Do not store a placeholder in wifi_temp for a missing temperature.
 ```
 
-Migration boundary rule:
+Migration boundary configuration & rule:
 
 ```text
-Define a fixed temperature_migration_cutover_time as the deployment/migration
-timestamp where radios[].wifi_temp starts being written consistently.
+temperatureMigrationCutoverTime:
+  source: Analytics service configuration (file key 'temperature.migration_cutover_time' or ENV 'TEMPERATURE_MIGRATION_CUTOVER_TIME')
+  scope: global per deployment
+  format: ISO 8601 / RFC 3339 UTC string (e.g. "2026-07-01T00:00:00Z")
+  required: true (Analytics service fails startup with a FATAL log if missing or unparseable)
 
-Only use temperature records created at or after temperature_migration_cutover_time.
+Only use temperature records created at or after temperatureMigrationCutoverTime.
 Ignore all earlier records because historical temperature values cannot reliably
 distinguish measured values from synthetic fallback values.
 
-If the requested range starts before temperature_migration_cutover_time:
-  effective_start_time = temperature_migration_cutover_time
-else:
-  effective_start_time = startTime
+If the requested range starts before temperatureMigrationCutoverTime (startTime < temperatureMigrationCutoverTime):
+  return 400 Bad Request with JSON error envelope:
+  {
+    "error": "temperature_range_before_cutover",
+    "message": "The requested summary interval starts before the temperature migration cutover timestamp."
+  }
 
 Do not filter out post-cutover samples only because the measured value is 20°C.
-After the cutover, a present wifi_temp value is treated as a legitimate
-measurement.
+After the cutover, a present wifi_temp value is treated as a legitimate measurement.
+However, wifi_temp = 0 is defined as an uninitialized or missing-sensor sentinel across all OpenWiFi telemetry. A sample with wifi_temp = 0, null, 255, or outside the valid range [-40, 125] is treated as a missing sensor reading and MUST be excluded from aggregation for all samples regardless of timestamp.
 ```
 
 The current radio-band mapping is:
@@ -855,20 +860,20 @@ band = 5 → fields ending in _5G
 
 ### Aggregation Logic
 
-Use the current `timepoints.radio_data` JSON array:
+After validating `startTime >= temperatureMigrationCutoverTime`, query the `timepoints.radio_data` JSON array:
 
 ```text
 Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
-  timestamp >= effective_start_time
+  timestamp >= startTime
   timestamp < endTime
 
 For each record:
   parse radio_data
   for each radio in radio_data:
     if radio.band is 2 or 5:
-      if radio.wifi_temp is present and non-null:
+      if radio.wifi_temp is present, non-null, != 0, and -40 <= radio.wifi_temp <= 125:
         add radio.wifi_temp to that band's sample list
 
 For each band:
@@ -880,8 +885,8 @@ For each band:
 A valid temperature sample is:
 
 ```text
-record timestamp is at or after temperature_migration_cutover_time
-radio.wifi_temp is present and non-null
+record timestamp is at or after temperatureMigrationCutoverTime
+radio.wifi_temp is present, non-null, != 0, and within range [-40, 125]
 ```
 
 If all samples for a band are invalid or missing, return `null` for that band's min, max, and average fields.

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -1899,8 +1899,8 @@ None
 {
   "meta": {
     "requestedWindow": {
-      "from": "2026-07-26T12:00:00Z",
-      "till": "2026-07-27T12:00:00Z"
+      "startTime": "2026-07-26T12:00:00Z",
+      "endTime": "2026-07-27T12:00:00Z"
     },
     "observedWindow": {
       "firstSampleAt": "2026-07-26T13:15:00Z",
@@ -2662,8 +2662,8 @@ Use an HTTP error:
 {
   "meta": {
     "requestedWindow": {
-      "from": "2026-07-26T12:00:00Z",
-      "till": "2026-07-27T12:00:00Z"
+      "startTime": "2026-07-26T12:00:00Z",
+      "endTime": "2026-07-27T12:00:00Z"
     },
     "observedWindow": {
       "firstSampleAt": null,
@@ -2798,6 +2798,8 @@ struct GatewayOfflineSummary;
 
 JSON field names should match the MCP CSV where the API is directly returning MCP fields. `usage-summary` additionally returns raw byte totals and usage accuracy fields so callers can distinguish exact usage from lower-bound estimates.
 
+Client MAC addresses (`mac`) must be normalized to canonical lowercase colon-separated format matching pattern `^[0-9a-f]{2}(:[0-9a-f]{2}){5}$` across all client metrics endpoints.
+
 ---
 
 ## REST Handlers
@@ -2826,6 +2828,9 @@ Wi-Fi client metrics handler:
 usage-summary
 rssi-summary
 ```
+
+Handler query parsing implementation note:
+REST handlers must inspect and parse the raw HTTP query string parameter collection directly rather than relying solely on generated framework parameter binding. Handlers must verify that `lookbackHours` and `timestampTill` appear exactly once in the raw query string, reject repeated parameters, reject fractional numeric values, and reject 32-bit integer overflow.
 
 Timepoint-backed handlers must call a shared serial-resolution helper before storage access:
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -51,7 +51,12 @@ start_time = end_time - (lookback_hours * 3600)
 
 Validation & Processing Order:
 
-All REST handlers must enforce request validation in three distinct sequential phases:
+All REST handlers must enforce request validation in four distinct sequential phases:
+
+0. **Phase 0: Request Authentication (Bearer Token)**
+   - Extract and validate HTTP `Authorization` header (`Bearer <token>`).
+   - If missing, malformed, expired, or invalid: return HTTP `401 Unauthorized` (`error: "unauthorized"`) immediately.
+   - Authentication takes precedence over parameter validation; unauthenticated callers receive HTTP `401 Unauthorized` regardless of whether `routerId`, `timestampTill`, or `lookbackHours` are malformed, missing, or invalid.
 
 1. **Phase 1: Pure Request Parsing & Input Validation (No DB or I/O lookups)**
    - Validate `routerId` syntax (1–64 characters matching `^[a-zA-Z0-9_-]+$`) -> HTTP `400 invalid_router_id` if malformed.

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -10,8 +10,11 @@ This document defines the request format, response format, and implementation lo
 
 The specification is structured across three distinct component layers:
 1. **Public API Contract Specifications**: External OpenAPI schemas (`openapi/owanalytics.yaml`) defining HTTP requests, parameter validation, and response envelopes.
-2. **Persistence & Pipeline Architecture Design**: Internal storage structures (`device_availability_events`, `device_availability_state`), Kafka event consumption/ordering, and cutover semantics.
+2. **Persistence & Pipeline Architecture Design**: Internal storage structures (`device_availability_events`, `device_availability_state`, `device_availability_ingestion_checkpoint`, `device_availability_ingestion_gaps`), Kafka event consumption/ordering, and cutover semantics.
 3. **Test Specifications Matrix**: Independent verification matrix documented in `analytics_mcp_api_test_cases.md`.
+
+> [!IMPORTANT]
+> The specified production architecture changes—including four new availability persistence structures (`device_availability_events`, `device_availability_state`, `device_availability_ingestion_checkpoint`, `device_availability_ingestion_gaps`), Kafka event ordering/checkpointing rules, cutover migration rules, and OpenAPI v2.7.0 endpoint schemas—constitute a production architecture specification. Approving or merging this test specification PR does NOT bypass separate explicit architecture design sign-off for backend schema additions and production Kafka pipeline changes prior to production deployment.
 
 The API contracts match the MCP tool names and response fields from the provided CSV.
 
@@ -1418,7 +1421,7 @@ segment objects. When `includeCalculationDetails=true`, the detailed
 any segment contributing to a station MAC is lower_bound, that station's usage
 is lower_bound.
 
-Client MAC values in API responses must be normalized colon-separated MAC addresses matching `^[A-Fa-f0-9]{2}(:[A-Fa-f0-9]{2}){5}$`.
+Client MAC values in API responses must be normalized canonical lowercase colon-separated MAC addresses matching `^[0-9a-f]{2}(:[0-9a-f]{2}){5}$`.
 
 Usage accuracy contract:
 
@@ -1548,7 +1551,7 @@ Different stream keys are calculated independently. BSSID, SSID, band, and radio
 identify counter streams; they must not be used to invent temporal order between
 different counter values at the same timestamp.
 
-Discard out-of-order or ambiguous samples for the same calculated stream.
+Deterministically sort all stream samples by timestamp ASC before calculating deltas. Valid out-of-order historical telemetry must be sorted and included in differential calculation; valid samples must not be discarded or treated as stale merely because they arrived out of temporal sequence. Discarding is strictly reserved for exact duplicate samples or ambiguous conflicting counter samples at the same timestamp without sequence proof.
 
 When an association/session identifier is available:
   calculate deltas only within the same session.

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -577,7 +577,7 @@ None
 {
   "min_memfree": 211374,
   "max_memfree": 215050,
-  "avg_memfree": 212074.360
+  "avg_memfree": 212074.36
 }
 ```
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -2069,7 +2069,39 @@ Constraints:
 
 `device_availability_events` stores only online/offline transition history. `device_availability_state` stores the authoritative current state and the latest accepted source availability event time.
 
-`last_event_time` is the source-event ordering watermark. It must be populated from the normalized Kafka source timestamp (`event_time`) and used for stale/out-of-order detection. `DeviceInfo.lastContact` may remain local contact or processing metadata, but it must not be used to order source events because Kafka delivery can be delayed.
+`last_event_time` is the source-event ordering watermark after events have passed the required per-serial ordering mechanism. It must be populated from the normalized Kafka source timestamp (`event_time`) and used for stale detection only after Analytics has established that no older transition for the same serialNumber can still be accepted. `DeviceInfo.lastContact` may remain local contact or processing metadata, but it must not be used to order source events because Kafka delivery can be delayed.
+
+Add persisted ingestion coverage tables for availability exactness:
+
+```text
+device_availability_ingestion_checkpoint
+----------------------------------------
+serialNumber
+coverage_start
+processed_through_event_time
+partition
+offset
+ordering_strategy
+reorder_window_ms
+ingestion_gap_known
+updated_at
+metadata
+
+device_availability_ingestion_gaps
+----------------------------------
+serialNumber
+gap_start_event_time
+gap_end_event_time
+reason
+detected_at
+metadata
+```
+
+`processed_through_event_time` is a source-event-time watermark, not a Kafka processing-time or `DeviceInfo.lastContact` value. Kafka topic, partition, and offset are stored only as proof metadata. An exact zero is allowed only when the serialNumber checkpoint proves `coverage_start <= startTime`, `processed_through_event_time >= endTime`, and no persisted gap overlaps the requested range.
+
+The checkpoint must be advanced durably with event processing. For a message that changes availability state or updates same-state metadata, the state update, optional transition insert, and checkpoint update must commit in one database transaction before the corresponding Kafka offset is committed. Rebalances and restarts must reload the checkpoint and any persisted reorder-buffer state needed by the selected ordering strategy. If the implementation cannot prove continuity after a restart, rebalance, topic retention truncation, skipped unparseable connection message, reorder-window overflow, or offset discontinuity, it must persist an ingestion gap and stop returning exact coverage for overlapping ranges.
+
+When one serialNumber has no recent messages, do not infer coverage from an empty event table. The API may return an exact zero only if that serialNumber has a durable checkpoint whose `processed_through_event_time` reaches the requested `endTime`; otherwise the result is partial/lower-bound or unavailable according to the coverage rules.
 
 Add a `DeviceAvailabilityEvent` REST/storage object with `to_json` and `from_json` support in:
 
@@ -2084,22 +2116,32 @@ Update `StorageService`:
 src/StorageService.h
   include storage/storage_device_availability_events.h
   include storage/storage_device_availability_state.h
+  include storage/storage_device_availability_ingestion_checkpoint.h
+  include storage/storage_device_availability_ingestion_gaps.h
   add DeviceAvailabilityEventsDB accessor
   add DeviceAvailabilityStateDB accessor
+  add DeviceAvailabilityIngestionCheckpointDB accessor
+  add DeviceAvailabilityIngestionGapsDB accessor
   add std::unique_ptr<DeviceAvailabilityEventsDB>
   add std::unique_ptr<DeviceAvailabilityStateDB>
+  add std::unique_ptr<DeviceAvailabilityIngestionCheckpointDB>
+  add std::unique_ptr<DeviceAvailabilityIngestionGapsDB>
 
 src/StorageService.cpp
   construct DeviceAvailabilityEventsDB
   construct DeviceAvailabilityStateDB
+  construct DeviceAvailabilityIngestionCheckpointDB
+  construct DeviceAvailabilityIngestionGapsDB
   call DeviceAvailabilityEventsDB->Create()
   call DeviceAvailabilityStateDB->Create()
+  call DeviceAvailabilityIngestionCheckpointDB->Create()
+  call DeviceAvailabilityIngestionGapsDB->Create()
   include availability retention cleanup if retention should match board timepoint cleanup
 ```
 
-Add a DB upgrade/migration path for the new table. Existing deployments will start with no historical availability events. Define a fixed `availabilityValidFrom` timestamp as the deployment/migration time when availability-event persistence starts. The API should return `offline_count: 0` only for successful empty queries whose requested range starts at or after `availabilityValidFrom`; do not infer old events from `lastDisconnection`.
+Add a DB upgrade/migration path for the new tables. Existing deployments will start with no historical availability events. Define a fixed `availabilityValidFrom` timestamp as the deployment/migration time when availability-event persistence starts. The API should return `offline_count: 0` as an exact result only for successful empty queries whose requested range starts at or after `availabilityValidFrom` and is covered by the per-serial ingestion checkpoint; do not infer old events from `lastDisconnection`.
 
-Add all availability storage files to `CMakeLists.txt`, including both `storage_device_availability_events.*` and `storage_device_availability_state.*`. Register database migration/upgrade logic for both tables so fresh databases and upgraded deployments create the event table, state table, indexes, uniqueness constraints, and state constraints consistently.
+Add all availability storage files to `CMakeLists.txt`, including `storage_device_availability_events.*`, `storage_device_availability_state.*`, `storage_device_availability_ingestion_checkpoint.*`, and `storage_device_availability_ingestion_gaps.*`. Register database migration/upgrade logic for all availability tables so fresh databases and upgraded deployments create the event table, state table, checkpoint table, gap table, indexes, uniqueness constraints, and state constraints consistently.
 
 ### Ingestion Hook
 
@@ -2287,12 +2329,12 @@ Ordering rule:
 Availability transition detection must process connection events in source-event
 order for each serialNumber.
 
-The preferred implementation is to produce and consume Kafka connection messages
-with serialNumber as the Kafka message key, so all events for one gateway are in
-one partition and retain gateway event order. If the source topic cannot provide
-that guarantee, Analytics must add a bounded event-time reorder window or an
-equivalent serialNumber-scoped ordering mechanism before applying the transition
-state machine.
+The preferred implementation is to produce Kafka connection messages in
+source-event order with serialNumber as the Kafka message key, so all events for
+one gateway are in one partition and retain gateway event order. If the source
+topic cannot provide that guarantee, Analytics must add a bounded event-time
+reorder window or an equivalent serialNumber-scoped ordering mechanism before
+applying the transition state machine.
 
 A newer same-state online event must not advance last_event_time in a way that
 causes an older offline transition for the same serialNumber to be discarded
@@ -2304,7 +2346,7 @@ and surfaced to callers; it must not be reported as exact availability counting.
 Atomic transition and insert rule:
 
 ```text
-For each valid connection message:
+For each valid connection message emitted by the per-serial ordering stage:
   BEGIN
 
   acquire a serialNumber-scoped transaction lock before reading state
@@ -2377,6 +2419,11 @@ or the equivalent database-specific "insert if absent" operation.
 The storage method must return whether a row was inserted. Duplicate events that hit
 the unique idempotency constraint must not be treated as new offline transitions and
 must not move `device_availability_state` backward or forward.
+
+This transaction shape assumes the selected ordering strategy has already made
+the message eligible for state-machine processing. Do not apply this scalar
+`last_event_time` staleness check directly to raw Kafka arrival order unless the
+connection topic is keyed by serialNumber and source-event ordered.
 ```
 
 Equivalent transaction shape:
@@ -2405,11 +2452,13 @@ Update device_availability_state only when timestamp and idempotency checks allo
 COMMIT;
 ```
 
-Staleness rule:
+Staleness rule after ordering:
 
 ```text
 An event is stale when its source event_time is older than the persisted
-device_availability_state.last_event_time for the same serialNumber.
+device_availability_state.last_event_time for the same serialNumber and the
+selected ordering strategy has already advanced the serialNumber beyond that
+source time.
 
 Stale or non-advancing events must not insert counted availability events and must
 not update device_availability_state, even if their idempotency_key has not been
@@ -2435,7 +2484,7 @@ Incorrect:
 every ping → store online event
 ```
 
-Every ping should not be treated as a new online transition. However, every newer source ping must still update `device_availability_state.last_event_time` and metadata.
+Every ping should not be treated as a new online transition. However, every source-newer ping that is accepted by the per-serial ordering stage must still update `device_availability_state.last_event_time` and metadata.
 
 Ping handling:
 
@@ -2457,18 +2506,25 @@ Example:
 
 ```text
 12:00 first ping initializes current_state=online with no transition event
-12:10 ping received
+12:05 disconnection source event
+12:10 ping source event
 ```
 
-At `12:10`, no new event is inserted, but `device_availability_state` becomes:
+If Kafka delivers the `12:10` ping before the `12:05` disconnection and the
+topic does not guarantee serialNumber ordering, Analytics must not immediately
+advance `last_event_time` to `12:10` and then reject the delayed `12:05`
+disconnection. With a bounded reorder window, both messages are ordered by
+source time before transition processing:
 
 ```text
-current_state = online
-last_event_time = 12:10
-updated_at = processing time for the 12:10 ping
+12:05 disconnection -> insert offline event, current_state=offline, last_event_time=12:05
+12:10 ping          -> insert online event, current_state=online,  last_event_time=12:10
 ```
 
-If a delayed disconnection with source time `12:05` then arrives, it is ignored because `12:05 < last_event_time 12:10`, regardless of when Analytics processes the delayed Kafka message.
+The final current state is online, and the outage from `12:05` to `12:10` remains
+present in transition history. If the implementation lacks serial-keyed
+source-event ordering or a bounded reorder window, this case is only best-effort
+and must not be surfaced as exact availability counting.
 
 Kafka delay example:
 
@@ -2484,7 +2540,7 @@ The `12:03` disconnection is not stale because it is newer than `device_availabi
 Review conclusion:
 
 ```text
-The implementation requires `device_availability_state` unless a future design explicitly names an existing persistent table with the same fields and locking guarantees. `last_event_time` must be updated for every newer ping, capabilities, or disconnection message, even when no availability transition event is inserted. `DeviceInfo.lastContact` remains contact/processing metadata and is not the source-event ordering field.
+The implementation requires `device_availability_state` unless a future design explicitly names an existing persistent table with the same fields and locking guarantees. `last_event_time` must be updated for every source-newer ping, capabilities, or disconnection message accepted by the per-serial ordering stage, even when no availability transition event is inserted. `DeviceInfo.lastContact` remains contact/processing metadata and is not the source-event ordering field.
 ```
 
 ### Calculation

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -675,24 +675,33 @@ Do not represent missing memory fields as `0`. A missing `memory_free` value and
 AnalyticsObjects::DeviceResourceTimePoint resource;
 
 // Validate numeric type, integral value, non-negative range (>= 0), and 64-bit non-overflow before unsigned conversion.
-// Field-level isolation rule: An invalid or negative field (e.g. free < 0 or total < 0) invalidates only that specific field, leaving it unset (null), so unparseable or negative values do not throw unhandled exceptions or corrupt other valid fields in the sample.
-auto parseMemoryField = [](const Poco::JSON::Object::Ptr &obj, const std::string &key) -> std::optional<uint64_t> {
+// Sample-level rejection policy for negative telemetry: If ANY present memory field (free, total, cached, buffered) is negative (< 0), non-numeric, or invalid, mark the entire memory sample invalid and omit resource_data so the entire corrupted memory timepoint is excluded during aggregation.
+bool sampleValid = true;
+auto parseMemoryField = [&sampleValid](const Poco::JSON::Object::Ptr &obj, const std::string &key) -> std::optional<uint64_t> {
     if (!obj->has(key) || obj->isNull(key)) return std::nullopt;
     try {
-        if (!obj->isNumeric(key)) return std::nullopt;
+        if (!obj->isNumeric(key)) { sampleValid = false; return std::nullopt; }
         int64_t val = obj->getElement<int64_t>(key);
-        if (val < 0) return std::nullopt;
+        if (val < 0) { sampleValid = false; return std::nullopt; }
         return static_cast<uint64_t>(val);
     } catch (...) {
+        sampleValid = false;
         return std::nullopt;
     }
 };
 
-if (auto val = parseMemoryField(memory, "free"))     resource.memory_free = *val;
-if (auto val = parseMemoryField(memory, "total"))    resource.memory_total = *val;
-if (auto val = parseMemoryField(memory, "cached"))   resource.memory_cached = *val;
-if (auto val = parseMemoryField(memory, "buffered")) resource.memory_buffered = *val;
-DTP.resource_data = resource;
+auto freeVal = parseMemoryField(memory, "free");
+auto totalVal = parseMemoryField(memory, "total");
+auto cachedVal = parseMemoryField(memory, "cached");
+auto bufferedVal = parseMemoryField(memory, "buffered");
+
+if (sampleValid) {
+    if (freeVal)     resource.memory_free = *freeVal;
+    if (totalVal)    resource.memory_total = *totalVal;
+    if (cachedVal)   resource.memory_cached = *cachedVal;
+    if (bufferedVal) resource.memory_buffered = *bufferedVal;
+    DTP.resource_data = resource;
+}
 ```
 
 ### Aggregation Logic
@@ -1567,6 +1576,20 @@ When no session identifier is available:
   use station MAC as the result grouping key,
   but use BSSID/SSID/band/radio changes as stream boundaries when possible.
 
+Independent Directional Counter Rules (RX vs TX):
+1. RX and TX counters are calculated independently per stream.
+2. If RX is present and valid but TX is missing, non-numeric, negative (< 0), or uncalculable:
+   - RX bytes are calculated normally and included in data_consume_rx.
+   - TX bytes return 0 (or null in raw segment details) and formatted "0.00 MB".
+   - The stream accuracy is classified as lower_bound.
+3. If TX is present and valid but RX is missing/invalid:
+   - TX bytes are calculated normally and included in data_consume_tx.
+   - RX bytes return 0 and formatted "0.00 MB".
+   - The stream accuracy is classified as lower_bound.
+4. If a boundary sample has RX but not TX (or vice versa), the missing direction cannot form a calculable boundary delta; that direction is marked uncalculable (lower_bound).
+5. segment_count is incremented if at least one direction (RX or TX) produces a valid calculable segment delta.
+6. A client MAC is included in totalClients and items[] if it has proven in-window presence or session overlap, regardless of whether one counter direction was missing or uncalculable.
+
 If current < previous:
   if a new association/session is confirmed:
     if the new session start time is within [startTime, endTime):
@@ -1944,6 +1967,12 @@ None
     "selection": "boundary_assisted",
     "coverage": "full",
     "accuracy": "exact",
+    "coverageStart": "2026-07-26T11:55:00Z",
+    "stateKnownFrom": "2026-07-26T11:55:00Z",
+    "processedThrough": "2026-07-27T12:00:00Z",
+    "allowedIngestionDelaySeconds": 0,
+    "ingestionGapKnown": false,
+    "proofSource": "checkpoint",
     "sampleCount": 6,
     "offlineEventCount": 6,
     "effectiveSamplingIntervalSeconds": 0,
@@ -2637,8 +2666,12 @@ offline_count =
 Availability migration boundary:
 
 ```text
-availabilityValidFrom = deployment timestamp when device_availability_events
-persistence became active
+availabilityValidFrom is a durable, deployment-wide timestamp loaded on service startup from:
+  1. Configuration file property `availability_valid_from` (in /etc/ucentral/owanalytics.json)
+  2. Environment variable `ANALYTICS_AVAILABILITY_VALID_FROM`
+  3. Persistent database migration metadata table (`system_properties` key `availability_valid_from`) populated during initial table creation.
+
+All service replicas and process restarts MUST load the identical `availabilityValidFrom` timestamp from these durable configuration/DB sources to guarantee multi-replica and restart consistency. Dynamic process-start timestamps (e.g. std::chrono::system_clock::now() at startup) are strictly prohibited.
 
 If startTime < availabilityValidFrom:
   reject the request

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -578,7 +578,7 @@ None
 {
   "min_memfree": 211374,
   "max_memfree": 215050,
-  "avg_memfree": 212074.36
+  "avg_memfree": 212074.360
 }
 ```
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -129,6 +129,8 @@ Validation rules:
 
 ```text
 timestampTill must parse as a valid UTC timestamp ending with 'Z'.
+lookbackHours must be present exactly once.
+lookbackHours must parse as a strict whole decimal integer with no trailing characters.
 lookbackHours must be greater than 0.
 maxLookbackHours = floor(configured monitoringDuration / 3600).
 lookbackHours must be less than or equal to maxLookbackHours.
@@ -145,8 +147,9 @@ Return validation errors with field-specific error codes:
 invalid_timestamp:
   timestampTill is missing, malformed, not UTC `Z` format, or otherwise unsupported.
 
-invalid_lookback:
-  lookbackHours is missing, non-numeric, zero, negative, or greater than maxLookbackHours.
+invalid_lookback_hours:
+  lookbackHours is missing, repeated, empty, non-numeric, fractional, partially numeric, overflowing,
+  zero, negative, or greater than maxLookbackHours.
 
 lookback_outside_retention:
   the calculated [startTime, endTime) window is outside the configured retention window.
@@ -692,6 +695,8 @@ For each record:
   read record.resource_data.memory_free
   ignore missing resource_data
   include the sample only when memory_free is present
+  exclude the sample if any present memory value is negative
+  exclude the sample if memory_total is present and memory_free > memory_total
 
 Return:
   min_memfree = min(memory_free samples)
@@ -699,7 +704,7 @@ Return:
   avg_memfree = sum(memory_free samples) / sample_count
 ```
 
-Memory values are bytes and must be nonnegative. For successful responses with samples, the invariant is:
+Memory values are bytes and must be nonnegative. If `memory_total` is present, `memory_free` must not exceed `memory_total`; corrupted samples that violate this consistency rule are ignored rather than contributing to the summary. For successful responses with samples, the invariant is:
 
 ```text
 min_memfree <= avg_memfree <= max_memfree
@@ -1521,11 +1526,20 @@ Build a deterministic sample key from the stable fields available in the associa
 Sort samples by:
   station MAC
   timestamp ASC
-  BSSID/SSID/band/radio tie-breakers
+  stream identity fields for grouping only
 
 Deduplicate exact duplicate samples before calculating deltas.
 
-Discard out-of-order samples for the same calculated stream.
+For the same calculated stream and same timestamp:
+  identical counters are duplicates and collapse to one sample
+  different counters are ambiguous and must be excluded from delta calculation
+  unless a reliable source sequence number proves their temporal order
+
+Different stream keys are calculated independently. BSSID, SSID, band, and radio
+identify counter streams; they must not be used to invent temporal order between
+different counter values at the same timestamp.
+
+Discard out-of-order or ambiguous samples for the same calculated stream.
 
 When an association/session identifier is available:
   calculate deltas only within the same session.
@@ -1882,9 +1896,48 @@ None
 
 ```json
 {
-  "gw_uuid": "60cf84f22290",
-  "fetch_status": "success",
-  "offline_count": 6
+  "meta": {
+    "requestedWindow": {
+      "from": "2026-07-26T12:00:00Z",
+      "till": "2026-07-27T12:00:00Z"
+    },
+    "observedWindow": {
+      "firstSampleAt": "2026-07-26T13:15:00Z",
+      "lastSampleAt": "2026-07-27T09:45:00Z"
+    },
+    "sourceWindow": {
+      "firstSampleAt": "2026-07-26T11:55:00Z",
+      "lastSampleAt": "2026-07-27T09:45:00Z"
+    },
+    "contributingWindow": {
+      "firstSampleAt": "2026-07-26T13:15:00Z",
+      "lastSampleAt": "2026-07-27T09:45:00Z"
+    },
+    "selection": "boundary_assisted",
+    "coverage": "full",
+    "accuracy": "exact",
+    "sampleCount": 6,
+    "effectiveSamplingIntervalSeconds": 0,
+    "allowedGapSeconds": 0,
+    "boundarySamplesUsed": {
+      "beforeStart": true,
+      "atStart": false,
+      "atEnd": false,
+      "afterEnd": false
+    },
+    "availabilityCoverage": {
+      "coverageStart": "2026-07-20T00:00:00Z",
+      "processedThrough": "2026-07-27T12:01:00Z",
+      "allowedIngestionDelaySeconds": 60,
+      "ingestionGapKnown": false,
+      "proofSource": "serial_partition_checkpoint"
+    }
+  },
+  "data": {
+    "gw_uuid": "60cf84f22290",
+    "fetch_status": "success",
+    "offline_count": 6
+  }
 }
 ```
 
@@ -2088,10 +2141,10 @@ Bootstrap rule when no `device_availability_state` row exists:
 
 ```text
 First observed disconnection:
-  insert one offline event
   insert state row with current_state = offline
   set last_event_time = event_time
   set last_idempotency_key = idempotency_key
+  do not insert an offline transition event because the prior state is unknown
 
 First observed ping/capabilities:
   insert state row with current_state = online
@@ -2228,6 +2281,26 @@ Do not include Kafka topic, partition, or offset in the derived logical `idempot
 
 The same delivered logical connection event must always produce the same `idempotency_key`. If the implementation cannot build a stable or deterministic key for an event, it must not write that event as a counted availability transition; log it as an ingestion error instead.
 
+Ordering rule:
+
+```text
+Availability transition detection must process connection events in source-event
+order for each serialNumber.
+
+The preferred implementation is to produce and consume Kafka connection messages
+with serialNumber as the Kafka message key, so all events for one gateway are in
+one partition and retain gateway event order. If the source topic cannot provide
+that guarantee, Analytics must add a bounded event-time reorder window or an
+equivalent serialNumber-scoped ordering mechanism before applying the transition
+state machine.
+
+A newer same-state online event must not advance last_event_time in a way that
+causes an older offline transition for the same serialNumber to be discarded
+silently. If a deployment intentionally chooses best-effort counting instead of
+per-serial ordering, that lower-accuracy behavior must be documented separately
+and surfaced to callers; it must not be reported as exact availability counting.
+```
+
 Atomic transition and insert rule:
 
 ```text
@@ -2294,11 +2367,8 @@ For each valid connection message:
       update device_availability_state metadata, last_event_time, last_idempotency_key, and updated_at
       do not insert a transition event
     else:
-      INSERT offline transition event with conflict-safe semantics
-      if the insert created a row:
-        update device_availability_state to offline and last_event_time
-      else:
-        do not update state
+      update device_availability_state to offline and last_event_time
+      do not insert an initial offline transition event because the prior state is unknown
 
   COMMIT
 
@@ -2380,7 +2450,7 @@ Disconnection handling:
 ```text
 current_state=online  + disconnection -> insert offline event, set current_state=offline, update last_event_time
 current_state=offline + disconnection -> update last_event_time and metadata only when the source message is newer; do not insert another offline event
-no state row + disconnection -> create current_state=offline, update last_event_time, insert one offline event
+no state row + disconnection -> create current_state=offline, update last_event_time, do not insert an offline transition event
 ```
 
 Example:
@@ -2474,11 +2544,56 @@ Use an HTTP error:
 
 ```json
 {
-  "gw_uuid": "60cf84f22290",
-  "fetch_status": "success",
-  "offline_count": 0
+  "meta": {
+    "requestedWindow": {
+      "from": "2026-07-26T12:00:00Z",
+      "till": "2026-07-27T12:00:00Z"
+    },
+    "observedWindow": {
+      "firstSampleAt": null,
+      "lastSampleAt": null
+    },
+    "sourceWindow": {
+      "firstSampleAt": "2026-07-26T11:55:00Z",
+      "lastSampleAt": "2026-07-26T11:55:00Z"
+    },
+    "contributingWindow": {
+      "firstSampleAt": null,
+      "lastSampleAt": null
+    },
+    "selection": "boundary_assisted",
+    "coverage": "full",
+    "accuracy": "exact",
+    "sampleCount": 0,
+    "effectiveSamplingIntervalSeconds": 0,
+    "allowedGapSeconds": 0,
+    "boundarySamplesUsed": {
+      "beforeStart": true,
+      "atStart": false,
+      "atEnd": false,
+      "afterEnd": false
+    },
+    "availabilityCoverage": {
+      "coverageStart": "2026-07-20T00:00:00Z",
+      "processedThrough": "2026-07-27T12:01:00Z",
+      "allowedIngestionDelaySeconds": 60,
+      "ingestionGapKnown": false,
+      "proofSource": "serial_partition_checkpoint"
+    }
+  },
+  "data": {
+    "gw_uuid": "60cf84f22290",
+    "fetch_status": "success",
+    "offline_count": 0
+  }
 }
 ```
+
+An exact zero is valid only when availability coverage proves the complete
+requested interval: `coverageStart <= startTime`, `processedThrough >= endTime`,
+`ingestionGapKnown = false`, and `proofSource != "unavailable"`. Otherwise a
+zero matching event count must be reported as partial/lower-bound or unavailable
+coverage according to the availability coverage rules.
 
 ### Internal Error
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -54,6 +54,7 @@ Recommended query parameters:
 ```http
 ?timestampTill=2026-07-27T12:00:00Z
 &lookbackHours=24
+&metricMode=<latest|all|differential>
 ```
 
 These are `GET` APIs, so no request body is required.
@@ -915,7 +916,7 @@ GET /api/v1/devices/{routerId}/wifi-clients/usage-summary
 ## Example Request
 
 ```http
-GET /api/v1/devices/60cf84f22290/wifi-clients/usage-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24
+GET /api/v1/devices/60cf84f22290/wifi-clients/usage-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24&metricMode=differential
 Authorization: Bearer <token>
 ```
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -1277,6 +1277,10 @@ effective boundaries:
   effective_start = max(requested_start, proven_session_start)
   effective_end = min(requested_end, proven_session_end)
 
+effective boundaries:
+  effective_start = max(requested_start_time, proven_session_start)
+  effective_end = min(requested_end_time, proven_session_end)
+
 start_sample:
   exact sample at effective_start, if available
   otherwise latest available sample at or before effective_start

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -62,9 +62,13 @@ All REST handlers must enforce request validation in three distinct sequential p
 
 2. **Phase 2: Router Ownership & Serial Resolution**
    - Resolve `routerId` to `boardId` via local cache / OWPROV -> HTTP `404 not_found` if router serial does not exist in OWPROV.
+   - Load router scope monitoring configuration (`monitoringDuration`) to derive `maxLookbackHours = floor(monitoringDuration / 3600)`.
 
-3. **Phase 3: Domain Cutover & Range Validation**
-   - Verify `start_time` against service cutover thresholds (`availabilityValidFrom`, `temperatureMigrationCutoverTime`, `maxLookbackHours`) -> HTTP `400 availability_range_before_cutover` / `temperature_range_before_cutover` if before cutover.
+3. **Phase 3: Duration, Retention & Domain Cutover Validation**
+   - Validate duration against scope maximum: `lookbackHours > maxLookbackHours` -> HTTP `400 invalid_lookback_hours`.
+   - Validate requested range against data retention window: requested window outside retention -> HTTP `400 lookback_outside_retention`.
+   - Validate `start_time` against temperature cutover threshold (`start_time < temperatureMigrationCutoverTime`) -> HTTP `400 temperature_range_before_cutover`.
+   - Validate `start_time` against availability cutover threshold (`start_time < availabilityValidFrom`) -> HTTP `400 availability_range_before_cutover`.
 
 Example:
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -54,7 +54,6 @@ Recommended query parameters:
 ```http
 ?timestampTill=2026-07-27T12:00:00Z
 &lookbackHours=24
-&metricMode=<latest|all|differential>
 ```
 
 These are `GET` APIs, so no request body is required.
@@ -916,7 +915,7 @@ GET /api/v1/devices/{routerId}/wifi-clients/usage-summary
 ## Example Request
 
 ```http
-GET /api/v1/devices/60cf84f22290/wifi-clients/usage-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24&metricMode=differential
+GET /api/v1/devices/60cf84f22290/wifi-clients/usage-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24
 Authorization: Bearer <token>
 ```
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -673,18 +673,25 @@ Do not represent missing memory fields as `0`. A missing `memory_free` value and
 
 ```cpp
 AnalyticsObjects::DeviceResourceTimePoint resource;
-if (memory.has("free")) {
-    resource.memory_free = memory["free"].as<uint64_t>();
-}
-if (memory.has("total")) {
-    resource.memory_total = memory["total"].as<uint64_t>();
-}
-if (memory.has("cached")) {
-    resource.memory_cached = memory["cached"].as<uint64_t>();
-}
-if (memory.has("buffered")) {
-    resource.memory_buffered = memory["buffered"].as<uint64_t>();
-}
+
+// Validate numeric type, integral value, non-negative range (>= 0), and 64-bit non-overflow before unsigned conversion.
+// Field-level isolation rule: An invalid or negative field (e.g. free < 0 or total < 0) invalidates only that specific field, leaving it unset (null), so unparseable or negative values do not throw unhandled exceptions or corrupt other valid fields in the sample.
+auto parseMemoryField = [](const Poco::JSON::Object::Ptr &obj, const std::string &key) -> std::optional<uint64_t> {
+    if (!obj->has(key) || obj->isNull(key)) return std::nullopt;
+    try {
+        if (!obj->isNumeric(key)) return std::nullopt;
+        int64_t val = obj->getElement<int64_t>(key);
+        if (val < 0) return std::nullopt;
+        return static_cast<uint64_t>(val);
+    } catch (...) {
+        return std::nullopt;
+    }
+};
+
+if (auto val = parseMemoryField(memory, "free"))     resource.memory_free = *val;
+if (auto val = parseMemoryField(memory, "total"))    resource.memory_total = *val;
+if (auto val = parseMemoryField(memory, "cached"))   resource.memory_cached = *val;
+if (auto val = parseMemoryField(memory, "buffered")) resource.memory_buffered = *val;
 DTP.resource_data = resource;
 ```
 
@@ -1600,13 +1607,18 @@ Example:
 
 Delta 10:00 -> 10:05 = 500
 
-If 10:10 is a confirmed new session that started inside the request window:
-  add 200
+If 10:10 is a confirmed new session that started inside the request window WITH authoritative proof of starting at counter zero (e.g. session_start event with baseline 0 at session origin):
+  add 200 (delta from zero baseline)
   total rx_bytes = 700
   usage_accuracy = exact, unless another stream is incomplete
 
+If 10:10 is a confirmed new session that started inside the request window WITHOUT authoritative proof of starting at zero:
+  treat 200 as the new segment baseline (delta = 0 for 10:10 sample alone)
+  total rx_bytes = 500
+  usage_accuracy = lower_bound (until a subsequent sample in Session B establishes a proven delta)
+
 If 10:10 is an ambiguous decrease:
-  add 0
+  add 0 (treat 200 as baseline)
   total rx_bytes = 500
   usage_accuracy = lower_bound
 
@@ -1665,17 +1677,19 @@ Resolve boardId from routerId
     ↓
 Load TimePointDB records for resolvedBoardId and stored serialNumber == request routerId
     ↓
-Include records from startTime up to but not including endTime
-    ↓
-Also load the latest pre-window association sample for each calculated stream_key
+Query both boundary candidates for each calculated stream:
+  - In-window samples: timestamp >= startTime and timestamp < endTime
+  - Start boundary: latest sample at or before effective_start (timestamp <= effective_start)
+  - End boundary: earliest sample at or after effective_end (timestamp >= effective_end)
+(Outside-window samples serve strictly as boundary calculation aids for streams with in-window observations or proven session overlap; they do NOT make a client eligible for response items)
     ↓
 Parse ssid_data associations
     ↓
-Build stream_key values and sort samples by stream_key and timestamp
+Build stream_key values and sort samples by stream_key and timestamp ASC
     ↓
-Calculate reset-safe RX/TX deltas
+Calculate reset-safe RX/TX deltas using effective start and end boundary samples
     ↓
-Aggregate stream-level deltas by station MAC
+Aggregate stream-level deltas by station MAC (including only clients with in-window observations or proven session overlap)
     ↓
 Convert bytes to decimal megabytes
     ↓
@@ -2106,6 +2120,7 @@ device_availability_ingestion_checkpoint
 ----------------------------------------
 serialNumber
 coverage_start
+state_known_from
 processed_through_event_time
 partition
 offset
@@ -2125,7 +2140,7 @@ detected_at
 metadata
 ```
 
-`processed_through_event_time` is a source-event-time watermark, not a Kafka processing-time or `DeviceInfo.lastContact` value. Kafka topic, partition, and offset are stored only as proof metadata.
+`processed_through_event_time` is a source-event-time watermark, not a Kafka processing-time or `DeviceInfo.lastContact` value. `state_known_from` stores the earliest source event timestamp from which gateway state is authoritatively established. When initial state is unproven (such as a first observed disconnection initializing state without prior state history), `state_known_from` is set to the timestamp of the first observed transition or explicit state proof (or an unproven gap is persisted in `device_availability_ingestion_gaps` for `[coverage_start, initial_observation_time)`). Kafka topic, partition, and offset are stored only as proof metadata.
 
 For availability coverage decisions over a requested interval `[startTime, endTime)`:
 
@@ -2133,7 +2148,7 @@ For availability coverage decisions over a requested interval `[startTime, endTi
 coverageTargetEnd = endTime - allowedIngestionDelaySeconds
 ```
 
-An exact result (`meta.coverage = "full"`, `meta.accuracy = "exact"`) is allowed only when the serialNumber checkpoint proves `coverage_start <= startTime`, `processed_through_event_time >= endTime`, and no persisted gap overlaps `[startTime, endTime)`.
+An exact result (`meta.coverage = "full"`, `meta.accuracy = "exact"`) is allowed only when the serialNumber checkpoint proves `coverage_start <= startTime`, `state_known_from <= startTime` (or no unproven initial gap), `processed_through_event_time >= endTime`, and no persisted gap overlaps `[startTime, endTime)`.
 
 Evaluating coverage against `coverageTargetEnd = endTime - allowedIngestionDelaySeconds` does not prove that there were no offline transitions in `[coverageTargetEnd, endTime)`. Therefore, if `processed_through_event_time < endTime` (even when `processed_through_event_time >= coverageTargetEnd`), the requested interval `[startTime, endTime)` is not fully covered up to `endTime` and must be reported as partial coverage (`meta.coverage = "partial"`, `meta.accuracy = "lower_bound"`) with the effective/observed window covered so far ending at `processed_through_event_time` (or `coverageTargetEnd`). Set `allowedIngestionDelaySeconds` to the configured maximum tolerated ingestion/source-message delay for availability queries, and return it in `meta.availabilityCoverage`.
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -1731,7 +1731,7 @@ Build stream_key values and sort samples by stream_key and timestamp ASC
     ↓
 Calculate reset-safe RX/TX deltas using effective start and end boundary samples
     ↓
-Aggregate stream-level deltas by station MAC (including only clients with in-window observations or proven session overlap)
+Aggregate stream-level deltas by station MAC (including only clients with in-window observations or proven session overlap), sort clients deterministically by raw total_bytes DESC then normalized mac ASC, and apply the 500-client limit (truncated = totalClients > 500)
     ↓
 Convert bytes to decimal megabytes
     ↓

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -139,7 +139,20 @@ All APIs in this document derive `maxLookbackHours` from the configured `monitor
 
 For a one-year monitoring configuration, `maxLookbackHours` is `365 * 24` only when the configured monitoring duration is exactly 365 days. Do not assume every calendar year is 8760 hours; use the configured duration and effective retention timestamps when validating the request.
 
-Return `400 Bad Request` with `error: "invalid_timestamp"` for invalid timestamps, unsupported timezone formats/offsets, non-positive `lookbackHours`, or values above the applicable maximum. Internally, query `timepoints.timestamp` and `wificlienthistory.timestamp` using epoch seconds.
+Return validation errors with field-specific error codes:
+
+```text
+invalid_timestamp:
+  timestampTill is missing, malformed, not UTC `Z` format, or otherwise unsupported.
+
+invalid_lookback:
+  lookbackHours is missing, non-numeric, zero, negative, or greater than maxLookbackHours.
+
+lookback_outside_retention:
+  the calculated [startTime, endTime) window is outside the configured retention window.
+```
+
+A valid timestamp with an invalid `lookbackHours` value must not return `invalid_timestamp`. Internally, query `timepoints.timestamp` and `wificlienthistory.timestamp` using epoch seconds.
 
 ### Monitoring Configuration
 
@@ -1919,11 +1932,13 @@ metadata
 
 ### Required Storage Implementation
 
-Add a dedicated storage class for availability events:
+Add dedicated storage classes for availability events and restart-safe availability state:
 
 ```text
 src/storage/storage_device_availability_events.h
 src/storage/storage_device_availability_events.cpp
+src/storage/storage_device_availability_state.h
+src/storage/storage_device_availability_state.cpp
 ```
 
 Required ORM fields and indexes:
@@ -2031,7 +2046,7 @@ src/StorageService.cpp
 
 Add a DB upgrade/migration path for the new table. Existing deployments will start with no historical availability events. Define a fixed `availabilityValidFrom` timestamp as the deployment/migration time when availability-event persistence starts. The API should return `offline_count: 0` only for successful empty queries whose requested range starts at or after `availabilityValidFrom`; do not infer old events from `lastDisconnection`.
 
-Add the files to `CMakeLists.txt`.
+Add all availability storage files to `CMakeLists.txt`, including both `storage_device_availability_events.*` and `storage_device_availability_state.*`. Register database migration/upgrade logic for both tables so fresh databases and upgraded deployments create the event table, state table, indexes, uniqueness constraints, and state constraints consistently.
 
 ### Ingestion Hook
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -58,6 +58,58 @@ Recommended query parameters:
 
 These are `GET` APIs, so no request body is required.
 
+### Internal Retrieval Categories
+
+Retrieval behavior is intrinsic to each endpoint. Do not expose a public
+`metricMode` query parameter unless the endpoint also defines separate
+mode-specific response schemas.
+
+Endpoint retrieval mapping:
+
+```text
+memory-summary:
+  dataset retrieval = all
+  response = fixed gauge aggregation schema
+
+radio-temperature-summary:
+  dataset retrieval = all
+  response = fixed gauge aggregation schema
+
+wifi-clients/usage-summary:
+  dataset retrieval = differential
+  response = calculated cumulative-counter deltas
+
+wifi-clients/rssi-summary:
+  dataset retrieval = all
+  response = fixed RSSI quality percentage aggregation schema
+
+availability-summary:
+  dataset retrieval = all_with_baseline
+  response = offline transition count
+```
+
+For `all`, retrieve every record in the requested range. For state-transition
+calculations, also retrieve the latest valid state at or before the requested
+start; this is `all_with_baseline`.
+
+For `differential`, return the change in cumulative counter values over the
+requested time range:
+
+```text
+delta = ending metric value - starting metric value
+```
+
+Use exact effective-boundary samples when available. Effective boundaries are
+the requested boundaries clipped to any proven session lifetime. Otherwise, use
+the latest available starting sample at or before the effective start and the
+earliest available ending sample at or after the effective end. Each fallback
+boundary sample must be within two times the configured telemetry sampling
+interval from the effective boundary. When fallback samples are used, the
+default response exposes the requested time range, aggregate result time window,
+usage accuracy, segment count, and fallback status. Effective boundaries and
+per-segment actual sample timestamps are included only when
+`includeCalculationDetails=true`.
+
 ### Time Conversion and Validation
 
 The public MCP-facing parameters use ISO-8601/RFC3339 time, but the existing Analytics API style uses integer `fromDate` and `endDate` timestamps. Handlers should convert the request as:
@@ -150,6 +202,35 @@ timestamp < endTime
 ```
 
 `timestampTill` is the exclusive upper bound. This prevents adjacent requests from double-counting samples or events at the shared boundary.
+
+For cumulative-counter differential summaries, exact effective-boundary samples
+are preferred. For endpoints with proven session lifetimes, effective boundaries
+are the requested boundaries clipped to the proven session start and end. For
+endpoints without session lifetimes, effective boundaries equal the requested
+boundaries. Otherwise, the handler must use the latest available sample at or
+before `effective_start` and the earliest available sample at or after
+`effective_end`, provided each fallback sample is within two times the configured
+telemetry sampling interval from the effective boundary. These fallback samples
+can fall outside `[startTime, endTime)`, so the response must expose:
+
+```text
+requestedTimeWindow.startTime = startTime
+requestedTimeWindow.endTime = endTime
+resultTimeWindow.earliestActualStartTime =
+  earliest actual starting sample used by any calculable segment contributing
+  to returned clients
+resultTimeWindow.latestActualEndTime =
+  latest actual ending sample used by any calculable segment contributing
+  to returned clients
+resultTimeWindow.boundaryFallbackUsed =
+  true when any calculable segment contributing to returned clients used a
+  fallback boundary sample
+```
+
+When no calculable usage segment exists for an observed client, the client
+response uses `segment_count: 0` instead of inventing effective or actual
+boundary timestamps. If `includeCalculationDetails=true`, that client has
+`calculation_segments: []`.
 
 Example:
 
@@ -825,7 +906,11 @@ get_device_bandwidth_consumption(
 GET /api/v1/devices/{routerId}/wifi-clients/usage-summary
     ?timestampTill=2026-07-27T12:00:00Z
     &lookbackHours=24
+    &includeCalculationDetails=false
 ```
+
+`includeCalculationDetails` is optional and defaults to `false`. Set it to
+`true` only for diagnostic calculation provenance.
 
 ## Example Request
 
@@ -842,31 +927,294 @@ None
 
 ## Response
 
+By default, usage-summary returns concise calculation quality metadata for MCP
+consumers. Segment-level provenance is verbose and is omitted unless
+`includeCalculationDetails=true` is requested.
+
 ```json
-[
-  {
-    "mac": "e2:51:95:ed:0f:28",
-    "rx_bytes": 106487500,
-    "tx_bytes": 3851250,
-    "total_bytes": 110338750,
-    "data_consume_rx": "851.9 Mb",
-    "data_consume_tx": "30.81 Mb",
-    "total_data_usage": "882.71 Mb",
-    "usage_accuracy": "exact",
-    "incomplete": false
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
   },
-  {
-    "mac": "28:39:26:a1:7c:a5",
-    "rx_bytes": 30071250,
-    "tx_bytes": 16486250,
-    "total_bytes": 46557500,
-    "data_consume_rx": "240.57 Mb",
-    "data_consume_tx": "131.89 Mb",
-    "total_data_usage": "372.46 Mb",
-    "usage_accuracy": "lower_bound",
-    "incomplete": true
-  }
-]
+  "resultTimeWindow": {
+    "earliestActualStartTime": "2026-07-26T11:55:00Z",
+    "latestActualEndTime": "2026-07-27T12:05:00Z",
+    "boundaryFallbackUsed": true
+  },
+  "items": [
+    {
+      "mac": "e2:51:95:ed:0f:28",
+      "rx_bytes": 106487500,
+      "tx_bytes": 3851250,
+      "total_bytes": 110338750,
+      "data_consume_rx": "106.49 MB",
+      "data_consume_tx": "3.85 MB",
+      "total_data_usage": "110.34 MB",
+      "usage_accuracy": "exact",
+      "incomplete": false,
+      "segment_count": 1,
+      "boundary_fallback_used": false
+    },
+    {
+      "mac": "28:39:26:a1:7c:a5",
+      "rx_bytes": 30071250,
+      "tx_bytes": 16486250,
+      "total_bytes": 46557500,
+      "data_consume_rx": "30.07 MB",
+      "data_consume_tx": "16.49 MB",
+      "total_data_usage": "46.56 MB",
+      "usage_accuracy": "bounded_interval",
+      "incomplete": false,
+      "segment_count": 1,
+      "boundary_fallback_used": true
+    },
+    {
+      "mac": "54:6c:0e:44:11:09",
+      "rx_bytes": 4200000,
+      "tx_bytes": 600000,
+      "total_bytes": 4800000,
+      "data_consume_rx": "4.20 MB",
+      "data_consume_tx": "0.60 MB",
+      "total_data_usage": "4.80 MB",
+      "usage_accuracy": "exact",
+      "incomplete": false,
+      "segment_count": 2,
+      "boundary_fallback_used": false
+    }
+  ],
+  "totalClients": 3,
+  "truncated": false
+}
+```
+
+`resultTimeWindow` is aggregate response metadata:
+
+```text
+earliestActualStartTime =
+  minimum actual_start_time among the server's internal calculable segments
+  contributing to returned clients
+
+latestActualEndTime =
+  maximum actual_end_time among the server's internal calculable segments
+  contributing to returned clients
+
+boundaryFallbackUsed =
+  true when any internal calculable segment contributing to returned clients
+  used a fallback boundary sample
+```
+
+It describes only the overall result envelope. It does not mean every client or
+segment used the entire envelope, and it is identical whether or not
+`includeCalculationDetails` is enabled.
+
+When no clients are returned:
+
+```json
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
+  },
+  "resultTimeWindow": {
+    "earliestActualStartTime": null,
+    "latestActualEndTime": null,
+    "boundaryFallbackUsed": false
+  },
+  "items": [],
+  "totalClients": 0,
+  "truncated": false
+}
+```
+
+When a client is observed but no usage interval can be calculated, such as when
+only one cumulative-counter sample exists in or bounding the requested range,
+return the safely provable minimum with `segment_count: 0`:
+
+```json
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-08-05T12:00:00Z",
+    "endTime": "2026-08-05T13:00:00Z"
+  },
+  "resultTimeWindow": {
+    "earliestActualStartTime": null,
+    "latestActualEndTime": null,
+    "boundaryFallbackUsed": false
+  },
+  "items": [
+    {
+      "mac": "e2:51:95:ed:0f:28",
+      "rx_bytes": 0,
+      "tx_bytes": 0,
+      "total_bytes": 0,
+      "data_consume_rx": "0.00 MB",
+      "data_consume_tx": "0.00 MB",
+      "total_data_usage": "0.00 MB",
+      "usage_accuracy": "lower_bound",
+      "incomplete": true,
+      "segment_count": 0,
+      "boundary_fallback_used": false
+    }
+  ],
+  "totalClients": 1,
+  "truncated": false
+}
+```
+
+## Calculation Details
+
+Use `includeCalculationDetails=true` only for diagnostics, troubleshooting, or
+calculation provenance. Ordinary MCP decisions should use `usage_accuracy`,
+`segment_count`, `boundary_fallback_used`, and the aggregate `resultTimeWindow`.
+
+```http
+GET /api/v1/devices/60cf84f22290/wifi-clients/usage-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24&includeCalculationDetails=true
+Authorization: Bearer <token>
+```
+
+When details are enabled, every returned calculation segment has non-null
+`actual_start_time` and `actual_end_time`. `stream_id` and `segment_id` are
+opaque identifiers scoped to the response. Clients must not persist them,
+compare them across requests, parse them, or depend on their format; the
+examples below are illustrative only. If no differential can be calculated, the
+client still has `segment_count: 0` and
+`calculation_segments: []`.
+
+Detailed response invariants:
+
+```text
+client.rx_bytes == SUM(calculation_segments[].rx_bytes)
+client.tx_bytes == SUM(calculation_segments[].tx_bytes)
+client.total_bytes == SUM(calculation_segments[].total_bytes)
+client.segment_count == calculation_segments.length
+client.boundary_fallback_used ==
+  true when any calculation segment has boundary_fallback_used = true
+```
+
+Example detailed response for the same calculated result:
+
+```json
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
+  },
+  "resultTimeWindow": {
+    "earliestActualStartTime": "2026-07-26T11:55:00Z",
+    "latestActualEndTime": "2026-07-27T12:05:00Z",
+    "boundaryFallbackUsed": true
+  },
+  "items": [
+    {
+      "mac": "e2:51:95:ed:0f:28",
+      "rx_bytes": 106487500,
+      "tx_bytes": 3851250,
+      "total_bytes": 110338750,
+      "data_consume_rx": "106.49 MB",
+      "data_consume_tx": "3.85 MB",
+      "total_data_usage": "110.34 MB",
+      "usage_accuracy": "exact",
+      "incomplete": false,
+      "segment_count": 1,
+      "boundary_fallback_used": false,
+      "calculation_segments": [
+        {
+          "stream_id": "e2:51:95:ed:0f:28|bssid=18:34:af:01:02:03|ssid=Corp|band=5G",
+          "segment_id": "e2:51:95:ed:0f:28|session=42|segment=0",
+          "segment_start_reason": "window_start",
+          "segment_end_reason": "window_end",
+          "effective_start_time": "2026-07-26T12:00:00Z",
+          "effective_end_time": "2026-07-27T12:00:00Z",
+          "actual_start_time": "2026-07-26T12:00:00Z",
+          "actual_end_time": "2026-07-27T12:00:00Z",
+          "boundary_fallback_used": false,
+          "accuracy": "exact",
+          "rx_bytes": 106487500,
+          "tx_bytes": 3851250,
+          "total_bytes": 110338750
+        }
+      ]
+    },
+    {
+      "mac": "28:39:26:a1:7c:a5",
+      "rx_bytes": 30071250,
+      "tx_bytes": 16486250,
+      "total_bytes": 46557500,
+      "data_consume_rx": "30.07 MB",
+      "data_consume_tx": "16.49 MB",
+      "total_data_usage": "46.56 MB",
+      "usage_accuracy": "bounded_interval",
+      "incomplete": false,
+      "segment_count": 1,
+      "boundary_fallback_used": true,
+      "calculation_segments": [
+        {
+          "stream_id": "28:39:26:a1:7c:a5|bssid=18:34:af:04:05:06|ssid=Corp|band=5G",
+          "segment_id": "28:39:26:a1:7c:a5|session=99|segment=0",
+          "segment_start_reason": "window_start",
+          "segment_end_reason": "window_end",
+          "effective_start_time": "2026-07-26T12:00:00Z",
+          "effective_end_time": "2026-07-27T12:00:00Z",
+          "actual_start_time": "2026-07-26T11:55:00Z",
+          "actual_end_time": "2026-07-27T12:05:00Z",
+          "boundary_fallback_used": true,
+          "accuracy": "bounded_interval",
+          "rx_bytes": 30071250,
+          "tx_bytes": 16486250,
+          "total_bytes": 46557500
+        }
+      ]
+    },
+    {
+      "mac": "54:6c:0e:44:11:09",
+      "rx_bytes": 4200000,
+      "tx_bytes": 600000,
+      "total_bytes": 4800000,
+      "data_consume_rx": "4.20 MB",
+      "data_consume_tx": "0.60 MB",
+      "total_data_usage": "4.80 MB",
+      "usage_accuracy": "exact",
+      "incomplete": false,
+      "segment_count": 2,
+      "boundary_fallback_used": false,
+      "calculation_segments": [
+        {
+          "stream_id": "54:6c:0e:44:11:09|bssid=18:34:af:07:08:09|ssid=Corp|band=5G",
+          "segment_id": "54:6c:0e:44:11:09|session=10|segment=0",
+          "segment_start_reason": "window_start",
+          "segment_end_reason": "session_end",
+          "effective_start_time": "2026-07-26T12:00:00Z",
+          "effective_end_time": "2026-07-26T18:30:00Z",
+          "actual_start_time": "2026-07-26T12:00:00Z",
+          "actual_end_time": "2026-07-26T18:30:00Z",
+          "boundary_fallback_used": false,
+          "accuracy": "exact",
+          "rx_bytes": 1800000,
+          "tx_bytes": 250000,
+          "total_bytes": 2050000
+        },
+        {
+          "stream_id": "54:6c:0e:44:11:09|bssid=18:34:af:07:08:09|ssid=Corp|band=5G",
+          "segment_id": "54:6c:0e:44:11:09|session=11|segment=0",
+          "segment_start_reason": "session_start",
+          "segment_end_reason": "window_end",
+          "effective_start_time": "2026-07-26T19:00:00Z",
+          "effective_end_time": "2026-07-27T12:00:00Z",
+          "actual_start_time": "2026-07-26T19:00:00Z",
+          "actual_end_time": "2026-07-27T12:00:00Z",
+          "boundary_fallback_used": false,
+          "accuracy": "exact",
+          "rx_bytes": 2400000,
+          "tx_bytes": 350000,
+          "total_bytes": 2750000
+        }
+      ]
+    }
+  ],
+  "totalClients": 3,
+  "truncated": false
+}
 ```
 
 ## API Logic
@@ -902,62 +1250,164 @@ The values are cumulative counters, so they must not be summed directly.
 ### Correct Calculation
 
 ```text
+For an uninterrupted stream:
+  delta = ending metric value - starting metric value
+
+For confirmed rollover:
+  apply known-width rollover arithmetic
+
+For confirmed independent session split/reset:
+  calculate each proven session segment separately
+  sum segment differentials
+
+For ambiguous reset/session split:
+  calculate only safely observed nonnegative segment deltas
+  mark the stream lower_bound
+
 stream_key = association/session id when available, otherwise:
   station MAC
   BSSID
   SSID
   band/radio when present
 
-baseline = last sample before start_time for the same stream_key, if available
+requested_start = startTime
+requested_end = endTime
 
-first in-window delta:
-  if baseline exists:
-    counterDelta(first.rx_bytes, baseline.rx_bytes)
-    counterDelta(first.tx_bytes, baseline.tx_bytes)
-  else if this is a confirmed new association/session that began within the window:
-    first.rx_bytes
-    first.tx_bytes
-  else:
-    0
+effective boundaries:
+  effective_start = max(requested_start, proven_session_start)
+  effective_end = min(requested_end, proven_session_end)
 
-subsequent deltas:
-  counterDelta(current.rx_bytes, previous.rx_bytes)
-  counterDelta(current.tx_bytes, previous.tx_bytes)
+start_sample:
+  exact sample at effective_start, if available
+  otherwise latest available sample at or before effective_start
 
-data_consume_rx = SUM(reset-safe rx_bytes deltas)
-data_consume_tx = SUM(reset-safe tx_bytes deltas)
+end_sample:
+  exact sample at effective_end, if available
+  otherwise earliest available sample at or after effective_end
+
+boundary tolerance:
+  abs(effective_start - actual_start_time) <= 2 * expected_collection_interval
+  abs(actual_end_time - effective_end) <= 2 * expected_collection_interval
+
+actual_start_time = start_sample.timestamp
+actual_end_time = end_sample.timestamp
+boundary_fallback_used =
+  actual_start_time != effective_start ||
+  actual_end_time != effective_end
+
+uninterrupted segment differential:
+  counterDelta(end_sample.rx_bytes, start_sample.rx_bytes)
+  counterDelta(end_sample.tx_bytes, start_sample.tx_bytes)
+
+samples between start_sample and end_sample:
+  use to detect counter resets, confirmed rollovers, duplicate or
+  out-of-order telemetry, missing-sample gaps, and session boundaries
+  do not sum raw cumulative values as usage
+  do sum proven segment deltas when resets or session splits are confirmed
+
+data_consume_rx = SUM(stream rx_bytes segment differentials or lower-bound deltas)
+data_consume_tx = SUM(stream tx_bytes segment differentials or lower-bound deltas)
 total_data_usage = data_consume_rx + data_consume_tx
 
-usage_accuracy = exact when no contributing stream is incomplete, otherwise lower_bound
+stream accuracy =
+  exact when the segment has authoritative counter evidence at effective_start
+    and effective_end, and every internal sub-segment is fully proven
+  bounded_interval when the segment uses immediate fallback samples within
+    tolerance and every internal sub-segment is fully proven
+  lower_bound when the stream lacks a usable boundary pair, exceeds boundary
+    tolerance, has an ambiguous reset/session change, or only has partially
+    observed segments
+
+client usage_accuracy precedence =
+  lower_bound if any contributing stream is lower_bound
+  otherwise bounded_interval if any contributing stream is bounded_interval
+  otherwise exact
+
 incomplete = true when usage_accuracy is lower_bound
 ```
 
-Calculate counter deltas independently for RX and TX per `stream_key`. After stream-level deltas are calculated, aggregate the resulting RX/TX deltas by station MAC for the response. If any stream contributing to a station MAC is incomplete/estimated, that station's usage is incomplete/estimated.
+Calculate counter deltas independently for RX and TX per `stream_key` and
+internal calculable segment. After segment deltas are calculated, aggregate the
+resulting RX/TX deltas by station MAC for the response. Client `rx_bytes` and
+`tx_bytes` must equal the sum of internal segment RX/TX deltas; each internal
+segment's `total_bytes` must equal its `rx_bytes + tx_bytes`. The default
+response exposes `segment_count` and `boundary_fallback_used` instead of the
+segment objects. When `includeCalculationDetails=true`, the detailed
+`calculation_segments[]` array must satisfy the same byte-sum invariants. If
+any segment contributing to a station MAC is lower_bound, that station's usage
+is lower_bound.
 
 Usage accuracy contract:
 
 ```text
-Returned usage is exact only when every stream has enough information to account
-for the requested window:
-  a pre-window baseline exists for an ongoing stream, or
-  the stream is confirmed to have begun within the requested window, or
-  any counter rollover is confirmed and handled with rollover arithmetic.
+Returned usage is exact only when every contributing segment has enough
+information to account for its overlap with the requested window:
+  effective_start = max(requested_start, proven_session_start), and
+  effective_end = min(requested_end, proven_session_end), and
+  authoritative counter evidence exists exactly at effective_start and
+  effective_end, and any counter rollover is confirmed and handled with
+  rollover arithmetic.
 
-When a stream lacks a pre-window baseline, has no reliable session/association
-start, or has an ambiguous counter decrease, the returned usage is a lower-bound
-estimate. The algorithm must avoid overcounting unknown traffic, so it adds zero
-for ambiguous intervals and treats the result as incomplete/estimated.
+Returned usage is bounded_interval when exact boundary samples are unavailable but
+the latest available starting sample at or before `effective_start` and the
+earliest available ending sample at or after `effective_end` are available
+within two times the configured telemetry sampling interval, and no reset or gap
+prevents the segment differential from being calculated. The response must
+include requested timestamps and aggregate actual sample timestamps. When
+`includeCalculationDetails=true`, it must also include the effective and actual
+timestamps for each returned segment. This is usage over an interval containing
+the segment's overlap with the requested interval; when counters are monotonic
+and uninterrupted, the returned value is greater than or equal to usage in that
+overlap.
 
-The response must expose `usage_accuracy` per client:
+When a stream lacks a usable bounding sample pair or has an ambiguous counter
+decrease/session change, or when either fallback boundary exceeds tolerance, the
+returned usage is a lower-bound estimate. The algorithm must avoid overcounting
+unknown traffic, so it adds only safely provable nonnegative consecutive segment
+deltas inside the requested range and treats the result as incomplete/estimated.
+If no positive interval can be safely proven, return 0 bytes for that stream with
+`lower_bound`. Include a client in the response when it has at least one
+qualifying sample in or bounding the requested interval, even if the safely
+provable lower-bound delta is 0. If no differential segment can be calculated
+for that client, return `segment_count: 0` and `boundary_fallback_used: false`;
+do not create a segment with fabricated effective or actual boundary timestamps.
+If details are enabled, return `calculation_segments: []` for that client.
+
+The response must expose `usage_accuracy`, `segment_count`, and
+`boundary_fallback_used` per client:
   exact: all contributing streams are fully accounted for
+  bounded_interval: at least one contributing segment used fallback samples
+    within tolerance that bound the requested range
   lower_bound: at least one contributing stream used a conservative zero delta
-    for an ambiguous interval or missing baseline
+    for an ambiguous interval, missing usable boundary pair, or out-of-tolerance
+    boundary
 
 When `usage_accuracy` is `lower_bound`, the reported byte and formatted usage
 values are the safely observed minimum. Actual usage may be higher.
 ```
 
-A fixed-width rollover is confirmed only when the counter width is known for that source and the observed decrease is consistent with a rollover for that counter. If the counter width is unknown, or the decrease could also be a reset/reconnect/stale sample, treat it as ambiguous.
+Differential response decision table:
+
+| Condition | Result |
+|---|---|
+| Exact effective start and effective end counter evidence exists, no reset/session ambiguity | `exact` differential |
+| Fallback start and end samples bound the effective segment range and both are within `2 * expected_collection_interval`, no reset/session ambiguity | `bounded_interval` differential |
+| Session starts inside the requested window with proven zero/session baseline and authoritative end evidence | `exact` if effective boundaries are fully proven |
+| Session ends inside the requested window with authoritative start and proven session-end evidence | `exact` if effective boundaries are fully proven |
+| Start sample missing and session start inside the requested window is confirmed but complete effective-boundary evidence is unavailable | sum safely provable nonnegative segment deltas; `lower_bound` |
+| Start sample missing and session origin is unknown | `lower_bound` |
+| End sample missing | sum safely provable nonnegative consecutive segment deltas through the latest usable sample; `lower_bound` |
+| Both boundary samples missing | sum safely provable nonnegative consecutive segment deltas inside the requested range; `lower_bound` |
+| Only one in-window sample exists | return 0 bytes, `lower_bound`, `segment_count: 0`, and `boundary_fallback_used: false`; if details are enabled, return `calculation_segments: []` |
+| Client appears during the window without reliable session-start proof | sum safely provable post-appearance segment deltas only; `lower_bound` |
+| Client disappears before the end boundary | sum safely provable segment deltas through the last usable sample; `lower_bound` |
+| Client reconnects and counters reset | split only when session identity proves independent streams; otherwise `lower_bound` |
+| Multiple sessions for the same MAC | calculate per proven session stream, then aggregate by MAC; mark client `lower_bound` if any contributing stream is incomplete |
+| Ambiguous counter reset, stale sample, duplicate conflict, or out-of-order telemetry | `lower_bound` |
+
+A fixed-width rollover is confirmed only when the counter width is known for that source, the observed decrease is consistent with a rollover for that counter, and the maximum possible counter increase during the observation gap cannot exceed one full counter range. If the counter width is unknown, if multiple wraps may have occurred, or if the decrease could also be a reset/reconnect/stale sample, treat it as ambiguous and return `lower_bound`.
+
+If the expected collection interval is missing, zero, invalid, or cannot be resolved reliably for the requested retention period, fallback boundary samples cannot qualify as `bounded_interval`; exact boundary samples are required to avoid `lower_bound`.
 
 ### Reset-Safe Delta Logic
 
@@ -969,28 +1419,27 @@ struct CounterDeltaResult {
 
 CounterDeltaResult counterDelta(uint64_t current,
                                 uint64_t previous,
-                                bool confirmedNewSession,
-                                bool newSessionStartedInWindow,
                                 bool confirmedFixedWidthRollover,
+                                bool singleRolloverBoundProven,
                                 uint64_t counterMax) {
     if (current >= previous) {
         return {current - previous, false};
     }
 
-    if (confirmedNewSession) {
-        if (newSessionStartedInWindow) {
-            return {current, false};
-        }
-        return {0, true};
-    }
-
-    if (confirmedFixedWidthRollover) {
+    if (confirmedFixedWidthRollover && singleRolloverBoundProven) {
         return {(counterMax - previous) + current + 1, false};
     }
 
     return {0, true};
 }
 ```
+
+Session starts are handled by segment construction, not by blindly adding the
+current counter on every decrease. When reliable session evidence proves a new
+session started inside the requested window, use that session's first valid
+counter sample as the segment baseline and sum only subsequent proven segment
+deltas. If there is no subsequent usable sample, that segment contributes 0 with
+`lower_bound`.
 
 Do not treat every lower counter as a reset where `current` should be added. A lower value can mean a new association session, movement between radios/BSSIDs, stale or out-of-order telemetry, duplicate station records inside one timepoint, or counter-width rollover. Adding `current` on every decrease can overcount traffic by attributing unknown pre-window traffic to the requested window.
 
@@ -1021,18 +1470,31 @@ When no session identifier is available:
 If current < previous:
   if a new association/session is confirmed:
     if the new session start time is within [startTime, endTime):
-      add current as post-session-start traffic
+      close the previous segment at the last pre-reset sample
+      start a new segment with current as its baseline
+      add only subsequent proven nonnegative deltas for the new segment
+      mark the stream lower_bound unless both session segments can be fully proven
     else:
       treat current as the new baseline, add delta 0, and mark the result
       incomplete/estimated
-  else if fixed-width rollover is known and can be confirmed:
+  else if fixed-width rollover is known, one-wrap bound is proven, and can be confirmed:
     apply rollover math
   else:
     treat current as the new baseline, add delta 0, and mark the result
     incomplete/estimated
 ```
 
-Without the pre-window baseline for the same calculated stream, the first sample inside the requested window can include traffic that occurred before `start_time`. Do not add the first in-window cumulative counter directly unless it is known to be a fresh association/session that started inside the requested window. If the stream may have started before `start_time`, add zero for the first sample and mark the result incomplete/estimated.
+For usage differential calculation, choose the start and end samples first, then
+calculate the boundary differential for each segment. Exact usage requires
+authoritative counter evidence exactly at each segment's `effective_start` and
+`effective_end`, where effective boundaries are clipped to proven session
+lifetime and the requested window. If fallback samples within tolerance are used,
+classify the result as `bounded_interval`. The default response exposes the
+requested time window, aggregate result time window, and fallback summary
+fields. When `includeCalculationDetails=true`, each returned segment
+additionally exposes its effective and actual boundary timestamps. Do not add a
+cumulative counter directly unless it is known to represent traffic that started inside the
+segment's effective interval.
 
 A new association/session is confirmed only when the source provides reliable session identity or timing evidence. For example, a session id change, association id change, or connected-duration reset may prove a new session if it also proves the session start time is within the requested window. BSSID, SSID, band, or radio changes define separate calculation streams, but they do not by themselves prove that the new cumulative counter started inside the requested window.
 
@@ -1082,23 +1544,23 @@ A client moving between BSSIDs should remain one client in the final response un
 The MCP output expects strings such as:
 
 ```text
-851.9 Mb
-30.81 Mb
+106.49 MB
+3.85 MB
 ```
 
 Recommended conversion:
 
 ```cpp
-double rxMb = static_cast<double>(rxBytes) * 8.0 / 1000000.0;
-double txMb = static_cast<double>(txBytes) * 8.0 / 1000000.0;
+double rxMB = static_cast<double>(rxBytes) / 1000000.0;
+double txMB = static_cast<double>(txBytes) / 1000000.0;
 ```
 
-`Mb` means megabits. If the implementation divides bytes by `1024 * 1024`, label the result as `MiB` or `MB` instead.
+`MB` means decimal megabytes. If the implementation divides bytes by `1024 * 1024`, label the result as `MiB` instead.
 
 Formatting:
 
 ```cpp
-fmt::format("{:.2f} Mb", value);
+fmt::format("{:.2f} MB", value);
 ```
 
 ### Query Flow
@@ -1120,9 +1582,10 @@ Calculate reset-safe RX/TX deltas
     ↓
 Aggregate stream-level deltas by station MAC
     ↓
-Convert bytes to megabits
+Convert bytes to decimal megabytes
     ↓
-Return array
+Return wrapped response with requestedTimeWindow, resultTimeWindow, items,
+totalClients, and truncated
 ```
 
 ---
@@ -1163,24 +1626,70 @@ None
 ## Response
 
 ```json
-[
-  {
-    "mac": "e2:51:95:ed:0f:28",
-    "rssi_excellent_pct": 41.67,
-    "rssi_good_pct": 50.0,
-    "rssi_fair_pct": 1.67,
-    "rssi_poor_pct": 6.67,
-    "rssi_total_samples": 60
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
   },
-  {
-    "mac": "28:39:26:a1:7c:a5",
-    "rssi_excellent_pct": 92.73,
-    "rssi_good_pct": 7.27,
-    "rssi_fair_pct": 0.0,
-    "rssi_poor_pct": 0.0,
-    "rssi_total_samples": 110
-  }
-]
+  "resultTimeWindow": {
+    "firstSampleTime": "2026-07-26T12:01:00Z",
+    "lastSampleTime": "2026-07-27T11:58:00Z",
+    "totalSamples": 170
+  },
+  "items": [
+    {
+      "mac": "e2:51:95:ed:0f:28",
+      "rssi_excellent_pct": 41.67,
+      "rssi_good_pct": 50.0,
+      "rssi_fair_pct": 1.67,
+      "rssi_poor_pct": 6.67,
+      "rssi_total_samples": 60
+    },
+    {
+      "mac": "28:39:26:a1:7c:a5",
+      "rssi_excellent_pct": 92.73,
+      "rssi_good_pct": 7.27,
+      "rssi_fair_pct": 0.0,
+      "rssi_poor_pct": 0.0,
+      "rssi_total_samples": 110
+    }
+  ],
+  "totalClients": 2,
+  "truncated": false
+}
+```
+
+`resultTimeWindow` for RSSI is scoped to returned `items[]` after applying the
+500-client response limit:
+
+```text
+firstSampleTime =
+  earliest valid RSSI sample contributing to items[]
+
+lastSampleTime =
+  latest valid RSSI sample contributing to items[]
+
+totalSamples =
+  SUM(items[].rssi_total_samples)
+```
+
+For empty RSSI results:
+
+```json
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
+  },
+  "resultTimeWindow": {
+    "firstSampleTime": null,
+    "lastSampleTime": null,
+    "totalSamples": 0
+  },
+  "items": [],
+  "totalClients": 0,
+  "truncated": false
+}
 ```
 
 ## API Logic
@@ -1972,7 +2481,7 @@ bool GetGatewayAvailabilitySummary(...);
 |---|---|---|---|
 | `get_gateway_free_memory` | `GET /devices/{routerId}/memory-summary` | `timepoints.resource_data.memory_free` | Resolve routerId to venueId and boardId, then aggregate `timepoints` |
 | `get_gateway_wifi_temp` | `GET /devices/{routerId}/radio-temperature-summary` | `timepoints.radio_data[].wifi_temp` | Resolve routerId to venueId and boardId, then aggregate present Wi-Fi temperature samples from `timepoints` |
-| `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then reset-safe delta aggregation with pre-window baseline |
+| `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then calculate reset-safe cumulative-counter differentials with concise quality metadata by default; include segment provenance only when `includeCalculationDetails=true` |
 | `get_device_rssi_quality` | `GET /devices/{routerId}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve routerId to venueId and boardId, then classify RSSI samples |
 | `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic plus `device_availability_events` | Use routerId as durable serialNumber, persist restart-safe state transitions, then count offline events by serialNumber |
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -42,12 +42,29 @@ serialNumber = routerId
 
 Public `routerId` validation requires a path-safe string: 1 to 64 alphanumeric characters, hyphens, or underscores (matching `^[a-zA-Z0-9_-]+$`). Syntax validation intentionally rejects path dot-segments such as `.` and `..`, path separators (`/`, `\`), spaces, control characters, and URL-encoded path separators (`%2F`) before OWPROV ownership resolution. Any path-safe serial format (whether hexadecimal or non-hex serial string) passes syntax validation and is sent to OWPROV, letting OWPROV serve as the authoritative entity for verifying serial existence.
 
-The Analytics API should calculate the requested time range as:
+The Analytics API calculates the requested time range using checked 64-bit signed epoch arithmetic:
 
 ```text
 end_time = parse(timestamp_till)
 start_time = end_time - (lookback_hours * 3600)
 ```
+
+Validation & Processing Order:
+
+All REST handlers must enforce request validation in three distinct sequential phases:
+
+1. **Phase 1: Pure Request Parsing & Input Validation (No DB or I/O lookups)**
+   - Validate `routerId` syntax (1–64 characters matching `^[a-zA-Z0-9_-]+$`) -> HTTP `400 invalid_router_id` if malformed.
+   - Inspect raw query collection for exact-once presence of `timestampTill` and `lookbackHours` -> HTTP `400 invalid_timestamp` / `invalid_lookback_hours` if missing or repeated.
+   - Parse `timestampTill` shape & UTC semantics -> HTTP `400 invalid_timestamp` if malformed or invalid date/time.
+   - Parse `lookbackHours` strict positive integer -> HTTP `400 invalid_lookback_hours` if zero, negative, or non-numeric.
+   - Checked epoch calculation: Compute `start_time = end_time - (lookback_hours * 3600)` using signed 64-bit integers. Verify `start_time >= 0` (minimum supported Unix epoch `1970-01-01T00:00:00Z`) -> HTTP `400 invalid_timestamp` if underflowing before epoch.
+
+2. **Phase 2: Router Ownership & Serial Resolution**
+   - Resolve `routerId` to `boardId` via local cache / OWPROV -> HTTP `404 not_found` if router serial does not exist in OWPROV.
+
+3. **Phase 3: Domain Cutover & Range Validation**
+   - Verify `start_time` against service cutover thresholds (`availabilityValidFrom`, `temperatureMigrationCutoverTime`, `maxLookbackHours`) -> HTTP `400 availability_range_before_cutover` / `temperature_range_before_cutover` if before cutover.
 
 Example:
 
@@ -1580,13 +1597,15 @@ Independent Directional Counter Rules (RX vs TX):
 1. RX and TX counters are calculated independently per stream.
 2. If RX is present and valid but TX is missing, non-numeric, negative (< 0), or uncalculable:
    - RX bytes are calculated normally and included in data_consume_rx.
-   - TX bytes return 0 (or null in raw segment details) and formatted "0.00 MB".
+   - TX bytes return 0 as a required non-null integer in calculation_segments (and formatted "0.00 MB" in summary strings).
+   - Total segment bytes total_bytes = rx_bytes + 0 = rx_bytes.
    - The stream accuracy is classified as lower_bound.
 3. If TX is present and valid but RX is missing/invalid:
    - TX bytes are calculated normally and included in data_consume_tx.
-   - RX bytes return 0 and formatted "0.00 MB".
+   - RX bytes return 0 as a required non-null integer in calculation_segments (and formatted "0.00 MB" in summary strings).
+   - Total segment bytes total_bytes = 0 + tx_bytes = tx_bytes.
    - The stream accuracy is classified as lower_bound.
-4. If a boundary sample has RX but not TX (or vice versa), the missing direction cannot form a calculable boundary delta; that direction is marked uncalculable (lower_bound).
+4. If a boundary sample has RX but not TX (or vice versa), the missing direction cannot form a calculable boundary delta; that direction returns 0 bytes and is marked uncalculable (lower_bound).
 5. segment_count is incremented if at least one direction (RX or TX) produces a valid calculable segment delta.
 6. A client MAC is included in totalClients and items[] if it has proven in-window presence or session overlap, regardless of whether one counter direction was missing or uncalculable.
 
@@ -1958,7 +1977,7 @@ None
     },
     "sourceWindow": {
       "firstSampleAt": "2026-07-26T11:55:00Z",
-      "lastSampleAt": "2026-07-27T09:45:00Z"
+      "lastSampleAt": "2026-07-27T12:00:00Z"
     },
     "contributingWindow": {
       "firstSampleAt": "2026-07-26T13:15:00Z",
@@ -1967,12 +1986,6 @@ None
     "selection": "boundary_assisted",
     "coverage": "full",
     "accuracy": "exact",
-    "coverageStart": "2026-07-26T11:55:00Z",
-    "stateKnownFrom": "2026-07-26T11:55:00Z",
-    "processedThrough": "2026-07-27T12:00:00Z",
-    "allowedIngestionDelaySeconds": 0,
-    "ingestionGapKnown": false,
-    "proofSource": "checkpoint",
     "sampleCount": 6,
     "offlineEventCount": 6,
     "effectiveSamplingIntervalSeconds": 0,
@@ -1984,9 +1997,10 @@ None
       "afterEnd": false
     },
     "availabilityCoverage": {
-      "coverageStart": "2026-07-20T00:00:00Z",
-      "processedThrough": "2026-07-27T12:01:00Z",
-      "allowedIngestionDelaySeconds": 60,
+      "coverageStart": "2026-07-26T11:55:00Z",
+      "stateKnownFrom": "2026-07-26T11:55:00Z",
+      "processedThrough": "2026-07-27T12:00:00Z",
+      "allowedIngestionDelaySeconds": 0,
       "ingestionGapKnown": false,
       "proofSource": "serial_partition_checkpoint"
     }
@@ -2753,6 +2767,7 @@ Use an HTTP error:
     },
     "availabilityCoverage": {
       "coverageStart": "2026-07-20T00:00:00Z",
+      "stateKnownFrom": "2026-07-20T00:00:00Z",
       "processedThrough": "2026-07-27T12:01:00Z",
       "allowedIngestionDelaySeconds": 60,
       "ingestionGapKnown": false,

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -1342,10 +1342,6 @@ effective boundaries:
   effective_start = max(requested_start, proven_session_start)
   effective_end = min(requested_end, proven_session_end)
 
-effective boundaries:
-  effective_start = max(requested_start, proven_session_start)
-  effective_end = min(requested_end, proven_session_end)
-
 start_sample:
   exact sample at effective_start, if available
   otherwise latest available sample at or before effective_start
@@ -1917,6 +1913,7 @@ None
     "coverage": "full",
     "accuracy": "exact",
     "sampleCount": 6,
+    "offlineEventCount": 6,
     "effectiveSamplingIntervalSeconds": 0,
     "allowedGapSeconds": 0,
     "boundarySamplesUsed": {
@@ -2003,6 +2000,7 @@ Fields:
   serialNumber    TEXT
   event_type      TEXT
   event_time      BIGINT
+  source_sequence TEXT NULL
   reason          TEXT
   connection_ip   TEXT
   session_id      TEXT
@@ -2014,11 +2012,13 @@ Indexes:
   availability_serial_time_index:
     serialNumber ASC
     event_time ASC
+    source_sequence ASC
 
   availability_board_serial_time_index:
     board_id ASC
     serialNumber ASC
     event_time ASC
+    source_sequence ASC
 
 Unique constraints:
   availability_idempotency_key_unique:
@@ -2042,6 +2042,7 @@ serialNumber
 board_id
 current_state
 last_event_time
+last_source_sequence
 last_idempotency_key
 updated_at
 metadata
@@ -2055,6 +2056,7 @@ Fields:
   board_id             TEXT NULL
   current_state        TEXT
   last_event_time      BIGINT
+  last_source_sequence TEXT NULL
   last_idempotency_key TEXT
   updated_at           BIGINT
   metadata             TEXT
@@ -2067,9 +2069,9 @@ Constraints:
   current_state must be one of: online, offline, unknown
 ```
 
-`device_availability_events` stores only online/offline transition history. `device_availability_state` stores the authoritative current state and the latest accepted source availability event time.
+`device_availability_events` stores only online/offline transition history. `device_availability_state` stores the authoritative current state and the latest accepted source availability ordering key.
 
-`last_event_time` is the source-event ordering watermark after events have passed the required per-serial ordering mechanism. It must be populated from the normalized Kafka source timestamp (`event_time`) and used for stale detection only after Analytics has established that no older transition for the same serialNumber can still be accepted. `DeviceInfo.lastContact` may remain local contact or processing metadata, but it must not be used to order source events because Kafka delivery can be delayed.
+`last_event_time` and `last_source_sequence` form the persisted source ordering key after events have passed the required per-serial ordering mechanism. `last_event_time` must be populated from the normalized Kafka source timestamp (`event_time`), and `last_source_sequence` must be populated from a reliable source sequence, source offset within the producing system, or another deterministic source-provided ordering value when one exists. The composite key is used for stale detection only after Analytics has established that no older transition for the same serialNumber can still be accepted. `DeviceInfo.lastContact` may remain local contact or processing metadata, but it must not be used to order source events because Kafka delivery can be delayed.
 
 Add persisted ingestion coverage tables for availability exactness:
 
@@ -2097,11 +2099,26 @@ detected_at
 metadata
 ```
 
-`processed_through_event_time` is a source-event-time watermark, not a Kafka processing-time or `DeviceInfo.lastContact` value. Kafka topic, partition, and offset are stored only as proof metadata. An exact zero is allowed only when the serialNumber checkpoint proves `coverage_start <= startTime`, `processed_through_event_time >= endTime`, and no persisted gap overlaps the requested range.
+`processed_through_event_time` is a source-event-time watermark, not a Kafka processing-time or `DeviceInfo.lastContact` value. Kafka topic, partition, and offset are stored only as proof metadata.
+
+For availability coverage decisions, compute:
+
+```text
+coverageTargetEnd = endTime - allowedIngestionDelaySeconds
+```
+
+An exact result is allowed only when the serialNumber checkpoint proves
+`coverage_start <= startTime`, `processed_through_event_time >=
+coverageTargetEnd`, and no persisted gap overlaps `[startTime,
+coverageTargetEnd)`. This permits healthy near-real-time requests whose most
+recent gateway message is slightly before `endTime`, while still surfacing
+stale ingestion as partial coverage. Set `allowedIngestionDelaySeconds` to the
+configured maximum tolerated ingestion/source-message delay for availability
+queries, and return it in `meta.availabilityCoverage`.
 
 The checkpoint must be advanced durably with event processing. For a message that changes availability state or updates same-state metadata, the state update, optional transition insert, and checkpoint update must commit in one database transaction before the corresponding Kafka offset is committed. Rebalances and restarts must reload the checkpoint and any persisted reorder-buffer state needed by the selected ordering strategy. If the implementation cannot prove continuity after a restart, rebalance, topic retention truncation, skipped unparseable connection message, reorder-window overflow, or offset discontinuity, it must persist an ingestion gap and stop returning exact coverage for overlapping ranges.
 
-When one serialNumber has no recent messages, do not infer coverage from an empty event table. The API may return an exact zero only if that serialNumber has a durable checkpoint whose `processed_through_event_time` reaches the requested `endTime`; otherwise the result is partial/lower-bound or unavailable according to the coverage rules.
+When one serialNumber has no recent messages, do not infer coverage from an empty event table. The API may return an exact zero only if that serialNumber has a durable checkpoint whose `processed_through_event_time` reaches `coverageTargetEnd`; otherwise the result is partial/lower-bound or unavailable according to the coverage rules. A partition-level or source-level watermark may be used instead of per-message checkpoint advancement only if it is durable, serialNumber-scoped for the queried gateway, and can prove that no earlier source event for that gateway remains unprocessed.
 
 Add a `DeviceAvailabilityEvent` REST/storage object with `to_json` and `from_json` support in:
 
@@ -2358,15 +2375,33 @@ For each valid connection message emitted by the per-serial ordering stage:
       serializable transaction with retry
     treat previous state as unknown
 
-  if event_time < last_event_time:
+  order_key = (event_time, source_sequence)
+  last_order_key = (last_event_time, last_source_sequence)
+
+  if order_key < last_order_key:
     treat the message as stale
     do not insert an availability event
     do not update device_availability_state
     COMMIT
     stop processing this message
 
-  if event_time == last_event_time and no deterministic source tie-breaker proves this message is later:
-    treat the message as duplicate or non-advancing
+  if order_key == last_order_key:
+    if idempotency_key equals last_idempotency_key:
+      treat the message as an exact duplicate
+    else:
+      persist an ingestion ambiguity gap for this serialNumber and order_key
+      treat the message as ambiguous, not exact
+    do not insert an availability event
+    do not update device_availability_state
+    COMMIT
+    stop processing this message
+
+  if event_time == last_event_time and source_sequence is missing or not comparable:
+    if idempotency_key equals last_idempotency_key:
+      treat the message as an exact duplicate
+    else:
+      persist an ingestion ambiguity gap for this serialNumber and event_time
+      treat the message as unordered, not exact
     do not insert an availability event
     do not update device_availability_state
     COMMIT
@@ -2383,15 +2418,16 @@ For each valid connection message emitted by the per-serial ordering stage:
         update device_availability_state:
           current_state = online
           last_event_time = event_time
+          last_source_sequence = source_sequence
           last_idempotency_key = idempotency_key
           updated_at = processing time
       else:
         treat as duplicate and do not update state
     else if current_state is online:
-      update device_availability_state metadata, last_event_time, last_idempotency_key, and updated_at
+      update device_availability_state metadata, last_event_time, last_source_sequence, last_idempotency_key, and updated_at
       do not insert a transition event
     else:
-      update device_availability_state to online and last_event_time
+      update device_availability_state to online, last_event_time, and last_source_sequence
       do not insert an initial online transition event
 
   if incomingState is offline:
@@ -2401,15 +2437,16 @@ For each valid connection message emitted by the per-serial ordering stage:
         update device_availability_state:
           current_state = offline
           last_event_time = event_time
+          last_source_sequence = source_sequence
           last_idempotency_key = idempotency_key
           updated_at = processing time
       else:
         treat as duplicate and do not update state
     else if current_state is offline:
-      update device_availability_state metadata, last_event_time, last_idempotency_key, and updated_at
+      update device_availability_state metadata, last_event_time, last_source_sequence, last_idempotency_key, and updated_at
       do not insert a transition event
     else:
-      update device_availability_state to offline and last_event_time
+      update device_availability_state to offline, last_event_time, and last_source_sequence
       do not insert an initial offline transition event because the prior state is unknown
 
   COMMIT
@@ -2436,14 +2473,16 @@ Atomically create or lock the device_availability_state row for :serialNumber.
 Read:
   current_state
   last_event_time
+  last_source_sequence
   last_idempotency_key
 
--- Validate timestamp and determine whether state changed.
+-- Validate composite ordering key and determine whether state changed.
 -- Insert into device_availability_events only if state changed.
 
 Update device_availability_state only when timestamp and idempotency checks allow it:
   current_state = :newState
   last_event_time = :eventTime
+  last_source_sequence = :sourceSequence
   last_idempotency_key = :idempotencyKey
   updated_at = :processingTime
   board_id = :boardId when known, otherwise keep existing or NULL according to metadata policy
@@ -2455,18 +2494,22 @@ COMMIT;
 Staleness rule after ordering:
 
 ```text
-An event is stale when its source event_time is older than the persisted
-device_availability_state.last_event_time for the same serialNumber and the
-selected ordering strategy has already advanced the serialNumber beyond that
-source time.
+An event is stale when its source ordering key `(event_time, source_sequence)` is
+older than the persisted
+`device_availability_state.(last_event_time, last_source_sequence)` for the same
+serialNumber and the selected ordering strategy has already advanced the
+serialNumber beyond that source key.
 
 Stale or non-advancing events must not insert counted availability events and must
 not update device_availability_state, even if their idempotency_key has not been
 seen before.
 
-An event with the same event_time is non-advancing unless a deterministic source
-tie-breaker proves it occurred later. Exact Kafka redelivery should be ignored by
-the idempotency key.
+Two different logical events with the same `event_time` must be ordered by a
+deterministic source sequence. Exact Kafka redelivery should be ignored by the
+idempotency key. If two different logical events share the same `event_time` and
+no reliable source sequence exists, Analytics must persist an ingestion ambiguity
+gap for that source time and downgrade overlapping availability queries instead
+of silently discarding one transition as non-advancing.
 ```
 
 ### Store Only State Transitions
@@ -2565,6 +2608,10 @@ If startTime >= availabilityValidFrom:
   query device_availability_events normally
 ```
 
+For `meta.coverage = "none"` and `meta.accuracy = "not_applicable"`, return
+`data.offline_count = null`. Do not return a numeric `0` when the API has no
+coverage proof for the requested interval.
+
 Rejecting pre-cutover ranges prevents a successful zero response from meaning either
 "no outages occurred" or "Analytics was not collecting availability events yet."
 
@@ -2621,6 +2668,7 @@ Use an HTTP error:
     "coverage": "full",
     "accuracy": "exact",
     "sampleCount": 0,
+    "offlineEventCount": 0,
     "effectiveSamplingIntervalSeconds": 0,
     "allowedGapSeconds": 0,
     "boundarySamplesUsed": {
@@ -2646,10 +2694,22 @@ Use an HTTP error:
 ```
 
 An exact zero is valid only when availability coverage proves the complete
-requested interval: `coverageStart <= startTime`, `processedThrough >= endTime`,
+requested interval after the configured ingestion allowance: `coverageStart <=
+startTime`, `processedThrough >= endTime - allowedIngestionDelaySeconds`,
 `ingestionGapKnown = false`, and `proofSource != "unavailable"`. Otherwise a
-zero matching event count must be reported as partial/lower-bound or unavailable
-coverage according to the availability coverage rules.
+zero matching event count must be reported as partial/lower-bound, or as
+unavailable with `offline_count: null` when no coverage proof exists.
+
+For the availability endpoint, `sampleCount` is retained for response-shape
+consistency with the other summary APIs and means the number of offline
+transition rows contributing to `offline_count`. `offlineEventCount` is the
+availability-specific alias for the same value. Online transition rows may
+contribute to `observedWindow` and `sourceWindow`, but they do not contribute to
+`sampleCount`, `offlineEventCount`, or `offline_count`.
+
+`boundarySamplesUsed.beforeStart` is `true` only when a pre-start boundary event
+was actually selected. Event counting does not require a pre-start boundary
+event when durable availability coverage proves the requested interval.
 
 ### Internal Error
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -1278,8 +1278,8 @@ effective boundaries:
   effective_end = min(requested_end, proven_session_end)
 
 effective boundaries:
-  effective_start = max(requested_start_time, proven_session_start)
-  effective_end = min(requested_end_time, proven_session_end)
+  effective_start = max(requested_start, proven_session_start)
+  effective_end = min(requested_end, proven_session_end)
 
 start_sample:
   exact sample at effective_start, if available

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -2000,7 +2000,7 @@ Fields:
   serialNumber    TEXT
   event_type      TEXT
   event_time      BIGINT
-  source_sequence TEXT NULL
+  source_sequence BIGINT NULL
   reason          TEXT
   connection_ip   TEXT
   session_id      TEXT
@@ -2056,7 +2056,7 @@ Fields:
   board_id             TEXT NULL
   current_state        TEXT
   last_event_time      BIGINT
-  last_source_sequence TEXT NULL
+  last_source_sequence BIGINT NULL
   last_idempotency_key TEXT
   updated_at           BIGINT
   metadata             TEXT
@@ -2071,7 +2071,7 @@ Constraints:
 
 `device_availability_events` stores only online/offline transition history. `device_availability_state` stores the authoritative current state and the latest accepted source availability ordering key.
 
-`last_event_time` and `last_source_sequence` form the persisted source ordering key after events have passed the required per-serial ordering mechanism. `last_event_time` must be populated from the normalized Kafka source timestamp (`event_time`), and `last_source_sequence` must be populated from a reliable source sequence, source offset within the producing system, or another deterministic source-provided ordering value when one exists. The composite key is used for stale detection only after Analytics has established that no older transition for the same serialNumber can still be accepted. `DeviceInfo.lastContact` may remain local contact or processing metadata, but it must not be used to order source events because Kafka delivery can be delayed.
+`last_event_time` and `last_source_sequence` form the persisted source ordering key after events have passed the required per-serial ordering mechanism. `last_event_time` must be populated from the normalized Kafka source timestamp (`event_time`), and `last_source_sequence` must be populated from a reliable source sequence, source offset within the producing system, or another deterministic 64-bit numeric value (`BIGINT`) when one exists. `source_sequence` and `last_source_sequence` are stored as `BIGINT NULL` so SQL and application-layer index and comparator operations preserve numeric order (`10 > 2`). The composite key is used for stale detection only after Analytics has established that no older transition for the same serialNumber can still be accepted. `DeviceInfo.lastContact` may remain local contact or processing metadata, but it must not be used to order source events because Kafka delivery can be delayed.
 
 Add persisted ingestion coverage tables for availability exactness:
 
@@ -2101,24 +2101,19 @@ metadata
 
 `processed_through_event_time` is a source-event-time watermark, not a Kafka processing-time or `DeviceInfo.lastContact` value. Kafka topic, partition, and offset are stored only as proof metadata.
 
-For availability coverage decisions, compute:
+For availability coverage decisions over a requested interval `[startTime, endTime)`:
 
 ```text
 coverageTargetEnd = endTime - allowedIngestionDelaySeconds
 ```
 
-An exact result is allowed only when the serialNumber checkpoint proves
-`coverage_start <= startTime`, `processed_through_event_time >=
-coverageTargetEnd`, and no persisted gap overlaps `[startTime,
-coverageTargetEnd)`. This permits healthy near-real-time requests whose most
-recent gateway message is slightly before `endTime`, while still surfacing
-stale ingestion as partial coverage. Set `allowedIngestionDelaySeconds` to the
-configured maximum tolerated ingestion/source-message delay for availability
-queries, and return it in `meta.availabilityCoverage`.
+An exact result (`meta.coverage = "full"`, `meta.accuracy = "exact"`) is allowed only when the serialNumber checkpoint proves `coverage_start <= startTime`, `processed_through_event_time >= endTime`, and no persisted gap overlaps `[startTime, endTime)`.
+
+Evaluating coverage against `coverageTargetEnd = endTime - allowedIngestionDelaySeconds` does not prove that there were no offline transitions in `[coverageTargetEnd, endTime)`. Therefore, if `processed_through_event_time < endTime` (even when `processed_through_event_time >= coverageTargetEnd`), the requested interval `[startTime, endTime)` is not fully covered up to `endTime` and must be reported as partial coverage (`meta.coverage = "partial"`, `meta.accuracy = "lower_bound"`) with the effective/observed window covered so far ending at `processed_through_event_time` (or `coverageTargetEnd`). Set `allowedIngestionDelaySeconds` to the configured maximum tolerated ingestion/source-message delay for availability queries, and return it in `meta.availabilityCoverage`.
 
 The checkpoint must be advanced durably with event processing. For a message that changes availability state or updates same-state metadata, the state update, optional transition insert, and checkpoint update must commit in one database transaction before the corresponding Kafka offset is committed. Rebalances and restarts must reload the checkpoint and any persisted reorder-buffer state needed by the selected ordering strategy. If the implementation cannot prove continuity after a restart, rebalance, topic retention truncation, skipped unparseable connection message, reorder-window overflow, or offset discontinuity, it must persist an ingestion gap and stop returning exact coverage for overlapping ranges.
 
-When one serialNumber has no recent messages, do not infer coverage from an empty event table. The API may return an exact zero only if that serialNumber has a durable checkpoint whose `processed_through_event_time` reaches `coverageTargetEnd`; otherwise the result is partial/lower-bound or unavailable according to the coverage rules. A partition-level or source-level watermark may be used instead of per-message checkpoint advancement only if it is durable, serialNumber-scoped for the queried gateway, and can prove that no earlier source event for that gateway remains unprocessed.
+When one serialNumber has no recent messages, do not infer coverage from an empty event table. The API may return an exact zero only if that serialNumber has a durable checkpoint whose `processed_through_event_time` reaches `endTime`; otherwise the result is partial/lower-bound or unavailable according to the coverage rules. A partition-level or source-level watermark may be used instead of per-message checkpoint advancement only if it is durable, serialNumber-scoped for the queried gateway, and can prove that no earlier source event for that gateway remains unprocessed.
 
 Add a `DeviceAvailabilityEvent` REST/storage object with `to_json` and `from_json` support in:
 
@@ -2375,38 +2370,46 @@ For each valid connection message emitted by the per-serial ordering stage:
       serializable transaction with retry
     treat previous state as unknown
 
-  order_key = (event_time, source_sequence)
-  last_order_key = (last_event_time, last_source_sequence)
-
-  if order_key < last_order_key:
+  -- Explicit scalar ordering comparison logic:
+  if event_time < last_event_time:
     treat the message as stale
     do not insert an availability event
     do not update device_availability_state
     COMMIT
     stop processing this message
 
-  if order_key == last_order_key:
-    if idempotency_key equals last_idempotency_key:
-      treat the message as an exact duplicate
-    else:
-      persist an ingestion ambiguity gap for this serialNumber and order_key
-      treat the message as ambiguous, not exact
-    do not insert an availability event
-    do not update device_availability_state
-    COMMIT
-    stop processing this message
+  if event_time == last_event_time:
+    if both source_sequence and last_source_sequence are present (non-null BIGINT):
+      if source_sequence < last_source_sequence:
+        treat the message as stale
+        do not insert an availability event
+        do not update device_availability_state
+        COMMIT
+        stop processing this message
 
-  if event_time == last_event_time and source_sequence is missing or not comparable:
-    if idempotency_key equals last_idempotency_key:
-      treat the message as an exact duplicate
+      if source_sequence == last_source_sequence:
+        if idempotency_key equals last_idempotency_key:
+          treat the message as an exact duplicate
+        else:
+          persist an ingestion ambiguity gap for this serialNumber, event_time, and source_sequence
+          treat the message as ambiguous, not exact
+        do not insert an availability event
+        do not update device_availability_state
+        COMMIT
+        stop processing this message
     else:
-      persist an ingestion ambiguity gap for this serialNumber and event_time
-      treat the message as unordered, not exact
-    do not insert an availability event
-    do not update device_availability_state
-    COMMIT
-    stop processing this message
+      -- Equal timestamp without comparable non-null BIGINT sequences
+      if idempotency_key equals last_idempotency_key:
+        treat the message as an exact duplicate
+      else:
+        persist an ingestion ambiguity gap for this serialNumber and event_time
+        treat the message as unordered / ambiguous, not exact
+      do not insert an availability event
+      do not update device_availability_state
+      COMMIT
+      stop processing this message
 
+  -- event_time > last_event_time, or event_time == last_event_time with source_sequence > last_source_sequence:
   determine incomingState from message_type:
     ping or capabilities -> online
     disconnection -> offline
@@ -2476,10 +2479,10 @@ Read:
   last_source_sequence
   last_idempotency_key
 
--- Validate composite ordering key and determine whether state changed.
+-- Validate scalar timestamp and sequence ordering key and determine whether state changed.
 -- Insert into device_availability_events only if state changed.
 
-Update device_availability_state only when timestamp and idempotency checks allow it:
+Update device_availability_state only when timestamp, sequence, and idempotency checks allow it:
   current_state = :newState
   last_event_time = :eventTime
   last_source_sequence = :sourceSequence
@@ -2494,22 +2497,19 @@ COMMIT;
 Staleness rule after ordering:
 
 ```text
-An event is stale when its source ordering key `(event_time, source_sequence)` is
-older than the persisted
-`device_availability_state.(last_event_time, last_source_sequence)` for the same
-serialNumber and the selected ordering strategy has already advanced the
-serialNumber beyond that source key.
+An event is stale when `event_time < last_event_time`, or when `event_time == last_event_time` and both `source_sequence` and `last_source_sequence` are present (non-null BIGINT) with `source_sequence < last_source_sequence`.
 
 Stale or non-advancing events must not insert counted availability events and must
 not update device_availability_state, even if their idempotency_key has not been
 seen before.
 
 Two different logical events with the same `event_time` must be ordered by a
-deterministic source sequence. Exact Kafka redelivery should be ignored by the
-idempotency key. If two different logical events share the same `event_time` and
-no reliable source sequence exists, Analytics must persist an ingestion ambiguity
-gap for that source time and downgrade overlapping availability queries instead
-of silently discarding one transition as non-advancing.
+deterministic 64-bit numeric `source_sequence` (`BIGINT`). Exact Kafka redelivery
+should be identified by the idempotency key. If two different logical events share
+the same `event_time` and lack comparable non-null source sequences, or have identical
+source sequences, Analytics must persist an ingestion ambiguity gap for that source time
+and downgrade overlapping availability queries to partial/lower-bound coverage instead
+of silently discarding one transition as non-advancing or guessing order arbitrarily.
 ```
 
 ### Store Only State Transitions
@@ -2693,12 +2693,7 @@ Use an HTTP error:
 }
 ```
 
-An exact zero is valid only when availability coverage proves the complete
-requested interval after the configured ingestion allowance: `coverageStart <=
-startTime`, `processedThrough >= endTime - allowedIngestionDelaySeconds`,
-`ingestionGapKnown = false`, and `proofSource != "unavailable"`. Otherwise a
-zero matching event count must be reported as partial/lower-bound, or as
-unavailable with `offline_count: null` when no coverage proof exists.
+An exact zero is valid only when availability coverage proves the complete requested interval up to `endTime`: `coverageStart <= startTime`, `processedThrough >= endTime`, `ingestionGapKnown = false`, and `proofSource != "unavailable"`. When `processedThrough < endTime` (even if `processedThrough >= endTime - allowedIngestionDelaySeconds`), the requested interval is not fully covered up to `endTime` and a zero matching event count must be reported as partial/lower-bound (`meta.coverage = "partial"`), or as unavailable with `offline_count: null` when no coverage proof exists.
 
 For the availability endpoint, `sampleCount` is retained for response-shape
 consistency with the other summary APIs and means the number of offline

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -869,7 +869,7 @@ updated_at >= processing time
     },
     "availabilityCoverage": {
       "coverageStart": "<= startTime",
-      "processedThrough": ">= endTime - allowedIngestionDelaySeconds",
+      "processedThrough": ">= endTime",
       "allowedIngestionDelaySeconds": "<configured availability ingestion delay>",
       "ingestionGapKnown": false,
       "proofSource": "serial_partition_checkpoint"
@@ -1003,7 +1003,7 @@ event_time = disconnection message timestamp
     },
     "availabilityCoverage": {
       "coverageStart": "<= startTime",
-      "processedThrough": ">= endTime - allowedIngestionDelaySeconds",
+      "processedThrough": ">= endTime",
       "allowedIngestionDelaySeconds": "<configured availability ingestion delay>",
       "ingestionGapKnown": false,
       "proofSource": "serial_partition_checkpoint"
@@ -1212,7 +1212,7 @@ API result:
     },
     "availabilityCoverage": {
       "coverageStart": "<= startTime",
-      "processedThrough": ">= endTime - allowedIngestionDelaySeconds",
+      "processedThrough": ">= endTime",
       "allowedIngestionDelaySeconds": "<configured availability ingestion delay>",
       "ingestionGapKnown": false,
       "proofSource": "serial_partition_checkpoint"
@@ -1332,7 +1332,7 @@ The API returns:
     },
     "availabilityCoverage": {
       "coverageStart": "<= startTime",
-      "processedThrough": ">= endTime - allowedIngestionDelaySeconds",
+      "processedThrough": ">= endTime",
       "allowedIngestionDelaySeconds": "<configured availability ingestion delay>",
       "ingestionGapKnown": false,
       "proofSource": "serial_partition_checkpoint"
@@ -1608,7 +1608,7 @@ Verify successful empty results.
 ### Preconditions
 
 * The requested range starts at or after `availabilityValidFrom`.
-* The gateway has a durable `device_availability_ingestion_checkpoint` with `coverage_start <= startTime` and `processed_through_event_time >= endTime - allowedIngestionDelaySeconds`.
+* The gateway has a durable `device_availability_ingestion_checkpoint` with `coverage_start <= startTime` and `processed_through_event_time >= endTime`.
 * No `device_availability_ingestion_gaps` row overlaps `[startTime, endTime)`.
 * The cutover behavior for ranges beginning before `availabilityValidFrom` is covered by `TC-COMMON-023`.
 
@@ -1623,7 +1623,7 @@ Verify successful empty results.
 * `meta.coverage = "full"`.
 * `meta.accuracy = "exact"`.
 * `meta.availabilityCoverage.coverageStart <= startTime`.
-* `meta.availabilityCoverage.processedThrough >= endTime - meta.availabilityCoverage.allowedIngestionDelaySeconds`.
+* `meta.availabilityCoverage.processedThrough >= endTime`.
 * `meta.availabilityCoverage.ingestionGapKnown = false`.
 * `meta.availabilityCoverage.proofSource != "unavailable"`.
 * `data.gw_uuid = "60cf84f22290"`.
@@ -1664,7 +1664,7 @@ Verify successful empty results.
     },
     "availabilityCoverage": {
       "coverageStart": "<= startTime",
-      "processedThrough": ">= endTime - allowedIngestionDelaySeconds",
+      "processedThrough": ">= endTime",
       "allowedIngestionDelaySeconds": "<configured availability ingestion delay>",
       "ingestionGapKnown": false,
       "proofSource": "serial_partition_checkpoint"
@@ -1696,7 +1696,7 @@ availability ingestion stream does not prove full interval coverage.
 
 * The requested range starts at or after `availabilityValidFrom`.
 * No `offline` rows match `[startTime, endTime)`.
-* `availabilityCoverage.processedThrough < endTime - allowedIngestionDelaySeconds` or a known ingestion gap overlaps the covered portion of the requested range.
+* `availabilityCoverage.processedThrough < endTime` or a known ingestion gap overlaps the covered portion of the requested range.
 
 ### Steps
 
@@ -1747,8 +1747,7 @@ interval result when no durable availability coverage proof exists.
 
 ### Objective
 
-Verify that a healthy near-real-time query can still return exact coverage when
-the latest gateway source message is slightly before `endTime`.
+Verify that when the latest gateway source message is inside the allowed ingestion delay window (`endTime - 30 seconds`), the query reports partial coverage for `[startTime, endTime)` because ingestion has not yet reached `endTime`.
 
 ### Preconditions
 
@@ -1757,7 +1756,7 @@ the latest gateway source message is slightly before `endTime`.
 * `allowedIngestionDelaySeconds = 60`.
 * The per-serial checkpoint has `coverage_start <= startTime`.
 * The latest processed source event for the gateway is a ping at `endTime - 30 seconds`.
-* No `device_availability_ingestion_gaps` row overlaps `[startTime, endTime - allowedIngestionDelaySeconds)`.
+* No `device_availability_ingestion_gaps` row overlaps `[startTime, endTime - 30 seconds)`.
 
 ### Steps
 
@@ -1767,9 +1766,9 @@ the latest gateway source message is slightly before `endTime`.
 ### Expected result
 
 * HTTP `200 OK`.
-* `meta.coverage = "full"`.
-* `meta.accuracy = "exact"`.
-* `meta.availabilityCoverage.processedThrough >= endTime - meta.availabilityCoverage.allowedIngestionDelaySeconds`.
+* `meta.coverage = "partial"`.
+* `meta.accuracy = "lower_bound"`.
+* `meta.availabilityCoverage.processedThrough < endTime`.
 * `meta.availabilityCoverage.ingestionGapKnown = false`.
 * `data.offline_count = 0`.
 
@@ -1795,7 +1794,7 @@ Requested lookback: 24 hours
 * `meta.coverage = "full"`.
 * `meta.accuracy = "exact"`.
 * `meta.availabilityCoverage.coverageStart <= startTime`.
-* `meta.availabilityCoverage.processedThrough >= endTime - meta.availabilityCoverage.allowedIngestionDelaySeconds`.
+* `meta.availabilityCoverage.processedThrough >= endTime`.
 * `meta.availabilityCoverage.ingestionGapKnown = false`.
 * `meta.availabilityCoverage.proofSource != "unavailable"`.
 
@@ -2260,17 +2259,18 @@ last_idempotency_key = ping-1210
 
 ---
 
-## TC-AVAIL-029B: Equal timestamp with source sequence preserves transitions
+## TC-AVAIL-029B: Equal timestamp with source sequence preserves numeric transitions
 
 ### Objective
 
 Verify that distinct opposite-state events sharing a timestamp are processed when
-a deterministic source sequence orders them.
+a deterministic 64-bit numeric `source_sequence` (`BIGINT`) orders them, and that
+numeric comparison (`10 > 2`) is preserved rather than string lexicographical order.
 
 ### Preconditions
 
 * Gateway state is initialized as online before `12:00:00`.
-* The source provides a reliable per-serial sequence field.
+* The source provides a reliable per-serial numeric sequence field (`BIGINT NULL`).
 
 ### Steps
 
@@ -2278,27 +2278,27 @@ a deterministic source sequence orders them.
 
 ```text
 event_time = 12:00:00
-source_sequence = 100
-idempotency_key = offline-120000-100
+source_sequence = 2
+idempotency_key = offline-120000-2
 ```
 
 2. Deliver a ping with:
 
 ```text
 event_time = 12:00:00
-source_sequence = 101
-idempotency_key = online-120000-101
+source_sequence = 10
+idempotency_key = online-120000-10
 ```
 
 3. Query `device_availability_state` and `device_availability_events`.
 
 ### Expected result
 
-* The offline transition is inserted with ordering key `(12:00:00, 100)`.
-* The online transition is inserted with ordering key `(12:00:00, 101)`.
+* The offline transition is inserted with ordering key `(12:00:00, 2)`.
+* The online transition is inserted with ordering key `(12:00:00, 10)` because numeric comparison evaluates `10 > 2` (whereas string comparison would incorrectly evaluate `"10" < "2"`).
 * `device_availability_state.current_state = online`.
 * `device_availability_state.last_event_time = 12:00:00`.
-* `device_availability_state.last_source_sequence = 101`.
+* `device_availability_state.last_source_sequence = 10`.
 * A full-coverage query over this interval returns `offline_count = 1`.
 
 ---
@@ -2542,7 +2542,7 @@ Ethernet reconnected        → online event
     },
     "availabilityCoverage": {
       "coverageStart": "<= startTime",
-      "processedThrough": ">= endTime - allowedIngestionDelaySeconds",
+      "processedThrough": ">= endTime",
       "allowedIngestionDelaySeconds": "<configured availability ingestion delay>",
       "ingestionGapKnown": false,
       "proofSource": "serial_partition_checkpoint"
@@ -4118,7 +4118,7 @@ Availability:    data.fetch_status = success, data.offline_count = 0, meta.cover
 ```
 
 * All metric responses use HTTP `200 OK` when queries succeed but return no data.
-* Availability returns `data.fetch_status = "success"` and `data.offline_count = 0` as an exact result only when `startTime >= availabilityValidFrom`, `meta.coverage = "full"`, and `meta.availabilityCoverage.processedThrough >= endTime - meta.availabilityCoverage.allowedIngestionDelaySeconds`.
+* Availability returns `data.fetch_status = "success"` and `data.offline_count = 0` as an exact result only when `startTime >= availabilityValidFrom`, `meta.coverage = "full"`, and `meta.availabilityCoverage.processedThrough >= endTime`.
 * If `startTime < availabilityValidFrom`, Availability returns `400 Bad Request` with `error: "availability_range_before_cutover"`.
 
 ---

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -25,7 +25,7 @@ get_gateway_offline_count
 The test cases cover:
 * API contract tests for request shapes, HTTP status codes, response schemas, parameter validation, filtering, and half-open time-range window semantics `[startTime, endTime)`.
 * Service integration tests for Kafka topic consumption, OWPROV fallback resolution, `VenueCoordinator` maintained ownership map, process-level router resolution cache, and PostgreSQL storage queries.
-* Database/white-box tests for `device_availability_events`, `timepoints`, and `wificlienthistory` table schemas, constraints, and event counting behavior.
+* Database/white-box tests for `device_availability_events`, `device_availability_state`, `timepoints`, and `wificlienthistory` table schemas, constraints, and event counting behavior.
 * End-to-end physical device scenarios covering gateway shutdown, power restoration, cable removal, and reconnection flows.
 
 ---
@@ -44,11 +44,12 @@ Before executing the test cases:
 
 ```text
 device_availability_events
+device_availability_state
 timepoints
 wificlienthistory
 ```
 
-8. Gateway availability uses the existing persisted gateway state record as the authoritative state and `device_availability_events` as the transition log. Kafka `disconnection` messages are treated as `offline`; Kafka `ping` and `capabilities` messages are treated as `online`. Every newer message updates that record's `lastContact`; pings also update `lastPing`, and real offline transitions update `lastDisconnection`. This does not require a table named `device` or `devices`.
+8. Gateway availability uses `device_availability_state` as the authoritative restart-safe state table and `device_availability_events` as the transition log. Kafka `disconnection` messages are treated as `offline`; Kafka `ping` and `capabilities` messages are treated as `online`. Every accepted newer source message updates `device_availability_state.last_event_time`. `DeviceInfo.lastContact` is contact/processing metadata and is not used for source-event ordering.
 9. Database records for the test gateway are cleared or isolated before each independent test.
 10. A valid authorization token is available for testing endpoint access.
 
@@ -508,18 +509,96 @@ Call `GET /api/v1/devices/{routerId}/availability-summary` with a calculated `st
 
 ## 4.1. Database/White-Box Validation Queries
 
-### Persisted gateway state check
+## TC-AVAIL-SCHEMA-001: Availability state table schema exists
+
+### Objective
+
+Verify that the required restart-safe state table exists with deterministic fields and constraints.
+
+### Expected result
+
+* `device_availability_state` exists.
+* `serialNumber` is the primary identity for a gateway state row.
+* Required fields exist:
 
 ```text
-Lock and read the existing persisted gateway state record for:
-serialNumber = 60cf84f22290
+serialNumber
+board_id
+current_state
+last_event_time
+last_idempotency_key
+updated_at
+metadata
+```
 
-Verify these fields:
-connected
-lastContact
-lastPing
-lastConnection
-lastDisconnection
+* `current_state` accepts only `online`, `offline`, or `unknown`.
+* An index exists for `board_id` when board-scoped maintenance queries need it.
+
+---
+
+## TC-AVAIL-SCHEMA-002: Availability event table schema exists
+
+### Objective
+
+Verify that transition history is stored separately from current state.
+
+### Expected result
+
+* `device_availability_events` exists.
+* Required event fields exist:
+
+```text
+serialNumber
+board_id
+event_type
+event_time
+event_id
+idempotency_key
+reason
+connection_ip
+metadata
+```
+
+* `idempotency_key` is unique.
+* At least one index supports lookup by `serialNumber` and `event_time`.
+* `event_type` accepts only stored transition values `online` and `offline`.
+
+---
+
+## TC-AVAIL-SCHEMA-003: Availability migrations are idempotent
+
+### Objective
+
+Verify that migration from a database without availability tables creates both required tables safely.
+
+### Steps
+
+1. Start with a previous-version database that has no availability tables.
+2. Run Analytics migrations.
+3. Run Analytics migrations again.
+4. Inspect the schema.
+
+### Expected result
+
+* `device_availability_events` and `device_availability_state` exist after migration.
+* Re-running migration does not drop or duplicate tables, indexes, or constraints.
+* Existing `timepoints` and `wificlienthistory` data remains intact.
+
+---
+
+### Availability state row query
+
+```sql
+SELECT serialNumber,
+       board_id,
+       current_state,
+       last_event_time,
+       last_idempotency_key,
+       updated_at,
+       metadata
+FROM device_availability_state
+WHERE serialNumber = '60cf84f22290'
+FOR UPDATE;
 ```
 
 ### Latest transition event query
@@ -560,36 +639,34 @@ WHERE serialNumber = ?
 
 ### Objective
 
-Verify that the first observed ping initializes the persisted gateway state record as online without creating an online transition event.
+Verify that the first observed ping initializes `device_availability_state` as online without creating an online transition event.
 
 ### Preconditions
 
 * No availability event exists for the gateway.
-* The persisted gateway state record has no prior availability contact state:
+* No `device_availability_state` row exists for the gateway.
 
-```text
-connected is unset or false only because the row is uninitialized
-lastContact is unset or 0
-```
 
 ### Steps
 
 1. Start the gateway.
 2. Wait for the gateway to publish a `ping` message.
 3. Wait for Analytics to consume the message.
-4. Query the persisted gateway state record.
+4. Query `device_availability_state`.
 5. Query `device_availability_events`.
 
 ### Expected result
 
 * No `online` event is inserted.
 * No `offline` event is inserted.
-* The persisted gateway state record is updated:
+* One `device_availability_state` row is created:
 
 ```text
-connected = true
-lastContact = ping timestamp
-lastPing = ping timestamp
+serialNumber = 60cf84f22290
+current_state = online
+last_event_time = ping source timestamp
+last_idempotency_key = ping idempotency key
+updated_at >= processing time
 ```
 
 * The availability API returns:
@@ -612,11 +689,11 @@ Verify that regular gateway pings do not create repeated online transition event
 
 ### Preconditions
 
-* The persisted gateway state record has:
+* `device_availability_state` has:
 
 ```text
-connected = true
-lastContact < latest ping timestamp
+current_state = online
+last_event_time < latest ping source timestamp
 ```
 
 ### Steps
@@ -624,7 +701,7 @@ lastContact < latest ping timestamp
 1. Keep the gateway online.
 2. Allow it to send at least three ping messages.
 3. Wait for Analytics to process all messages.
-4. Query the persisted gateway state record.
+4. Query `device_availability_state`.
 5. Query `device_availability_events`.
 
 Example messages:
@@ -638,9 +715,9 @@ Example messages:
 ### Expected result
 
 * No additional `online` event is inserted after the first online state.
-* `lastContact` is updated to the latest newer ping timestamp.
-* `lastPing` is updated to the latest newer ping timestamp.
-* `connected` remains `true`.
+* `last_event_time` is updated to the latest newer ping source timestamp.
+* `last_idempotency_key` is updated to the latest accepted ping idempotency key.
+* `current_state` remains `online`.
 * `offline_count` remains `0`.
 
 ---
@@ -654,7 +731,7 @@ Verify that physically powering off the gateway creates one offline transition.
 ### Preconditions
 
 * Gateway is online.
-* The persisted gateway state record has `connected = true`.
+* `device_availability_state.current_state = online`.
 
 ### Steps
 
@@ -669,12 +746,13 @@ Verify that physically powering off the gateway creates one offline transition.
 ### Expected result
 
 * Exactly one `offline` event is inserted.
-* The persisted gateway state record is updated:
+* `device_availability_state` is updated:
 
 ```text
-connected = false
-lastContact = disconnection message timestamp
-lastDisconnection = disconnection message timestamp
+current_state = offline
+last_event_time = disconnection source timestamp
+last_idempotency_key = disconnection idempotency key
+updated_at >= processing time
 ```
 
 * The event contains:
@@ -836,13 +914,13 @@ Verify that restoring power changes the gateway state from offline to online wit
 
 * One `online` transition event is inserted.
 * No additional `offline` event is inserted.
-* The persisted gateway state record is updated:
+* `device_availability_state` is updated:
 
 ```text
-connected = true
-lastContact = ping or capabilities timestamp
-lastPing = ping timestamp when message type is ping
-lastConnection = ping or capabilities timestamp
+current_state = online
+last_event_time = ping or capabilities source timestamp
+last_idempotency_key = ping or capabilities idempotency key
+updated_at >= processing time
 ```
 
 * Existing offline count remains unchanged.
@@ -889,8 +967,8 @@ Verify recovery after an Ethernet disconnection.
 
 * One `online` transition event is inserted.
 * No additional offline event is inserted.
-* `connected` becomes `true`.
-* `lastContact` and the applicable online timestamp field are updated.
+* `device_availability_state.current_state` becomes `online`.
+* `last_event_time`, `last_idempotency_key`, `updated_at`, and metadata are updated.
 * Offline count remains unchanged.
 
 ---
@@ -910,13 +988,13 @@ Verify that each separate online-to-offline transition is counted once.
 Perform the following sequence:
 
 ```text
-12:00 ping          → online
-12:10 shutdown      → offline
-12:15 boot          → online
-13:00 disconnect    → offline
-13:05 reconnect     → online
-14:00 power off     → offline
-14:10 power on      → online
+12:00 initial ping  → initialize online state, no event
+12:10 shutdown      → offline event
+12:15 boot          → online event
+13:00 disconnect    → offline event
+13:05 reconnect     → online event
+14:00 power off     → offline event
+14:10 power on      → online event
 ```
 
 Call the API for a time range covering the entire sequence.
@@ -926,7 +1004,6 @@ Call the API for a time range covering the entire sequence.
 The event table contains:
 
 ```text
-12:00 online
 12:10 offline
 12:15 online
 13:00 offline
@@ -956,12 +1033,12 @@ Verify that repeated offline messages do not create duplicate offline transition
 ### Preconditions
 
 * The gateway has already produced one offline transition.
-* The persisted gateway state record has `connected = false`.
+* `device_availability_state.current_state = offline`.
 
 ### Steps
 
 1. Keep the gateway offline after the first disconnection.
-2. Deliver another newer `disconnection` message for the same gateway while `connected = false`.
+2. Deliver another newer `disconnection` message for the same gateway while `current_state = offline`.
 3. Query the availability-event table.
 4. Call the API.
 
@@ -977,8 +1054,8 @@ Example:
 
 * Only the first offline transition is stored.
 * Later same-state disconnection messages are ignored.
-* For newer repeated disconnection messages while `connected = false`, `lastContact` advances.
-* `lastDisconnection` remains the timestamp of the actual offline transition.
+* For newer repeated disconnection messages while `current_state = offline`, `last_event_time` advances.
+* `last_idempotency_key`, `updated_at`, and metadata are updated for the latest accepted same-state message.
 * `offline_count` is `1`.
 
 ---
@@ -1006,8 +1083,69 @@ Verify storage-level idempotency when Kafka redelivers the same logical connecti
 
 * Both deliveries map to the same deterministic `idempotency_key` or source `event_id`.
 * Exactly one transition event row is inserted.
-* The duplicate delivery does not move `connected`, `lastContact`, `lastPing`, or `lastDisconnection`.
+* The duplicate delivery does not move `current_state`, `last_event_time`, `last_idempotency_key`, `updated_at`, or transition history.
 * `offline_count` is `1`.
+
+---
+
+## TC-AVAIL-012A: Same logical event at a different Kafka offset is ignored
+
+### Objective
+
+Verify that Kafka offset is not used as the logical idempotency key.
+
+### Steps
+
+1. Publish a disconnection message with a stable source UUID and source timestamp.
+2. Publish the same logical disconnection again as a separate Kafka record at a different topic offset.
+3. Query `device_availability_events` and `device_availability_state`.
+
+### Expected result
+
+* Both records derive the same logical `idempotency_key`.
+* Exactly one offline transition row exists.
+* `device_availability_state` is updated once for the logical event.
+* Kafka topic, partition, and offset may appear in metadata only.
+
+---
+
+## TC-AVAIL-012B: Same UUID from different source namespaces is not conflated
+
+### Objective
+
+Verify that `system.host` and `system.id` are part of the idempotency namespace.
+
+### Steps
+
+1. Process a ping from source namespace A with `payload.ping.uuid = 44702320`.
+2. Process a different ping for the same gateway from source namespace B with the same UUID.
+3. Query `device_availability_state`.
+
+### Expected result
+
+* The two messages derive different `idempotency_key` values because the source namespace differs.
+* If both messages are newer source events and same-state online, no transition row is inserted.
+* `last_event_time` advances only according to source timestamp ordering.
+
+---
+
+## TC-AVAIL-012C: Missing or unstable UUID uses stable logical fields
+
+### Objective
+
+Verify that UUID absence does not force Kafka-offset idempotency.
+
+### Steps
+
+1. Process a valid disconnection message without a stable source UUID.
+2. Derive the idempotency key from stable fields such as `serialNumber`, `message_type`, `event_type`, `event_time`, `reason`, and `connection_ip`.
+3. Re-deliver the same logical message.
+
+### Expected result
+
+* Both deliveries derive the same idempotency key.
+* Exactly one transition event is inserted.
+* If stable logical fields are insufficient, the message is rejected as a counted event instead of using Kafka offset as identity.
 
 ---
 
@@ -1020,15 +1158,15 @@ Verify that repeated online messages after an offline-to-online transition do no
 ### Steps
 
 1. Reconnect or power on the gateway from an offline state.
-2. Capture the first ping that creates the online transition.
-3. Deliver another newer ping while the persisted gateway state record has `connected = true`.
+2. Capture the first recovery ping that creates the online transition.
+3. Deliver another newer ping while `device_availability_state.current_state = online`.
 4. Query availability storage.
 
 ### Expected result
 
 * Exactly one online transition event is inserted.
 * No additional offline event is inserted.
-* The newer repeated ping updates `lastContact` and `lastPing`.
+* The newer repeated ping updates `last_event_time`, `last_idempotency_key`, `updated_at`, and metadata.
 * `offline_count` is unchanged.
 
 ---
@@ -1370,17 +1508,138 @@ Verify that concurrent processing cannot create duplicate offline transitions.
 
 ### Steps
 
-1. Start with the persisted gateway state record locked state as `connected = true`.
+1. Start with `device_availability_state.current_state = online`.
 2. Deliver two disconnection messages for the same gateway concurrently.
 3. Query event storage.
 
 ### Expected result
 
-* Gateway state check and event insertion happen inside one database transaction.
-* The persisted gateway state record is locked by `serialNumber` while processing.
+* State check, idempotency check, event insertion, and state update happen inside one database transaction.
+* The `device_availability_state` row is locked by `serialNumber` while processing.
 * Exactly one offline event row is inserted.
-* The persisted gateway state record ends with `connected = false` and `lastContact` equal to the accepted disconnection timestamp.
+* The `device_availability_state` row ends with `current_state = offline` and `last_event_time` equal to the accepted disconnection source timestamp.
 * Offline count is `1`.
+
+---
+
+## TC-AVAIL-028A: Two first disconnections race when no state row exists
+
+### Objective
+
+Verify that first-row creation is concurrency-safe and does not rely on locking a nonexistent row with only `SELECT ... FOR UPDATE`.
+
+### Preconditions
+
+* No `device_availability_state` row exists for the gateway.
+* No availability event exists for the gateway.
+
+### Steps
+
+1. Deliver two disconnection messages for the same gateway concurrently.
+2. Force both consumers to attempt state initialization.
+3. Query `device_availability_state` and `device_availability_events`.
+
+### Expected result
+
+* The implementation uses an atomic first-row mechanism, such as `INSERT ... ON CONFLICT`, a PostgreSQL advisory transaction lock, or a serializable transaction with retry.
+* Exactly one `device_availability_state` row exists.
+* Exactly one offline transition row exists.
+* The final state is `current_state = offline`.
+
+---
+
+## TC-AVAIL-028B: Opposite-state events arriving concurrently are serialized
+
+### Objective
+
+Verify deterministic state when an offline and online source event are processed concurrently.
+
+### Preconditions
+
+* `device_availability_state.current_state = online`.
+* Existing `last_event_time = 12:00`.
+
+### Steps
+
+1. Deliver an offline source event at `12:03`.
+2. Deliver an online source event at `12:04` concurrently.
+3. Query `device_availability_state` and transition history.
+
+### Expected result
+
+* State-row locking or equivalent serializes processing by `serialNumber`.
+* Both events are processed in source-time order or retried until that ordering is respected.
+* Final `device_availability_state.current_state = online`.
+* Transition history contains one `offline` event at `12:03` and one `online` event at `12:04`.
+
+---
+
+## TC-AVAIL-028C: Event insert and state update roll back together
+
+### Objective
+
+Verify atomicity when the transition event insert succeeds but the state update fails.
+
+### Steps
+
+1. Start from `device_availability_state.current_state = online`.
+2. Inject a failure after inserting the offline event but before updating `device_availability_state`.
+3. Roll back the transaction.
+4. Query both availability tables.
+
+### Expected result
+
+* No offline transition row remains after rollback.
+* `device_availability_state` remains unchanged.
+* A retry can process the same logical event exactly once.
+
+---
+
+## TC-AVAIL-028D: State update and event insert roll back together
+
+### Objective
+
+Verify atomicity when state mutation would succeed but event insertion fails.
+
+### Steps
+
+1. Start from `device_availability_state.current_state = online`.
+2. Inject an event insert failure for a newer offline transition.
+3. Query both availability tables.
+
+### Expected result
+
+* `device_availability_state` remains `online`.
+* `last_event_time` does not advance.
+* No offline event is counted.
+
+---
+
+## TC-AVAIL-028E: Restart and multiple replicas use persisted state
+
+### Objective
+
+Verify that transition detection does not depend on in-memory `DeviceInfo` state.
+
+### Steps
+
+1. Process a disconnection and commit:
+
+```text
+device_availability_state.current_state = offline
+last_event_time = 12:10
+```
+
+2. Restart Analytics or route the next message to another Analytics replica.
+3. Process a recovery ping at `12:15`.
+4. Query availability storage.
+
+### Expected result
+
+* The new process or replica loads `device_availability_state`.
+* One online transition event is inserted.
+* `device_availability_state.current_state = online`.
+* No duplicate offline event is created after restart.
 
 ---
 
@@ -1390,33 +1649,81 @@ Verify that concurrent processing cannot create duplicate offline transitions.
 
 ### Objective
 
-Verify that an event older than the persisted gateway state record's `lastContact` cannot change availability history.
+Verify that an event older than `device_availability_state.last_event_time` cannot change availability history.
 
 ### Steps
 
-1. Set the persisted gateway state record to:
+1. Set `device_availability_state` to:
 
 ```text
-connected = true
-lastContact = 12:10
-lastPing = 12:10
+current_state = online
+last_event_time = 12:10
+last_idempotency_key = ping-1210
 ```
 
 2. Deliver a delayed `disconnection` message for the same gateway at `12:05`.
-3. Query the persisted gateway state record.
+3. Query `device_availability_state`.
 4. Query `device_availability_events`.
 
 ### Expected result
 
 * The stale `12:05` event is ignored.
 * No offline event row is inserted.
-* The persisted gateway state record remains:
+* `device_availability_state` remains:
 
 ```text
-connected = true
-lastContact = 12:10
-lastPing = 12:10
+current_state = online
+last_event_time = 12:10
+last_idempotency_key = ping-1210
 ```
+
+---
+
+## TC-AVAIL-029A: Equal timestamp without tie-breaker is non-advancing
+
+### Objective
+
+Verify that an opposite-state message with the same source timestamp does not create an arbitrary transition.
+
+### Steps
+
+1. Set `device_availability_state` to:
+
+```text
+current_state = online
+last_event_time = 12:10
+last_idempotency_key = ping-1210
+```
+
+2. Deliver a disconnection for the same gateway with `event_time = 12:10` and no reliable source sequence.
+3. Query `device_availability_state` and `device_availability_events`.
+
+### Expected result
+
+* The disconnection is treated as duplicate or non-advancing.
+* No offline transition event is inserted.
+* `device_availability_state` remains unchanged.
+
+---
+
+## TC-AVAIL-029B: Equal timestamp with deterministic source sequence is ordered
+
+### Objective
+
+Verify behavior when the source provides a reliable tie-breaker for same-timestamp events.
+
+### Steps
+
+1. Set `device_availability_state` to an online event at `12:10` with source sequence `10`.
+2. Deliver a disconnection for the same gateway at `12:10` with source sequence `11`.
+3. Query availability storage.
+
+### Expected result
+
+* The implementation accepts the disconnection only if the source sequence is documented as reliable.
+* One offline transition event is inserted.
+* `device_availability_state.current_state = offline`.
+* `last_event_time` remains `12:10`, and metadata records the accepted tie-breaker.
 
 ---
 
@@ -1429,25 +1736,68 @@ Verify that a first observed `disconnection` message creates an offline transiti
 ### Preconditions
 
 * No availability event exists for the gateway.
-* The persisted gateway state record has:
-
-```text
-connected = true
-lastContact < disconnection timestamp
-```
+* No `device_availability_state` row exists for the gateway.
 
 ### Steps
 
 1. Deliver a `disconnection` message.
-3. Query `device_availability_events`.
-4. Call availability-summary for a window containing the event.
+2. Query `device_availability_events`.
+3. Call availability-summary for a window containing the event.
 
 ### Expected result
 
 * One `offline` event row is inserted.
 * The event uses the gateway `serialNumber`.
-* The persisted gateway state record is updated to `connected = false`.
+* A `device_availability_state` row is created with `current_state = offline` and `last_event_time` equal to the disconnection source timestamp.
 * `offline_count` is `1`.
+
+---
+
+## TC-AVAIL-030A: Delayed but source-newer event is accepted
+
+### Objective
+
+Verify that Kafka delivery delay does not cause a valid source-newer event to be rejected by processing-time `lastContact`.
+
+### Steps
+
+1. Process a ping with:
+
+```text
+source event_time = 12:00
+processed/contact time = 12:05
+```
+
+2. Confirm `device_availability_state` has:
+
+```text
+current_state = online
+last_event_time = 12:00
+updated_at = 12:05 or equivalent processing timestamp
+```
+
+3. Process a delayed disconnection with:
+
+```text
+source event_time = 12:03
+processed/contact time = 12:06
+```
+
+4. Query `device_availability_state` and `device_availability_events`.
+
+### Expected result
+
+* The disconnection is accepted because `12:03 > last_event_time 12:00`.
+* The implementation does not compare `12:03` against processing-time `DeviceInfo.lastContact = 12:05`.
+* One `offline` event row is inserted with `event_time = 12:03`.
+* `device_availability_state` ends with:
+
+```text
+current_state = offline
+last_event_time = 12:03
+updated_at = 12:06 or equivalent processing timestamp
+last_idempotency_key = disconnection idempotency key
+```
 
 ---
 
@@ -1484,7 +1834,6 @@ Verify that online transition rows do not affect `offline_count`.
 1. Store this event sequence for one gateway:
 
 ```text
-12:00 online
 12:10 offline
 12:15 online
 12:30 offline
@@ -1534,7 +1883,7 @@ sudo shutdown -h now
 ### Expected event sequence
 
 ```text
-Initial ping                 → online event
+Initial ping                 → initialize online state, no event
 Device shutdown             → offline event 1
 Device remains shut down    → no new event
 Device powers on            → online event
@@ -2125,7 +2474,7 @@ Two 5 GHz radios publish valid temperatures.
 
 ### Expected result
 
-* Only samples where `startTime <= sample_time < endTime` are included.
+* Only samples where `effective_start_time <= sample_time < endTime` are included, where `effective_start_time = max(startTime, temperature_migration_cutover_time)`.
 
 ---
 
@@ -3179,15 +3528,12 @@ offline_count
 
 ---
 
-## TC-CONTRACT-006: Bounded client summary arrays
+## TC-CONTRACT-006: Client summary array shape
 
 ### Expected result
 
 * Usage and RSSI summary responses are arrays, not wrapper objects.
-* Each response contains at most 500 client summary items.
-* Results are ordered by normalized client MAC address ascending before the 500-client cap is applied.
-* If more than 500 clients match, the response contains the first 500 clients in that deterministic order.
-* The endpoints do not accept or require `limit` or `cursor` query parameters.
+* The endpoints do not define `limit`, `cursor`, `totalClients`, or `truncated` response behavior unless those fields are added to the API contract first.
 
 ---
 
@@ -3254,7 +3600,7 @@ The PR implementation is functionally accepted when:
 12. RSSI thresholds and boundary values are classified correctly.
 13. Invalid RSSI values are ignored.
 14. RSSI percentages are calculated per client.
-15. Usage and RSSI client-summary arrays are ordered by normalized MAC address and capped at 500 clients.
+15. Usage and RSSI client-summary responses use the documented array shape and do not invent pagination or truncation fields.
 16. Gateway shutdown and network loss create one offline transition each.
 17. Repeated pings and disconnections do not create duplicate transitions.
 18. Availability events remain queryable after board reassignment.

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -22,6 +22,14 @@ get_device_rssi_quality
 get_gateway_offline_count
 ```
 
+The specification and test suite are modularized into three distinct architectural components:
+1. **Public API Contract Specification**: OpenAPI 3.0 schemas (`openapi/owanalytics.yaml` v2.7.0) defining external REST endpoints, query parameters, HTTP status codes, and response envelopes.
+2. **Persistence & Pipeline Architecture Design**: Backend storage structures (`device_availability_events`, `device_availability_state`), Kafka event consumption/ordering semantics, and cutover/migration behavior.
+3. **Test Specification & Verification Matrix**: Independent verification matrix (this document) defining assertion criteria for API contracts, integration workflows, white-box database rules, and failure modes.
+
+> [!NOTE]
+> Approving or executing this test specification validates implementation compliance with defined assertion logic. It does not replace or bypass separate architectural design approval for backend production schema additions or Kafka pipeline designs.
+
 The test cases cover:
 * API contract tests for request shapes, HTTP status codes, response schemas, parameter validation, filtering, and half-open time-range window semantics `[startTime, endTime)`.
 * Service integration tests for Kafka topic consumption, OWPROV fallback resolution, `VenueCoordinator` maintained ownership map, process-level router resolution cache, and PostgreSQL storage queries.
@@ -186,21 +194,20 @@ GET /api/v1/devices/unknown-router/memory-summary
 
 ### Objective
 
-Verify the public `routerId` contract: 12 to 29 hexadecimal characters only. Syntax validation runs before OWPROV ownership resolution.
+Verify the public `routerId` contract: path-safe strings only (1 to 64 alphanumeric characters, hyphens, or underscores matching `^[a-zA-Z0-9_-]+$`). Syntax validation runs before OWPROV ownership resolution.
 
 ### Requests and expected results
 
 | routerId path segment | Expected result |
 | --- | --- |
-| `abcdef12345` | HTTP `400 Bad Request`, `error: "invalid_router_id"` because the value has 11 hex characters. |
 | `abcdef123456` | Syntax is accepted. If the gateway does not exist or is outside scope, return HTTP `404 Not Found`, `error: "not_found"`. |
-| `abcdef123456abcdef123456abcde` | Syntax is accepted. If the gateway does not exist or is outside scope, return HTTP `404 Not Found`, `error: "not_found"`. |
-| `abcdef123456abcdef123456abcdef` | HTTP `400 Bad Request`, `error: "invalid_router_id"` because the value has 30 hex characters. |
+| `gateway-serial-1234` | Syntax is accepted (non-hex alphanumeric string with hyphens). If the gateway does not exist in OWPROV, return HTTP `404 Not Found`, `error: "not_found"`. |
 | `ABCDEF123456` | Syntax is accepted. If the gateway does not exist or is outside scope, return HTTP `404 Not Found`, `error: "not_found"`. |
-| `abcdef12345G` | HTTP `400 Bad Request`, `error: "invalid_router_id"` because `G` is not hexadecimal. |
 | `.` | Handler-level validation returns HTTP `400 Bad Request`, `error: "invalid_router_id"`. End-to-end route tests may observe framework-level rejection first if the server normalizes dot-segments, but OWPROV lookup must not run. |
 | `..` | Handler-level validation returns HTTP `400 Bad Request`, `error: "invalid_router_id"`. End-to-end route tests may observe framework-level rejection first if the server normalizes dot-segments, but OWPROV lookup must not run. |
 | `abc%2Fdef123456` | Rejected before OWPROV lookup. Encoded path separators must not be decoded into a router ID that reaches ownership resolution. |
+| `:::`, `router space` | HTTP `400 Bad Request`, `error: "invalid_router_id"` because punctuation or spaces violate path-safety validation. |
+| (string > 64 chars) | HTTP `400 Bad Request`, `error: "invalid_router_id"` because max length is 64 characters. |
 
 For all rejected syntax cases, OWPROV ownership lookup and metric aggregation are not executed.
 
@@ -1923,42 +1930,30 @@ GET /api/v1/devices/deadbeef1234/availability-summary
 
 ### Objective
 
-Verify that syntactically invalid router IDs (such as non-hexadecimal values or invalid punctuation) are rejected with HTTP 400 before OWPROV ownership lookup or availability database queries are executed.
+Verify that syntactically invalid router IDs (such as path dot-segments, path separators, spaces, or invalid punctuation) are rejected with HTTP 400 before OWPROV ownership lookup or availability database queries are executed.
 
 ### Requests
 
-1. Handler-level validation requests (length, non-hexadecimal, or invalid punctuation):
+1. Handler-level validation requests (invalid path characters or out-of-bounds length):
 
 ```http
-GET /api/v1/devices/unknown-router/availability-summary
-    ?timestampTill=2026-07-29T12:00:00Z
-    &lookbackHours=24
-
 GET /api/v1/devices/:::/availability-summary
     ?timestampTill=2026-07-29T12:00:00Z
     &lookbackHours=24
 
-GET /api/v1/devices/abcdef12345/availability-summary
-    ?timestampTill=2026-07-29T12:00:00Z
-    &lookbackHours=24
-
-GET /api/v1/devices/abcdef123456abcdef123456abcdef/availability-summary
-    ?timestampTill=2026-07-29T12:00:00Z
-    &lookbackHours=24
-
-GET /api/v1/devices/abcdef12345G/availability-summary
+GET /api/v1/devices/router%20id/availability-summary
     ?timestampTill=2026-07-29T12:00:00Z
     &lookbackHours=24
 ```
 
-2. Syntax-accepted nonexistent values:
+2. Syntax-accepted nonexistent values (hexadecimal and non-hex serial strings):
 
 ```http
 GET /api/v1/devices/abcdef123456/availability-summary
     ?timestampTill=2026-07-29T12:00:00Z
     &lookbackHours=24
 
-GET /api/v1/devices/abcdef123456abcdef123456abcde/availability-summary
+GET /api/v1/devices/gateway-serial-1234/availability-summary
     ?timestampTill=2026-07-29T12:00:00Z
     &lookbackHours=24
 
@@ -1977,21 +1972,21 @@ GET /api/v1/devices/abc%2Fdef123456/availability-summary
 
 ### Expected result
 
-* For handler-level validation requests (`unknown-router`, `:::`, 11 hex characters, 30 hex characters, non-hex `G`):
+* For handler-level validation requests (`:::`, spaces):
   * HTTP `400 Bad Request`.
   * Response resembles:
 
 ```json
 {
   "error": "invalid_router_id",
-  "message": "routerId must be a valid 12-29 hex character gateway serial number"
+  "message": "routerId must be a valid path-safe OWPROV gateway serial number (1 to 64 alphanumeric characters, hyphens, or underscores)"
 }
 ```
 
   * OWPROV resolution is not called.
   * No availability query is executed.
 
-* For syntax-accepted nonexistent values (12 hex characters, 29 hex characters, and uppercase hexadecimal):
+* For syntax-accepted nonexistent values (`abcdef123456`, `gateway-serial-1234`, and uppercase hexadecimal):
   * HTTP `404 Not Found`.
   * Error is `not_found`.
   * The response proves the value passed syntax validation before OWPROV ownership resolution determined it was nonexistent or outside scope.
@@ -3908,6 +3903,22 @@ serialNumber = routerId
 * Malformed record is skipped and logged.
 * Other valid records in the requested range are processed.
 * Fabricated usage is not returned.
+
+---
+
+## TC-USAGE-027: Client with only outside-window boundary fallback samples
+
+### Test data
+
+* Requested time window: `[10:00:00Z, 11:00:00Z)`.
+* Database contains a sample for station MAC `aa:bb:cc:dd:ee:ff` at `09:58:00Z` (pre-window boundary sample within 2x interval tolerance).
+* Database contains NO in-window observations (`[10:00:00Z, 11:00:00Z)`) and no proven session overlap during `[10:00:00Z, 11:00:00Z)` for station `aa:bb:cc:dd:ee:ff`.
+
+### Expected result
+
+* Station MAC `aa:bb:cc:dd:ee:ff` is EXCLUDED from `items[]` and NOT counted in `totalClients`.
+* Outside-window fallback samples are used solely for calculating boundary differentials for clients with proven in-window presence or session overlap.
+* Response returns `items: []`, `totalClients: 0`, and `truncated: false`.
 
 ---
 

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -179,6 +179,30 @@ GET /api/v1/devices/unknown-router/memory-summary
 
 ---
 
+## TC-COMMON-005A: Router ID syntax boundaries
+
+### Objective
+
+Verify the public `routerId` contract: 12 to 29 hexadecimal characters only. Syntax validation runs before OWPROV ownership resolution.
+
+### Requests and expected results
+
+| routerId path segment | Expected result |
+| --- | --- |
+| `abcdef12345` | HTTP `400 Bad Request`, `error: "invalid_router_id"` because the value has 11 hex characters. |
+| `abcdef123456` | Syntax is accepted. If the gateway does not exist or is outside scope, return HTTP `404 Not Found`, `error: "not_found"`. |
+| `abcdef123456abcdef123456abcde` | Syntax is accepted. If the gateway does not exist or is outside scope, return HTTP `404 Not Found`, `error: "not_found"`. |
+| `abcdef123456abcdef123456abcdef` | HTTP `400 Bad Request`, `error: "invalid_router_id"` because the value has 30 hex characters. |
+| `ABCDEF123456` | Syntax is accepted. If the gateway does not exist or is outside scope, return HTTP `404 Not Found`, `error: "not_found"`. |
+| `abcdef12345G` | HTTP `400 Bad Request`, `error: "invalid_router_id"` because `G` is not hexadecimal. |
+| `.` | Handler-level validation returns HTTP `400 Bad Request`, `error: "invalid_router_id"`. End-to-end route tests may observe framework-level rejection first if the server normalizes dot-segments, but OWPROV lookup must not run. |
+| `..` | Handler-level validation returns HTTP `400 Bad Request`, `error: "invalid_router_id"`. End-to-end route tests may observe framework-level rejection first if the server normalizes dot-segments, but OWPROV lookup must not run. |
+| `abc%2Fdef123456` | Rejected before OWPROV lookup. Encoded path separators must not be decoded into a router ID that reaches ownership resolution. |
+
+For all rejected syntax cases, OWPROV ownership lookup and metric aggregation are not executed.
+
+---
+
 ## TC-COMMON-006: Router inventory has no venue
 
 ### Preconditions
@@ -272,7 +296,7 @@ Verify that non-UTC timezone formats, explicit numeric timezone offsets, or miss
 
 ```http
 GET /api/v1/devices/60cf84f22290/memory-summary
-    ?timestampTill=2026-07-29T12:00:00+05:30
+    ?timestampTill=2026-07-29T12:00:00%2B05:30
     &lookbackHours=24
 ```
 
@@ -297,6 +321,28 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 ```
 
 * OWPROV ownership lookup and metric aggregation are not executed.
+
+---
+
+## TC-COMMON-011A: Literal unencoded plus in timestamp is malformed
+
+### Objective
+
+Verify that a literal `+` in a query string is not treated as a valid numeric timezone offset. HTTP frameworks commonly decode `+` as a space in query parameters.
+
+### Request
+
+```http
+GET /api/v1/devices/60cf84f22290/memory-summary
+    ?timestampTill=2026-07-29T12:00:00+05:30
+    &lookbackHours=24
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error is `invalid_timestamp`.
+* The encoded numeric-offset case in `TC-COMMON-011` is still required to prove valid RFC3339 numeric offsets are intentionally unsupported.
 
 ---
 
@@ -330,7 +376,7 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
-* Error is `invalid_lookback`, not `invalid_timestamp`.
+* Error is `invalid_lookback_hours`, not `invalid_timestamp`.
 
 ---
 
@@ -346,7 +392,7 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
-* Error is `invalid_lookback`, not `invalid_timestamp`.
+* Error is `invalid_lookback_hours`, not `invalid_timestamp`.
 
 ---
 
@@ -362,7 +408,7 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
-* Error is `invalid_lookback`, not `invalid_timestamp`.
+* Error is `invalid_lookback_hours`, not `invalid_timestamp`.
 * Error message may indicate that the maximum supported lookback was exceeded.
 
 ---
@@ -393,7 +439,109 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
-* Error is `invalid_lookback`, not `invalid_timestamp`.
+* Error is `invalid_lookback_hours`, not `invalid_timestamp`.
+
+---
+
+## TC-COMMON-017A: Non-numeric lookback
+
+### Request
+
+```http
+?timestampTill=2026-07-29T12:00:00Z
+&lookbackHours=abc
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error is `invalid_lookback_hours`, not `invalid_timestamp`.
+* The value is not accepted as `0` or as a missing parameter.
+
+---
+
+## TC-COMMON-017B: Fractional lookback
+
+### Request
+
+```http
+?timestampTill=2026-07-29T12:00:00Z
+&lookbackHours=1.5
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error is `invalid_lookback_hours`, not `invalid_timestamp`.
+* `lookbackHours` must be parsed as a strict whole decimal integer.
+
+---
+
+## TC-COMMON-017C: Partially numeric lookback
+
+### Request
+
+```http
+?timestampTill=2026-07-29T12:00:00Z
+&lookbackHours=24hours
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error is `invalid_lookback_hours`, not `invalid_timestamp`.
+* Parsers must reject partial conversions such as `atoi("24hours") == 24`.
+
+---
+
+## TC-COMMON-017D: Empty lookback
+
+### Request
+
+```http
+?timestampTill=2026-07-29T12:00:00Z
+&lookbackHours=
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error is `invalid_lookback_hours`, not `invalid_timestamp`.
+
+---
+
+## TC-COMMON-017E: Overflowing lookback
+
+### Request
+
+```http
+?timestampTill=2026-07-29T12:00:00Z
+&lookbackHours=999999999999999999999
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error is `invalid_lookback_hours`, not `invalid_timestamp`.
+* The value is rejected before integer overflow, wraparound, or truncation can affect range calculation.
+
+---
+
+## TC-COMMON-017F: Repeated lookback parameter
+
+### Request
+
+```http
+?timestampTill=2026-07-29T12:00:00Z
+&lookbackHours=24
+&lookbackHours=48
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error is `invalid_lookback_hours`, not `invalid_timestamp`.
+* Repeated `lookbackHours` query parameters are ambiguous and must not be accepted by picking the first or last value.
 
 ---
 
@@ -686,9 +834,47 @@ updated_at >= processing time
 
 ```json
 {
-  "gw_uuid": "60cf84f22290",
-  "fetch_status": "success",
-  "offline_count": 0
+  "meta": {
+    "requestedWindow": {
+      "from": "<startTime>",
+      "till": "<endTime>"
+    },
+    "observedWindow": {
+      "firstSampleAt": null,
+      "lastSampleAt": null
+    },
+    "sourceWindow": {
+      "firstSampleAt": "<firstSourceAt>",
+      "lastSampleAt": "<lastSourceAt>"
+    },
+    "contributingWindow": {
+      "firstSampleAt": null,
+      "lastSampleAt": null
+    },
+    "selection": "boundary_assisted",
+    "coverage": "full",
+    "accuracy": "exact",
+    "sampleCount": 0,
+    "effectiveSamplingIntervalSeconds": 0,
+    "allowedGapSeconds": 0,
+    "boundarySamplesUsed": {
+      "beforeStart": true,
+      "atStart": false,
+      "atEnd": false,
+      "afterEnd": false
+    },
+    "availabilityCoverage": {
+      "coverageStart": "<= startTime",
+      "processedThrough": ">= endTime",
+      "ingestionGapKnown": false,
+      "proofSource": "serial_partition_checkpoint"
+    }
+  },
+  "data": {
+    "gw_uuid": "60cf84f22290",
+    "fetch_status": "success",
+    "offline_count": 0
+  }
 }
 ```
 
@@ -780,9 +966,47 @@ event_time = disconnection message timestamp
 
 ```json
 {
-  "gw_uuid": "60cf84f22290",
-  "fetch_status": "success",
-  "offline_count": 1
+  "meta": {
+    "requestedWindow": {
+      "from": "<startTime>",
+      "till": "<endTime>"
+    },
+    "observedWindow": {
+      "firstSampleAt": "<firstOfflineEventAt>",
+      "lastSampleAt": "<lastOfflineEventAt>"
+    },
+    "sourceWindow": {
+      "firstSampleAt": "<firstSourceAt>",
+      "lastSampleAt": "<lastSourceAt>"
+    },
+    "contributingWindow": {
+      "firstSampleAt": "<firstOfflineEventAt>",
+      "lastSampleAt": "<lastOfflineEventAt>"
+    },
+    "selection": "boundary_assisted",
+    "coverage": "full",
+    "accuracy": "exact",
+    "sampleCount": 1,
+    "effectiveSamplingIntervalSeconds": 0,
+    "allowedGapSeconds": 0,
+    "boundarySamplesUsed": {
+      "beforeStart": true,
+      "atStart": false,
+      "atEnd": false,
+      "afterEnd": false
+    },
+    "availabilityCoverage": {
+      "coverageStart": "<= startTime",
+      "processedThrough": ">= endTime",
+      "ingestionGapKnown": false,
+      "proofSource": "serial_partition_checkpoint"
+    }
+  },
+  "data": {
+    "gw_uuid": "60cf84f22290",
+    "fetch_status": "success",
+    "offline_count": 1
+  }
 }
 ```
 
@@ -949,9 +1173,47 @@ API result:
 
 ```json
 {
-  "gw_uuid": "60cf84f22290",
-  "fetch_status": "success",
-  "offline_count": 1
+  "meta": {
+    "requestedWindow": {
+      "from": "<startTime>",
+      "till": "<endTime>"
+    },
+    "observedWindow": {
+      "firstSampleAt": "<firstOfflineEventAt>",
+      "lastSampleAt": "<lastOfflineEventAt>"
+    },
+    "sourceWindow": {
+      "firstSampleAt": "<firstSourceAt>",
+      "lastSampleAt": "<lastSourceAt>"
+    },
+    "contributingWindow": {
+      "firstSampleAt": "<firstOfflineEventAt>",
+      "lastSampleAt": "<lastOfflineEventAt>"
+    },
+    "selection": "boundary_assisted",
+    "coverage": "full",
+    "accuracy": "exact",
+    "sampleCount": 1,
+    "effectiveSamplingIntervalSeconds": 0,
+    "allowedGapSeconds": 0,
+    "boundarySamplesUsed": {
+      "beforeStart": true,
+      "atStart": false,
+      "atEnd": false,
+      "afterEnd": false
+    },
+    "availabilityCoverage": {
+      "coverageStart": "<= startTime",
+      "processedThrough": ">= endTime",
+      "ingestionGapKnown": false,
+      "proofSource": "serial_partition_checkpoint"
+    }
+  },
+  "data": {
+    "gw_uuid": "60cf84f22290",
+    "fetch_status": "success",
+    "offline_count": 1
+  }
 }
 ```
 
@@ -1029,9 +1291,47 @@ The API returns:
 
 ```json
 {
-  "gw_uuid": "60cf84f22290",
-  "fetch_status": "success",
-  "offline_count": 3
+  "meta": {
+    "requestedWindow": {
+      "from": "<startTime>",
+      "till": "<endTime>"
+    },
+    "observedWindow": {
+      "firstSampleAt": "<firstOfflineEventAt>",
+      "lastSampleAt": "<lastOfflineEventAt>"
+    },
+    "sourceWindow": {
+      "firstSampleAt": "<firstSourceAt>",
+      "lastSampleAt": "<lastSourceAt>"
+    },
+    "contributingWindow": {
+      "firstSampleAt": "<firstOfflineEventAt>",
+      "lastSampleAt": "<lastOfflineEventAt>"
+    },
+    "selection": "boundary_assisted",
+    "coverage": "full",
+    "accuracy": "exact",
+    "sampleCount": 3,
+    "effectiveSamplingIntervalSeconds": 0,
+    "allowedGapSeconds": 0,
+    "boundarySamplesUsed": {
+      "beforeStart": true,
+      "atStart": false,
+      "atEnd": false,
+      "afterEnd": false
+    },
+    "availabilityCoverage": {
+      "coverageStart": "<= startTime",
+      "processedThrough": ">= endTime",
+      "ingestionGapKnown": false,
+      "proofSource": "serial_partition_checkpoint"
+    }
+  },
+  "data": {
+    "gw_uuid": "60cf84f22290",
+    "fetch_status": "success",
+    "offline_count": 3
+  }
 }
 ```
 
@@ -1294,6 +1594,11 @@ offline event = 16:00
 
 Verify successful empty results.
 
+### Preconditions
+
+* The requested range starts at or after `availabilityValidFrom`.
+* The cutover behavior for ranges beginning before `availabilityValidFrom` is covered by `TC-COMMON-023`.
+
 ### Steps
 
 1. Select a time range containing no offline events.
@@ -1301,15 +1606,125 @@ Verify successful empty results.
 
 ### Expected result
 
+* The response uses the top-level `meta` and `data` shape.
+* `meta.coverage = "full"`.
+* `meta.accuracy = "exact"`.
+* `meta.availabilityCoverage.coverageStart <= startTime`.
+* `meta.availabilityCoverage.processedThrough >= endTime`.
+* `meta.availabilityCoverage.ingestionGapKnown = false`.
+* `meta.availabilityCoverage.proofSource != "unavailable"`.
+* `data.gw_uuid = "60cf84f22290"`.
+* `data.fetch_status = "success"`.
+* `data.offline_count = 0`.
+
 ```json
 {
-  "gw_uuid": "60cf84f22290",
-  "fetch_status": "success",
-  "offline_count": 0
+  "meta": {
+    "requestedWindow": {
+      "from": "<startTime>",
+      "till": "<endTime>"
+    },
+    "observedWindow": {
+      "firstSampleAt": null,
+      "lastSampleAt": null
+    },
+    "sourceWindow": {
+      "firstSampleAt": "<firstSourceAt>",
+      "lastSampleAt": "<lastSourceAt>"
+    },
+    "contributingWindow": {
+      "firstSampleAt": null,
+      "lastSampleAt": null
+    },
+    "selection": "boundary_assisted",
+    "coverage": "full",
+    "accuracy": "exact",
+    "sampleCount": 0,
+    "effectiveSamplingIntervalSeconds": 0,
+    "allowedGapSeconds": 0,
+    "boundarySamplesUsed": {
+      "beforeStart": true,
+      "atStart": false,
+      "atEnd": false,
+      "afterEnd": false
+    },
+    "availabilityCoverage": {
+      "coverageStart": "<= startTime",
+      "processedThrough": ">= endTime",
+      "ingestionGapKnown": false,
+      "proofSource": "serial_partition_checkpoint"
+    }
+  },
+  "data": {
+    "gw_uuid": "60cf84f22290",
+    "fetch_status": "success",
+    "offline_count": 0
+  }
 }
 ```
 
-The API must not treat an empty result as an error.
+The API must not treat a full-coverage empty result as an error. Absence of
+matching offline rows is not enough by itself to prove an exact zero; if coverage
+is partial or unavailable, the response must use partial/lower-bound or no
+coverage semantics instead of reporting an exact zero.
+
+---
+
+## TC-AVAIL-018A: No offline events with partial ingestion coverage
+
+### Objective
+
+Verify that zero matching offline rows are not reported as an exact zero when the
+availability ingestion stream does not prove full interval coverage.
+
+### Preconditions
+
+* The requested range starts at or after `availabilityValidFrom`.
+* No `offline` rows match `[startTime, endTime)`.
+* `availabilityCoverage.processedThrough < endTime` or a known ingestion gap overlaps the requested range.
+
+### Steps
+
+1. Select a range with no matching offline rows.
+2. Set availability coverage proof to overlap only part of the requested range.
+3. Call the availability-summary API.
+
+### Expected result
+
+* HTTP `200 OK`.
+* `data.offline_count = 0`.
+* `meta.coverage = "partial"`.
+* `meta.accuracy = "lower_bound"`.
+* The response includes `meta.availabilityCoverage`.
+* The response must not describe the zero as exact full coverage.
+
+---
+
+## TC-AVAIL-018B: No offline events with unavailable ingestion coverage
+
+### Objective
+
+Verify that the API does not present a zero matching count as a meaningful
+interval result when no durable availability coverage proof exists.
+
+### Preconditions
+
+* No `offline` rows match `[startTime, endTime)`.
+* `availabilityCoverage.proofSource = "unavailable"` or no durable processed-through watermark exists.
+
+### Steps
+
+1. Select a range with no matching offline rows.
+2. Make availability coverage proof unavailable.
+3. Call the availability-summary API.
+
+### Expected result
+
+* HTTP `200 OK` when the storage query itself succeeds.
+* `meta.coverage = "none"`.
+* `meta.accuracy = "not_applicable"`.
+* `meta.availabilityCoverage.proofSource = "unavailable"`.
+* `data.offline_count` is not asserted as an exact outage count for the interval.
 
 ---
 
@@ -1328,9 +1743,17 @@ Requested lookback: 24 hours
 
 ### Expected result
 
-```text
-offline_count = 0
-```
+* The old event is excluded by the half-open requested window.
+* `data.offline_count = 0` only when the response proves full availability coverage.
+* `meta.coverage = "full"`.
+* `meta.accuracy = "exact"`.
+* `meta.availabilityCoverage.coverageStart <= startTime`.
+* `meta.availabilityCoverage.processedThrough >= endTime`.
+* `meta.availabilityCoverage.ingestionGapKnown = false`.
+* `meta.availabilityCoverage.proofSource != "unavailable"`.
+
+If these coverage assertions fail, the zero matching count must be reported using
+partial/lower-bound or no-coverage semantics instead of as an exact zero.
 
 ---
 
@@ -1381,7 +1804,7 @@ Verify that syntactically invalid router IDs (such as non-hexadecimal values or 
 
 ### Requests
 
-1. Handler-level validation requests (non-hexadecimal or invalid punctuation):
+1. Handler-level validation requests (length, non-hexadecimal, or invalid punctuation):
 
 ```http
 GET /api/v1/devices/unknown-router/availability-summary
@@ -1391,18 +1814,47 @@ GET /api/v1/devices/unknown-router/availability-summary
 GET /api/v1/devices/:::/availability-summary
     ?timestampTill=2026-07-29T12:00:00Z
     &lookbackHours=24
+
+GET /api/v1/devices/abcdef12345/availability-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=24
+
+GET /api/v1/devices/abcdef123456abcdef123456abcdef/availability-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=24
+
+GET /api/v1/devices/abcdef12345G/availability-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=24
 ```
 
-2. Framework / route-level security requests (path dot-segments):
+2. Syntax-accepted nonexistent values:
+
+```http
+GET /api/v1/devices/abcdef123456/availability-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=24
+
+GET /api/v1/devices/abcdef123456abcdef123456abcde/availability-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=24
+
+GET /api/v1/devices/ABCDEF123456/availability-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=24
+```
+
+3. Framework / route-level security requests (path dot-segments and encoded slash):
 
 ```http
 GET /api/v1/devices/./availability-summary
 GET /api/v1/devices/../availability-summary
+GET /api/v1/devices/abc%2Fdef123456/availability-summary
 ```
 
 ### Expected result
 
-* For handler-level validation requests (`unknown-router`, `:::`):
+* For handler-level validation requests (`unknown-router`, `:::`, 11 hex characters, 30 hex characters, non-hex `G`):
   * HTTP `400 Bad Request`.
   * Response resembles:
 
@@ -1416,9 +1868,15 @@ GET /api/v1/devices/../availability-summary
   * OWPROV resolution is not called.
   * No availability query is executed.
 
-* For framework / route-level dot-segment requests (`.`, `..`):
-  * Requests are normalized or rejected by the HTTP server/framework layer before reaching the handler.
-  * Dot-segments are never passed to OWPROV ownership resolution.
+* For syntax-accepted nonexistent values (12 hex characters, 29 hex characters, and uppercase hexadecimal):
+  * HTTP `404 Not Found`.
+  * Error is `not_found`.
+  * The response proves the value passed syntax validation before OWPROV ownership resolution determined it was nonexistent or outside scope.
+
+* For dot-segment and encoded slash requests (`.`, `..`, `%2F`):
+  * Handler-level validation of `.` and `..` returns HTTP `400 Bad Request` with `error: "invalid_router_id"` when those values reach the handler as router IDs.
+  * End-to-end route tests may observe framework-level rejection before reaching the handler if the HTTP server normalizes dot-segments or rejects encoded path separators.
+  * These path values are never passed to OWPROV ownership resolution.
 
 ---
 
@@ -1450,7 +1908,8 @@ GET /api/v1/devices/60cf84f22290/availability-summary
 
 ### Expected result
 
-* Request is rejected according to the API contract.
+* HTTP `400 Bad Request`.
+* Error is `invalid_timestamp`.
 * No query is executed with an undefined time range.
 
 ---
@@ -1468,7 +1927,7 @@ GET /api/v1/devices/60cf84f22290/availability-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
-* Error is `invalid_lookback`, not `invalid_timestamp`.
+* Error is `invalid_lookback_hours`, not `invalid_timestamp`.
 
 ---
 
@@ -1485,7 +1944,7 @@ GET /api/v1/devices/60cf84f22290/availability-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
-* Error is `invalid_lookback`, not `invalid_timestamp`.
+* Error is `invalid_lookback_hours`, not `invalid_timestamp`.
 
 ---
 
@@ -1502,7 +1961,7 @@ GET /api/v1/devices/60cf84f22290/availability-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
-* Error is `invalid_lookback`, not `invalid_timestamp`.
+* Error is `invalid_lookback_hours`, not `invalid_timestamp`.
 * Error message may indicate that the supported lookback limit was exceeded.
 
 ---
@@ -1558,8 +2017,9 @@ Verify that first-row creation is concurrency-safe and does not rely on locking 
 
 * The implementation uses an atomic first-row mechanism, such as `INSERT ... ON CONFLICT`, a PostgreSQL advisory transaction lock, or a serializable transaction with retry.
 * Exactly one `device_availability_state` row exists.
-* Exactly one offline transition row exists.
 * The final state is `current_state = offline`.
+* No offline transition row is inserted because the prior state was unknown.
+* A full-coverage availability-summary response for a window containing these first observations reports `data.offline_count = 0`, `meta.coverage = "full"`, and `meta.accuracy = "exact"`.
 
 ---
 
@@ -1567,7 +2027,7 @@ Verify that first-row creation is concurrency-safe and does not rely on locking 
 
 ### Objective
 
-Verify deterministic state when an offline and online source event are processed concurrently.
+Verify that an offline and online source event for the same gateway are applied in source-event order, even when delivery to workers is concurrent.
 
 ### Preconditions
 
@@ -1582,38 +2042,30 @@ Verify deterministic state when an offline and online source event are processed
 
 ### Expected result
 
-* State-row locking or equivalent serializes processing by `serialNumber`, but it does not sort messages by source `event_time`.
-* Either processing-order outcome is valid under the watermark design:
+* The ingestion path provides one explicit ordering guarantee for each `serialNumber` before transition detection, such as:
+  * Kafka partitioning keyed by `serialNumber`, preserving gateway event order; or
+  * a bounded event-time reorder window; or
+  * an equivalent serialNumber-scoped ordering mechanism that prevents a newer online event from causing an older offline transition to be discarded silently.
+* Processing must produce the source-time outcome:
 
 ```text
-Outcome 1:
-  12:03 offline processes first
-  offline transition event is inserted
-  device_availability_state.current_state = offline
-  last_event_time = 12:03
+12:03 offline is applied first
+offline transition event is inserted
+device_availability_state.current_state = offline
+last_event_time = 12:03
 
-  12:04 online processes second
-  online transition event is inserted
-  device_availability_state.current_state = online
-  last_event_time = 12:04
-
-Outcome 2:
-  12:04 online processes first
-  same-state online message updates last_event_time to 12:04
-  no transition event is inserted
-
-  12:03 offline processes second
-  offline message is rejected as stale because 12:03 < last_event_time 12:04
-  no transition event is inserted
+12:04 online is applied second
+online transition event is inserted
+device_availability_state.current_state = online
+last_event_time = 12:04
 ```
 
-* In both outcomes:
-  * Final `device_availability_state.current_state = online`.
-  * Final `last_event_time = 12:04`.
-  * State never moves backward.
-  * No duplicate transition events are inserted.
-  * State and event writes are atomic.
-* Outcome 2 can undercount a short outage. Preventing that undercount would require an additional ordering guarantee such as Kafka key ordering, an event-time reorder buffer, or another explicitly defined source-ordering mechanism.
+* Final `device_availability_state.current_state = online`.
+* Final `last_event_time = 12:04`.
+* State never moves backward.
+* No duplicate transition events are inserted.
+* State and event writes are atomic.
+* It is not valid to process the `12:04` online event first, mark the `12:03` offline event stale, and lose the outage. If the implementation intentionally chooses best-effort counting instead of an ordering guarantee, this test must be replaced by an explicit documented best-effort contract and must assert that the undercount is observable as degraded accuracy, not silently successful exact counting.
 
 ---
 
@@ -1749,32 +2201,16 @@ last_idempotency_key = ping-1210
 
 ---
 
-## TC-AVAIL-029B: Equal timestamp with deterministic source sequence is ordered
-
-### Objective
-
-Verify behavior when the source provides a reliable tie-breaker for same-timestamp events.
-
-### Steps
-
-1. Set `device_availability_state` to an online event at `12:10` with source sequence `10`.
-2. Deliver a disconnection for the same gateway at `12:10` with source sequence `11`.
-3. Query availability storage.
-
-### Expected result
-
-* The implementation accepts the disconnection only if the source sequence is documented as reliable.
-* One offline transition event is inserted.
-* `device_availability_state.current_state = offline`.
-* `last_event_time` remains `12:10`, and metadata records the accepted tie-breaker.
-
----
-
 ## TC-AVAIL-030: First event is a disconnection
 
 ### Objective
 
-Verify that a first observed `disconnection` message creates an offline transition.
+Verify the explicit bootstrap behavior when the first accepted availability
+message for a gateway is `disconnection`.
+
+This contract treats an initial unknown-to-offline observation as state
+initialization, not as a counted offline transition, because `offline_count`
+counts observed online-to-offline transitions.
 
 ### Preconditions
 
@@ -1789,10 +2225,9 @@ Verify that a first observed `disconnection` message creates an offline transiti
 
 ### Expected result
 
-* One `offline` event row is inserted.
-* The event uses the gateway `serialNumber`.
+* No `offline` transition event row is inserted.
 * A `device_availability_state` row is created with `current_state = offline` and `last_event_time` equal to the disconnection source timestamp.
-* `offline_count` is `1`.
+* A full-coverage availability-summary response for a window containing the first disconnection reports `data.offline_count = 0`, `meta.coverage = "full"`, and `meta.accuracy = "exact"`.
 
 ---
 
@@ -1939,9 +2374,47 @@ Ethernet reconnected        → online event
 
 ```json
 {
-  "gw_uuid": "60cf84f22290",
-  "fetch_status": "success",
-  "offline_count": 2
+  "meta": {
+    "requestedWindow": {
+      "from": "<startTime>",
+      "till": "<endTime>"
+    },
+    "observedWindow": {
+      "firstSampleAt": "<firstOfflineEventAt>",
+      "lastSampleAt": "<lastOfflineEventAt>"
+    },
+    "sourceWindow": {
+      "firstSampleAt": "<firstSourceAt>",
+      "lastSampleAt": "<lastSourceAt>"
+    },
+    "contributingWindow": {
+      "firstSampleAt": "<firstOfflineEventAt>",
+      "lastSampleAt": "<lastOfflineEventAt>"
+    },
+    "selection": "boundary_assisted",
+    "coverage": "full",
+    "accuracy": "exact",
+    "sampleCount": 2,
+    "effectiveSamplingIntervalSeconds": 0,
+    "allowedGapSeconds": 0,
+    "boundarySamplesUsed": {
+      "beforeStart": true,
+      "atStart": false,
+      "atEnd": false,
+      "afterEnd": false
+    },
+    "availabilityCoverage": {
+      "coverageStart": "<= startTime",
+      "processedThrough": ">= endTime",
+      "ingestionGapKnown": false,
+      "proofSource": "serial_partition_checkpoint"
+    }
+  },
+  "data": {
+    "gw_uuid": "60cf84f22290",
+    "fetch_status": "success",
+    "offline_count": 2
+  }
 }
 ```
 
@@ -2192,6 +2665,56 @@ The result is not truncated to `100`.
 ```text
 min_memfree <= avg_memfree <= max_memfree
 ```
+
+---
+
+## TC-MEM-012A: Negative memory value is excluded
+
+### Test data
+
+```text
+10:00 memory_free = -1      memory_total = 512000
+10:10 memory_free = 200000  memory_total = 512000
+10:20 memory_free = 300000  memory_total = 512000
+```
+
+### Expected result
+
+```json
+{
+  "min_memfree": 200000,
+  "max_memfree": 300000,
+  "avg_memfree": 250000.0
+}
+```
+
+* The negative `memory_free` sample is treated as corrupted telemetry and excluded.
+* It cannot make `min_memfree` negative or affect the average.
+
+---
+
+## TC-MEM-012B: Free memory exceeds total memory
+
+### Test data
+
+```text
+10:00 memory_free = 700000  memory_total = 512000
+10:10 memory_free = 200000  memory_total = 512000
+10:20 memory_free = 300000  memory_total = 512000
+```
+
+### Expected result
+
+```json
+{
+  "min_memfree": 200000,
+  "max_memfree": 300000,
+  "avg_memfree": 250000.0
+}
+```
+
+* When `memory_total` is present and `memory_free > memory_total`, the sample is treated as corrupted telemetry and excluded.
+* If all samples are excluded by this rule, the memory summary uses the same empty-sample response as `TC-MEM-005`.
 
 ---
 
@@ -2571,9 +3094,9 @@ Expected response:
     "rx_bytes": 106487500,
     "tx_bytes": 3851250,
     "total_bytes": 110338750,
-    "data_consume_rx": "851.90 Mb",
-    "data_consume_tx": "30.81 Mb",
-    "total_data_usage": "882.71 Mb",
+    "data_consume_rx": "106.49 MB",
+    "data_consume_tx": "3.85 MB",
+    "total_data_usage": "110.34 MB",
     "usage_accuracy": "exact",
     "incomplete": false
   }
@@ -2608,7 +3131,7 @@ TX usage = 2000 bytes
 Total = 7000 bytes
 ```
 
-The API converts the byte totals to decimal megabits.
+The API converts the byte totals to decimal megabytes.
 
 ---
 
@@ -2822,13 +3345,30 @@ Samples arrive in this order:
 
 ---
 
-## TC-USAGE-013: Same timestamp with deterministic tie-breakers
+## TC-USAGE-013: Same timestamp samples
+
+### Test data
+
+```text
+Case A, same stream and identical counters:
+10:00 BSSID-A SSID-A radio-1 RX=9000 TX=1000
+10:00 BSSID-A SSID-A radio-1 RX=9000 TX=1000
+
+Case B, same stream and different counters:
+10:00 BSSID-A SSID-A radio-1 RX=9000 TX=1000
+10:00 BSSID-A SSID-A radio-1 RX=1000 TX=500
+
+Case C, different stream keys:
+10:00 BSSID-A SSID-A radio-1 RX=9000 TX=1000
+10:00 BSSID-B SSID-B radio-2 RX=1000 TX=500
+```
 
 ### Expected result
 
-* BSSID, SSID, radio or other stable fields provide deterministic ordering.
-* Exact duplicates are removed.
-* Two unrelated streams are not combined incorrectly.
+* Case A is treated as an exact duplicate and collapses to one sample before delta calculation.
+* Case B is ambiguous and is excluded from delta calculation unless a reliable source sequence number proves temporal order.
+* Case C is calculated independently by stream key; different streams are not ordered against each other or combined.
+* BSSID, SSID, radio, or other stable fields identify streams. They must not be used as tie-breakers to invent temporal order for two different counter values with the same stream key and timestamp.
 
 ---
 
@@ -2867,7 +3407,7 @@ e2:51:95:ed:0f:28
 
 ```text
 data_consume_rx > 0
-data_consume_tx = 0.00 Mb
+data_consume_tx = 0.00 MB
 total_data_usage = RX usage
 ```
 
@@ -2878,7 +3418,7 @@ total_data_usage = RX usage
 ### Expected result
 
 ```text
-data_consume_rx = 0.00 Mb
+data_consume_rx = 0.00 MB
 data_consume_tx > 0
 total_data_usage = TX usage
 ```
@@ -2928,7 +3468,7 @@ total = 0
 
 ---
 
-## TC-USAGE-021: Byte-to-megabit conversion
+## TC-USAGE-021: Byte-to-megabyte conversion
 
 ### Test data
 
@@ -2939,13 +3479,13 @@ total = 0
 ### Expected result
 
 ```text
-8.00 Mb
+1.00 MB
 ```
 
 The implementation uses:
 
 ```text
-bytes * 8 / 1,000,000
+bytes / 1,000,000
 ```
 
 ---
@@ -2954,8 +3494,9 @@ bytes * 8 / 1,000,000
 
 ### Expected result
 
-* Decimal megabit conversion is labelled `Mb`.
-* If binary-byte conversion is used instead, it must not still be labelled `Mb`.
+* Decimal megabyte conversion is labelled `MB`.
+* The response must not use `Mb`, which commonly means megabits.
+* If binary-byte conversion is used instead, it must be labelled `MiB`.
 * Response formatting follows the API contract.
 
 ---
@@ -3435,11 +3976,11 @@ Memory API:      null summary fields
 Temperature API: null summary fields
 Usage API:       []
 RSSI API:        []
-Availability:    fetch_status = success, offline_count = 0 (when startTime >= availabilityValidFrom)
+Availability:    data.fetch_status = success, data.offline_count = 0, meta.coverage = full
 ```
 
 * All metric responses use HTTP `200 OK` when queries succeed but return no data.
-* Availability returns `fetch_status = "success"` and `offline_count = 0` only when `startTime >= availabilityValidFrom`.
+* Availability returns `data.fetch_status = "success"` and `data.offline_count = 0` as an exact result only when `startTime >= availabilityValidFrom`, `meta.coverage = "full"`, and `meta.availabilityCoverage.processedThrough >= endTime`.
 * If `startTime < availabilityValidFrom`, Availability returns `400 Bad Request` with `error: "availability_range_before_cutover"`.
 
 ---
@@ -3564,9 +4105,31 @@ rssi_total_samples
 Expected exact fields:
 
 ```text
+meta
+data
+```
+
+Expected `data` fields:
+
+```text
 gw_uuid
 fetch_status
 offline_count
+```
+
+Expected availability-specific `meta` fields:
+
+```text
+requestedWindow
+observedWindow
+sourceWindow
+contributingWindow
+selection
+coverage
+accuracy
+sampleCount
+boundarySamplesUsed
+availabilityCoverage
 ```
 
 ---
@@ -3618,7 +4181,20 @@ total_bytes = rx_bytes + tx_bytes
 * Memory min and max are numeric or `null`.
 * Memory average is numeric or `null`.
 * Temperature fields are numeric or `null`.
-* Usage fields are formatted strings using the documented unit.
+* Usage summary client objects use these exact data types:
+
+```text
+mac                 string
+rx_bytes            non-negative integer
+tx_bytes            non-negative integer
+total_bytes         non-negative integer
+data_consume_rx     formatted string using the documented unit
+data_consume_tx     formatted string using the documented unit
+total_data_usage    formatted string using the documented unit
+usage_accuracy      enum string: "exact" or "lower_bound"
+incomplete          boolean
+```
+
 * RSSI percentages are numeric.
 * RSSI sample count is an integer.
 * Offline count is a non-negative integer.

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -3965,7 +3965,7 @@ Query with `includeCalculationDetails=true` vs `includeCalculationDetails=false`
 
 ### Expected result
 
-* When `includeCalculationDetails=false` or omitted: `items[]` contain `mac`, `data_consume_rx`, `data_consume_tx`, `total_data_usage`, and `usage_accuracy`; `calculation_segments` array is omitted.
+* When `includeCalculationDetails=false` or omitted: `items[]` contain all mandatory `ClientBandwidthConsumption` fields (`mac`, `rx_bytes`, `tx_bytes`, `total_bytes`, `data_consume_rx`, `data_consume_tx`, `total_data_usage`, `incomplete`, `segment_count`, `boundary_fallback_used`, `usage_accuracy`). The `calculation_segments` array is omitted.
 * When `includeCalculationDetails=true`: `items[]` additionally expose `calculation_segments[]`. Each segment object has non-null required integer fields `rx_bytes`, `tx_bytes`, and `total_bytes`.
 * The byte invariant `rx_bytes + tx_bytes == total_bytes` holds for every segment.
 
@@ -3981,12 +3981,12 @@ Query with `includeCalculationDetails=true` vs `includeCalculationDetails=false`
 
 ### Expected result
 
-* Client A uses the 09:51:00Z sample as boundary baseline (accuracy `exact` or `bounded_interval`).
+* Client A uses the 09:51:00Z sample as boundary baseline; expected accuracy is deterministically `bounded_interval` (because actual start 09:51 != effective start 10:00).
 * Client B cannot use the 09:48:00Z sample because it exceeds 2x collection interval tolerance; Client B starts delta calculation from the first in-window sample at 10:05:00Z (accuracy `lower_bound`).
 
 ---
 
-## TC-USAGE-031: Result time window calculation
+## TC-USAGE-031: Result time window calculation and OpenAPI property naming
 
 ### Test data
 
@@ -3994,13 +3994,14 @@ Observations for requested window `[10:00:00Z, 11:00:00Z)` occur at `10:05:00Z` 
 
 ### Expected result
 
-* `resultTimeWindow.startTime` = `"2026-07-27T10:05:00Z"` (earliest contributing sample in window).
-* `resultTimeWindow.endTime` = `"2026-07-27T10:55:00Z"` (latest contributing sample in window).
+* `resultTimeWindow.earliestActualStartTime` = `"2026-07-27T10:05:00Z"` (earliest contributing sample in window).
+* `resultTimeWindow.latestActualEndTime` = `"2026-07-27T10:55:00Z"` (latest contributing sample in window).
+* `resultTimeWindow.boundaryFallbackUsed` = `false`.
 * `requestedTimeWindow` remains `"2026-07-27T10:00:00Z"` to `"2026-07-27T11:00:00Z"`.
 
 ---
 
-## TC-USAGE-032: Client truncation threshold and deterministic ordering
+## TC-USAGE-032: Client truncation threshold and total_bytes deterministic ordering
 
 ### Test data
 
@@ -4011,7 +4012,7 @@ Observations for requested window `[10:00:00Z, 11:00:00Z)` occur at `10:05:00Z` 
 * `totalClients` = 501.
 * `items[]` array length = 500.
 * `truncated` = `true`.
-* Returned 500 items are deterministically sorted by `total_data_usage` DESC, then station `mac` ASC (canonical lowercase) as tie-breaker.
+* Returned 500 items are deterministically sorted by raw `total_bytes` DESC, then normalized station `mac` ASC (canonical lowercase) as tie-breaker (not by rounded `total_data_usage` string).
 
 ---
 

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -914,8 +914,8 @@ updated_at >= processing time
 {
   "meta": {
     "requestedWindow": {
-      "from": "<startTime>",
-      "till": "<endTime>"
+      "startTime": "<startTime>",
+      "endTime": "<endTime>"
     },
     "observedWindow": {
       "firstSampleAt": null,
@@ -1048,8 +1048,8 @@ event_time = disconnection message timestamp
 {
   "meta": {
     "requestedWindow": {
-      "from": "<startTime>",
-      "till": "<endTime>"
+      "startTime": "<startTime>",
+      "endTime": "<endTime>"
     },
     "observedWindow": {
       "firstSampleAt": "<firstOfflineEventAt>",
@@ -1257,8 +1257,8 @@ API result:
 {
   "meta": {
     "requestedWindow": {
-      "from": "<startTime>",
-      "till": "<endTime>"
+      "startTime": "<startTime>",
+      "endTime": "<endTime>"
     },
     "observedWindow": {
       "firstSampleAt": "<firstOfflineEventAt>",
@@ -1377,8 +1377,8 @@ The API returns:
 {
   "meta": {
     "requestedWindow": {
-      "from": "<startTime>",
-      "till": "<endTime>"
+      "startTime": "<startTime>",
+      "endTime": "<endTime>"
     },
     "observedWindow": {
       "firstSampleAt": "<firstOfflineEventAt>",
@@ -1709,8 +1709,8 @@ Verify successful empty results.
 {
   "meta": {
     "requestedWindow": {
-      "from": "<startTime>",
-      "till": "<endTime>"
+      "startTime": "<startTime>",
+      "endTime": "<endTime>"
     },
     "observedWindow": {
       "firstSampleAt": null,
@@ -2590,8 +2590,8 @@ Ethernet reconnected        → online event
 {
   "meta": {
     "requestedWindow": {
-      "from": "<startTime>",
-      "till": "<endTime>"
+      "startTime": "<startTime>",
+      "endTime": "<endTime>"
     },
     "observedWindow": {
       "firstSampleAt": "<firstOfflineEventAt>",
@@ -4445,9 +4445,9 @@ a pre-start boundary event.
 
 ### Expected result
 
-* Usage and RSSI `mac` fields match `^[A-Fa-f0-9]{2}(:[A-Fa-f0-9]{2}){5}$`.
-* MAC addresses are returned as colon-separated six-octet values.
-* Arbitrary strings are not valid client MAC addresses in the response contract.
+* Usage and RSSI `mac` fields match `^[0-9a-f]{2}(:[0-9a-f]{2}){5}$`.
+* MAC addresses are returned as canonical lowercase colon-separated six-octet values.
+* Upper-case hex or arbitrary strings are not valid client MAC addresses in the response contract.
 
 ---
 

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -3997,13 +3997,15 @@ Query with `includeCalculationDetails=true` vs `includeCalculationDetails=false`
 
 ### Test data
 
-Observations for requested window `[10:00:00Z, 11:00:00Z)` occur at `10:05:00Z` and `10:55:00Z`.
+* Requested time window `[10:00:00Z, 11:00:00Z)`.
+* Observations occur exactly at start boundary `10:00:00Z` and end boundary `11:00:00Z`.
 
 ### Expected result
 
-* `resultTimeWindow.earliestActualStartTime` = `"2026-07-27T10:05:00Z"` (earliest contributing sample in window).
-* `resultTimeWindow.latestActualEndTime` = `"2026-07-27T10:55:00Z"` (latest contributing sample in window).
-* `resultTimeWindow.boundaryFallbackUsed` = `false`.
+* `resultTimeWindow.earliestActualStartTime` = `"2026-07-27T10:00:00Z"` (earliest contributing sample at effective start).
+* `resultTimeWindow.latestActualEndTime` = `"2026-07-27T11:00:00Z"` (latest contributing sample at effective end).
+* `resultTimeWindow.boundaryFallbackUsed` = `false` (exact boundary samples present).
+* `items[].usage_accuracy` = `"exact"`.
 * `requestedTimeWindow` remains `"2026-07-27T10:00:00Z"` to `"2026-07-27T11:00:00Z"`.
 
 ---

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -582,6 +582,24 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 
 ---
 
+## TC-COMMON-018A: Unauthenticated request with malformed query parameters
+
+### Request
+
+```http
+GET /api/v1/devices/unknown.router/wifi-clients/bandwidth-consumption?timestampTill=invalid-date&lookbackHours=-5
+```
+
+Headers: missing `Authorization` header.
+
+### Expected result
+
+* HTTP `401 Unauthorized`.
+* Error is `unauthorized`.
+* Phase 0 Bearer token authentication takes precedence over Phase 1 parameter validation. The request is rejected as unauthorized before parsing or validating `routerId`, `timestampTill`, or `lookbackHours`.
+
+---
+
 ## TC-COMMON-019: User is not authorized for the gateway scope
 
 ### Preconditions

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -858,17 +858,19 @@ updated_at >= processing time
     "coverage": "full",
     "accuracy": "exact",
     "sampleCount": 0,
+    "offlineEventCount": 0,
     "effectiveSamplingIntervalSeconds": 0,
     "allowedGapSeconds": 0,
     "boundarySamplesUsed": {
-      "beforeStart": true,
+      "beforeStart": false,
       "atStart": false,
       "atEnd": false,
       "afterEnd": false
     },
     "availabilityCoverage": {
       "coverageStart": "<= startTime",
-      "processedThrough": ">= endTime",
+      "processedThrough": ">= endTime - allowedIngestionDelaySeconds",
+      "allowedIngestionDelaySeconds": "<configured availability ingestion delay>",
       "ingestionGapKnown": false,
       "proofSource": "serial_partition_checkpoint"
     }
@@ -990,17 +992,19 @@ event_time = disconnection message timestamp
     "coverage": "full",
     "accuracy": "exact",
     "sampleCount": 1,
+    "offlineEventCount": 1,
     "effectiveSamplingIntervalSeconds": 0,
     "allowedGapSeconds": 0,
     "boundarySamplesUsed": {
-      "beforeStart": true,
+      "beforeStart": false,
       "atStart": false,
       "atEnd": false,
       "afterEnd": false
     },
     "availabilityCoverage": {
       "coverageStart": "<= startTime",
-      "processedThrough": ">= endTime",
+      "processedThrough": ">= endTime - allowedIngestionDelaySeconds",
+      "allowedIngestionDelaySeconds": "<configured availability ingestion delay>",
       "ingestionGapKnown": false,
       "proofSource": "serial_partition_checkpoint"
     }
@@ -1197,17 +1201,19 @@ API result:
     "coverage": "full",
     "accuracy": "exact",
     "sampleCount": 1,
+    "offlineEventCount": 1,
     "effectiveSamplingIntervalSeconds": 0,
     "allowedGapSeconds": 0,
     "boundarySamplesUsed": {
-      "beforeStart": true,
+      "beforeStart": false,
       "atStart": false,
       "atEnd": false,
       "afterEnd": false
     },
     "availabilityCoverage": {
       "coverageStart": "<= startTime",
-      "processedThrough": ">= endTime",
+      "processedThrough": ">= endTime - allowedIngestionDelaySeconds",
+      "allowedIngestionDelaySeconds": "<configured availability ingestion delay>",
       "ingestionGapKnown": false,
       "proofSource": "serial_partition_checkpoint"
     }
@@ -1315,17 +1321,19 @@ The API returns:
     "coverage": "full",
     "accuracy": "exact",
     "sampleCount": 3,
+    "offlineEventCount": 3,
     "effectiveSamplingIntervalSeconds": 0,
     "allowedGapSeconds": 0,
     "boundarySamplesUsed": {
-      "beforeStart": true,
+      "beforeStart": false,
       "atStart": false,
       "atEnd": false,
       "afterEnd": false
     },
     "availabilityCoverage": {
       "coverageStart": "<= startTime",
-      "processedThrough": ">= endTime",
+      "processedThrough": ">= endTime - allowedIngestionDelaySeconds",
+      "allowedIngestionDelaySeconds": "<configured availability ingestion delay>",
       "ingestionGapKnown": false,
       "proofSource": "serial_partition_checkpoint"
     }
@@ -1600,7 +1608,7 @@ Verify successful empty results.
 ### Preconditions
 
 * The requested range starts at or after `availabilityValidFrom`.
-* The gateway has a durable `device_availability_ingestion_checkpoint` with `coverage_start <= startTime` and `processed_through_event_time >= endTime`.
+* The gateway has a durable `device_availability_ingestion_checkpoint` with `coverage_start <= startTime` and `processed_through_event_time >= endTime - allowedIngestionDelaySeconds`.
 * No `device_availability_ingestion_gaps` row overlaps `[startTime, endTime)`.
 * The cutover behavior for ranges beginning before `availabilityValidFrom` is covered by `TC-COMMON-023`.
 
@@ -1615,7 +1623,7 @@ Verify successful empty results.
 * `meta.coverage = "full"`.
 * `meta.accuracy = "exact"`.
 * `meta.availabilityCoverage.coverageStart <= startTime`.
-* `meta.availabilityCoverage.processedThrough >= endTime`.
+* `meta.availabilityCoverage.processedThrough >= endTime - meta.availabilityCoverage.allowedIngestionDelaySeconds`.
 * `meta.availabilityCoverage.ingestionGapKnown = false`.
 * `meta.availabilityCoverage.proofSource != "unavailable"`.
 * `data.gw_uuid = "60cf84f22290"`.
@@ -1645,17 +1653,19 @@ Verify successful empty results.
     "coverage": "full",
     "accuracy": "exact",
     "sampleCount": 0,
+    "offlineEventCount": 0,
     "effectiveSamplingIntervalSeconds": 0,
     "allowedGapSeconds": 0,
     "boundarySamplesUsed": {
-      "beforeStart": true,
+      "beforeStart": false,
       "atStart": false,
       "atEnd": false,
       "afterEnd": false
     },
     "availabilityCoverage": {
       "coverageStart": "<= startTime",
-      "processedThrough": ">= endTime",
+      "processedThrough": ">= endTime - allowedIngestionDelaySeconds",
+      "allowedIngestionDelaySeconds": "<configured availability ingestion delay>",
       "ingestionGapKnown": false,
       "proofSource": "serial_partition_checkpoint"
     }
@@ -1686,7 +1696,7 @@ availability ingestion stream does not prove full interval coverage.
 
 * The requested range starts at or after `availabilityValidFrom`.
 * No `offline` rows match `[startTime, endTime)`.
-* `availabilityCoverage.processedThrough < endTime` or a known ingestion gap overlaps the requested range.
+* `availabilityCoverage.processedThrough < endTime - allowedIngestionDelaySeconds` or a known ingestion gap overlaps the covered portion of the requested range.
 
 ### Steps
 
@@ -1729,7 +1739,39 @@ interval result when no durable availability coverage proof exists.
 * `meta.coverage = "none"`.
 * `meta.accuracy = "not_applicable"`.
 * `meta.availabilityCoverage.proofSource = "unavailable"`.
-* `data.offline_count` is not asserted as an exact outage count for the interval.
+* `data.offline_count = null`.
+
+---
+
+## TC-AVAIL-018C: No offline events with last message inside ingestion allowance
+
+### Objective
+
+Verify that a healthy near-real-time query can still return exact coverage when
+the latest gateway source message is slightly before `endTime`.
+
+### Preconditions
+
+* The requested range starts at or after `availabilityValidFrom`.
+* No `offline` rows match `[startTime, endTime)`.
+* `allowedIngestionDelaySeconds = 60`.
+* The per-serial checkpoint has `coverage_start <= startTime`.
+* The latest processed source event for the gateway is a ping at `endTime - 30 seconds`.
+* No `device_availability_ingestion_gaps` row overlaps `[startTime, endTime - allowedIngestionDelaySeconds)`.
+
+### Steps
+
+1. Set the availability checkpoint `processed_through_event_time = endTime - 30 seconds`.
+2. Call the availability-summary API with `timestampTill = endTime`.
+
+### Expected result
+
+* HTTP `200 OK`.
+* `meta.coverage = "full"`.
+* `meta.accuracy = "exact"`.
+* `meta.availabilityCoverage.processedThrough >= endTime - meta.availabilityCoverage.allowedIngestionDelaySeconds`.
+* `meta.availabilityCoverage.ingestionGapKnown = false`.
+* `data.offline_count = 0`.
 
 ---
 
@@ -1753,7 +1795,7 @@ Requested lookback: 24 hours
 * `meta.coverage = "full"`.
 * `meta.accuracy = "exact"`.
 * `meta.availabilityCoverage.coverageStart <= startTime`.
-* `meta.availabilityCoverage.processedThrough >= endTime`.
+* `meta.availabilityCoverage.processedThrough >= endTime - meta.availabilityCoverage.allowedIngestionDelaySeconds`.
 * `meta.availabilityCoverage.ingestionGapKnown = false`.
 * `meta.availabilityCoverage.proofSource != "unavailable"`.
 
@@ -2188,11 +2230,12 @@ last_idempotency_key = ping-1210
 
 ---
 
-## TC-AVAIL-029A: Equal timestamp without tie-breaker is non-advancing
+## TC-AVAIL-029A: Equal timestamp without source sequence creates ambiguity gap
 
 ### Objective
 
-Verify that an opposite-state message with the same source timestamp does not create an arbitrary transition.
+Verify that a distinct opposite-state message with the same source timestamp is
+not silently discarded when no reliable source sequence can prove ordering.
 
 ### Steps
 
@@ -2204,18 +2247,63 @@ last_event_time = 12:10
 last_idempotency_key = ping-1210
 ```
 
-2. Deliver a disconnection for the same gateway with `event_time = 12:10` and no reliable source sequence.
+2. Deliver a disconnection for the same gateway with `event_time = 12:10`, a different logical `idempotency_key`, and no reliable source sequence.
+3. Query `device_availability_state`, `device_availability_events`, and `device_availability_ingestion_gaps`.
+
+### Expected result
+
+* The disconnection is treated as unordered or ambiguous, not as an exact duplicate.
+* No offline transition event is inserted.
+* `device_availability_state` remains unchanged.
+* An ingestion ambiguity gap is persisted for the overlapping source time.
+* Availability queries overlapping the ambiguous source time do not return `meta.accuracy = "exact"`.
+
+---
+
+## TC-AVAIL-029B: Equal timestamp with source sequence preserves transitions
+
+### Objective
+
+Verify that distinct opposite-state events sharing a timestamp are processed when
+a deterministic source sequence orders them.
+
+### Preconditions
+
+* Gateway state is initialized as online before `12:00:00`.
+* The source provides a reliable per-serial sequence field.
+
+### Steps
+
+1. Deliver a disconnection with:
+
+```text
+event_time = 12:00:00
+source_sequence = 100
+idempotency_key = offline-120000-100
+```
+
+2. Deliver a ping with:
+
+```text
+event_time = 12:00:00
+source_sequence = 101
+idempotency_key = online-120000-101
+```
+
 3. Query `device_availability_state` and `device_availability_events`.
 
 ### Expected result
 
-* The disconnection is treated as duplicate or non-advancing.
-* No offline transition event is inserted.
-* `device_availability_state` remains unchanged.
+* The offline transition is inserted with ordering key `(12:00:00, 100)`.
+* The online transition is inserted with ordering key `(12:00:00, 101)`.
+* `device_availability_state.current_state = online`.
+* `device_availability_state.last_event_time = 12:00:00`.
+* `device_availability_state.last_source_sequence = 101`.
+* A full-coverage query over this interval returns `offline_count = 1`.
 
 ---
 
-## TC-AVAIL-029B: Delayed offline before newer same-state ping is not lost
+## TC-AVAIL-029C: Delayed offline before newer same-state ping is not lost
 
 ### Objective
 
@@ -2369,6 +2457,8 @@ Verify that online transition rows do not affect `offline_count`.
 
 * The API counts only the two stored `offline` rows.
 * Stored `online` rows are ignored by the offline count.
+* `meta.sampleCount = 2`.
+* `meta.offlineEventCount = 2`.
 * `offline_count` is `2`.
 
 ---
@@ -2441,17 +2531,19 @@ Ethernet reconnected        → online event
     "coverage": "full",
     "accuracy": "exact",
     "sampleCount": 2,
+    "offlineEventCount": 2,
     "effectiveSamplingIntervalSeconds": 0,
     "allowedGapSeconds": 0,
     "boundarySamplesUsed": {
-      "beforeStart": true,
+      "beforeStart": false,
       "atStart": false,
       "atEnd": false,
       "afterEnd": false
     },
     "availabilityCoverage": {
       "coverageStart": "<= startTime",
-      "processedThrough": ">= endTime",
+      "processedThrough": ">= endTime - allowedIngestionDelaySeconds",
+      "allowedIngestionDelaySeconds": "<configured availability ingestion delay>",
       "ingestionGapKnown": false,
       "proofSource": "serial_partition_checkpoint"
     }
@@ -4026,7 +4118,7 @@ Availability:    data.fetch_status = success, data.offline_count = 0, meta.cover
 ```
 
 * All metric responses use HTTP `200 OK` when queries succeed but return no data.
-* Availability returns `data.fetch_status = "success"` and `data.offline_count = 0` as an exact result only when `startTime >= availabilityValidFrom`, `meta.coverage = "full"`, and `meta.availabilityCoverage.processedThrough >= endTime`.
+* Availability returns `data.fetch_status = "success"` and `data.offline_count = 0` as an exact result only when `startTime >= availabilityValidFrom`, `meta.coverage = "full"`, and `meta.availabilityCoverage.processedThrough >= endTime - meta.availabilityCoverage.allowedIngestionDelaySeconds`.
 * If `startTime < availabilityValidFrom`, Availability returns `400 Bad Request` with `error: "availability_range_before_cutover"`.
 
 ---
@@ -4163,6 +4255,9 @@ fetch_status
 offline_count
 ```
 
+`offline_count` is an integer for `coverage = "full"` or `coverage = "partial"`.
+It is `null` for `coverage = "none"` and `accuracy = "not_applicable"`.
+
 Expected availability-specific `meta` fields:
 
 ```text
@@ -4174,6 +4269,7 @@ selection
 coverage
 accuracy
 sampleCount
+offlineEventCount
 boundarySamplesUsed
 availabilityCoverage
 ```
@@ -4191,6 +4287,13 @@ proofSource
 `coverageStart` and `processedThrough` are derived from durable per-serial
 availability ingestion checkpoint state, and `ingestionGapKnown` reflects
 persisted gaps that overlap the requested interval.
+
+For availability responses, `sampleCount` and `offlineEventCount` both mean the
+number of offline transition rows contributing to `offline_count`; online
+transition rows do not contribute to either field. `boundarySamplesUsed` is
+data-dependent: `beforeStart` is `true` only when a pre-start boundary event was
+actually selected by the query setup, and event counting does not require a
+pre-start boundary event.
 
 ---
 

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -1582,10 +1582,38 @@ Verify deterministic state when an offline and online source event are processed
 
 ### Expected result
 
-* State-row locking or equivalent serializes processing by `serialNumber`.
-* Both events are processed in source-time order or retried until that ordering is respected.
-* Final `device_availability_state.current_state = online`.
-* Transition history contains one `offline` event at `12:03` and one `online` event at `12:04`.
+* State-row locking or equivalent serializes processing by `serialNumber`, but it does not sort messages by source `event_time`.
+* Either processing-order outcome is valid under the watermark design:
+
+```text
+Outcome 1:
+  12:03 offline processes first
+  offline transition event is inserted
+  device_availability_state.current_state = offline
+  last_event_time = 12:03
+
+  12:04 online processes second
+  online transition event is inserted
+  device_availability_state.current_state = online
+  last_event_time = 12:04
+
+Outcome 2:
+  12:04 online processes first
+  same-state online message updates last_event_time to 12:04
+  no transition event is inserted
+
+  12:03 offline processes second
+  offline message is rejected as stale because 12:03 < last_event_time 12:04
+  no transition event is inserted
+```
+
+* In both outcomes:
+  * Final `device_availability_state.current_state = online`.
+  * Final `last_event_time = 12:04`.
+  * State never moves backward.
+  * No duplicate transition events are inserted.
+  * State and event writes are atomic.
+* Outcome 2 can undercount a short outage. Preventing that undercount would require an additional ordering guarantee such as Kafka key ordering, an event-time reorder buffer, or another explicitly defined source-ordering mechanism.
 
 ---
 

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -802,6 +802,7 @@ Verify that durable per-serial ingestion coverage watermarks are stored in a ded
 ```text
 serialNumber
 coverage_start
+state_known_from
 processed_through_event_time
 partition
 offset
@@ -812,7 +813,7 @@ updated_at
 metadata
 ```
 
-* `coverage_start` and `processed_through_event_time` exist and are 64-bit integers (`BIGINT`).
+* `coverage_start`, `state_known_from`, and `processed_through_event_time` exist and are 64-bit integers (`BIGINT`).
 * `ingestion_gap_known` exists and is boolean.
 
 ---
@@ -933,55 +934,13 @@ last_idempotency_key = ping idempotency key
 updated_at >= processing time
 ```
 
-* The availability API returns:
-
-```json
-{
-  "meta": {
-    "requestedWindow": {
-      "startTime": "<startTime>",
-      "endTime": "<endTime>"
-    },
-    "observedWindow": {
-      "firstSampleAt": null,
-      "lastSampleAt": null
-    },
-    "sourceWindow": {
-      "firstSampleAt": "<firstSourceAt>",
-      "lastSampleAt": "<lastSourceAt>"
-    },
-    "contributingWindow": {
-      "firstSampleAt": null,
-      "lastSampleAt": null
-    },
-    "selection": "boundary_assisted",
-    "coverage": "full",
-    "accuracy": "exact",
-    "sampleCount": 0,
-    "offlineEventCount": 0,
-    "effectiveSamplingIntervalSeconds": 0,
-    "allowedGapSeconds": 0,
-    "boundarySamplesUsed": {
-      "beforeStart": false,
-      "atStart": false,
-      "atEnd": false,
-      "afterEnd": false
-    },
-    "availabilityCoverage": {
-      "coverageStart": "<= startTime",
-      "processedThrough": ">= endTime",
-      "allowedIngestionDelaySeconds": "<configured availability ingestion delay>",
-      "ingestionGapKnown": false,
-      "proofSource": "serial_partition_checkpoint"
-    }
-  },
-  "data": {
-    "gw_uuid": "60cf84f22290",
-    "fetch_status": "success",
-    "offline_count": 0
-  }
-}
-```
+* The checkpoint's `state_known_from` timestamp is set to the first ping source timestamp.
+* If requested window starts BEFORE the first ping (`startTime < state_known_from`):
+  * Prior state boundary is unknown.
+  * The response returns `meta.coverage = "partial"`, `meta.accuracy = "lower_bound"`, and `meta.availabilityCoverage.stateKnownFrom` equal to the first ping timestamp.
+* If requested window starts AT OR AFTER the first ping (`startTime >= state_known_from`):
+  * State is authoritatively known as online throughout the window.
+  * The response returns `meta.coverage = "full"`, `meta.accuracy = "exact"`, `data.offline_count = 0`, and `meta.availabilityCoverage.stateKnownFrom = first ping timestamp`.
 
 ---
 
@@ -2650,7 +2609,24 @@ Ethernet reconnected        → online event
 
 ---
 
+## TC-AVAIL-034: Multi-replica and process restart availabilityValidFrom consistency
 
+### Objective
+
+Verify that `availabilityValidFrom` is loaded from a durable configuration key or DB migration metadata table so that multiple service replicas and restarted instances make identical cutover decisions.
+
+### Steps
+
+1. Configure `availability_valid_from = 2026-07-01T00:00:00Z` in system configuration / DB properties.
+2. Start Replica A and Replica B.
+3. Issue a request with `startTime = 2026-06-30T23:00:00Z` (`startTime < availabilityValidFrom`) to both replicas.
+4. Restart Replica A and reissue the same request.
+
+### Expected result
+
+* Both Replica A and Replica B reject the request with HTTP `400 Bad Request` and `error: "availability_range_before_cutover"`.
+* After restart, Replica A continues to return identical HTTP 400 rejection for `startTime < availabilityValidFrom`.
+* Dynamic process startup timestamps (e.g. `std::chrono::system_clock::now()`) are prohibited.
 
 ---
 
@@ -2918,9 +2894,26 @@ min_memfree <= avg_memfree <= max_memfree
 }
 ```
 
-* Parsing and validation check numeric type, integral value, non-negative range (`>= 0`), and 64-bit non-overflow BEFORE unsigned conversion.
-* Field-level isolation: The negative `memory_free = -1` field is identified prior to unsigned casting and treated as invalid/unset (`null`), so it does not throw an exception or corrupt `memory_total = 512000` in the same sample.
-* The invalid `memory_free` field is excluded from `min_memfree`, `max_memfree`, and `avg_memfree`.
+* Sample-level rejection policy: When any present memory field (`free`, `total`, `cached`, `buffered`) is negative (`< 0`), non-numeric, or invalid, the ENTIRE memory sample is marked invalid and excluded from aggregation.
+* The 10:00 sample containing `memory_free = -1` (or negative `memory_total = -1`, negative `memory_cached = -1`, or negative `memory_buffered = -1`) is rejected as corrupted telemetry.
+* Corrupted memory samples do not affect `min_memfree`, `max_memfree`, or `avg_memfree`.
+
+---
+
+## TC-MEM-012A1: Negative memory_total or cached/buffered rejects entire sample
+
+### Test data
+
+```text
+10:00 memory_free = 200000  memory_total = -1
+10:10 memory_free = 300000  memory_total = 512000
+```
+
+### Expected result
+
+* Sample 10:00 has valid `memory_free` but negative `memory_total`.
+* The entire 10:00 memory sample is rejected at ingestion/validation stage; `memory_free = 200000` is NOT retained or included in aggregation.
+* Aggregation uses only valid sample 10:10 (`min_memfree = 300000`, `max_memfree = 300000`, `avg_memfree = 300000.0`).
 
 ---
 
@@ -3942,6 +3935,23 @@ serialNumber = routerId
 * Station MAC `aa:bb:cc:dd:ee:ff` is EXCLUDED from `items[]` and NOT counted in `totalClients`.
 * Outside-window fallback samples are used solely for calculating boundary differentials for clients with proven in-window presence or session overlap.
 * Response returns `items: []`, `totalClients: 0`, and `truncated: false`.
+
+---
+
+## TC-USAGE-028: Independent directional RX/TX counter calculation
+
+### Test data
+
+* Samples for client `11:22:33:44:55:66`:
+  * `10:00:00Z`: `rx_bytes = 1000`, `tx_bytes = -1` (invalid/missing TX)
+  * `10:10:00Z`: `rx_bytes = 3000`, `tx_bytes = 500`
+
+### Expected result
+
+* RX bytes are calculated independently: `3000 - 1000 = 2000` bytes (`data_consume_rx = 2.00 MB`).
+* TX bytes are uncalculable for 10:00:00Z sample; TX returns `"0.00 MB"` (or raw bytes `0` / `null` in segment details).
+* The stream usage accuracy is classified as `lower_bound`.
+* Client `11:22:33:44:55:66` is included in `items[]` and counted in `totalClients`.
 
 ---
 

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -551,25 +551,25 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 
 * HTTP `400 Bad Request`.
 * Error is `invalid_lookback_hours`, not `invalid_timestamp`.
-* The value is rejected before integer overflow, wraparound, or truncation can affect range calculation.
+* Repeated `lookbackHours` query parameters are ambiguous and must not be accepted by picking the first or last value.
 
 ---
 
-## TC-COMMON-017F: Repeated lookback parameter
+## TC-COMMON-017G: Timestamp arithmetic underflow before Unix epoch
 
 ### Request
 
 ```http
-?timestampTill=2026-07-29T12:00:00Z
-&lookbackHours=24
-&lookbackHours=48
+?timestampTill=1970-01-01T00:00:00Z
+&lookbackHours=1
 ```
 
 ### Expected result
 
 * HTTP `400 Bad Request`.
-* Error is `invalid_lookback_hours`, not `invalid_timestamp`.
-* Repeated `lookbackHours` query parameters are ambiguous and must not be accepted by picking the first or last value.
+* Error is `invalid_timestamp`.
+* Message states `"Calculated startTime precedes supported Unix epoch minimum"`.
+* Unsigned integer underflow / wraparound to large positive timestamps (e.g. `18446744073709548616`) is strictly prohibited.
 
 ---
 
@@ -1062,6 +1062,7 @@ event_time = disconnection message timestamp
     },
     "availabilityCoverage": {
       "coverageStart": "<= startTime",
+      "stateKnownFrom": "<= startTime",
       "processedThrough": ">= endTime",
       "allowedIngestionDelaySeconds": "<configured availability ingestion delay>",
       "ingestionGapKnown": false,
@@ -3943,15 +3944,74 @@ serialNumber = routerId
 ### Test data
 
 * Samples for client `11:22:33:44:55:66`:
-  * `10:00:00Z`: `rx_bytes = 1000`, `tx_bytes = -1` (invalid/missing TX)
-  * `10:10:00Z`: `rx_bytes = 3000`, `tx_bytes = 500`
+  * `10:00:00Z`: `rx_bytes = 1000000`, `tx_bytes = -1` (invalid/missing TX)
+  * `10:10:00Z`: `rx_bytes = 3000000`, `tx_bytes = 500000`
 
 ### Expected result
 
-* RX bytes are calculated independently: `3000 - 1000 = 2000` bytes (`data_consume_rx = 2.00 MB`).
-* TX bytes are uncalculable for 10:00:00Z sample; TX returns `"0.00 MB"` (or raw bytes `0` / `null` in segment details).
+* RX bytes are calculated independently: `3000000 - 1000000 = 2000000` bytes (`data_consume_rx = "2.00 MB"`).
+* TX bytes are uncalculable for 10:00:00Z sample; TX returns `0` bytes (required non-null integer in `calculation_segments`) and formatted `"0.00 MB"` in summary strings.
+* Segment `total_bytes` = `2000000 + 0 = 2000000`.
 * The stream usage accuracy is classified as `lower_bound`.
 * Client `11:22:33:44:55:66` is included in `items[]` and counted in `totalClients`.
+
+---
+
+## TC-USAGE-029: Calculation details flag and segment non-null integer invariants
+
+### Test data
+
+Query with `includeCalculationDetails=true` vs `includeCalculationDetails=false` (or omitted).
+
+### Expected result
+
+* When `includeCalculationDetails=false` or omitted: `items[]` contain `mac`, `data_consume_rx`, `data_consume_tx`, `total_data_usage`, and `usage_accuracy`; `calculation_segments` array is omitted.
+* When `includeCalculationDetails=true`: `items[]` additionally expose `calculation_segments[]`. Each segment object has non-null required integer fields `rx_bytes`, `tx_bytes`, and `total_bytes`.
+* The byte invariant `rx_bytes + tx_bytes == total_bytes` holds for every segment.
+
+---
+
+## TC-USAGE-030: Fallback boundary sampling 2x interval tolerance threshold
+
+### Test data
+
+* Expected collection interval = 300 seconds (5 minutes). Tolerance threshold = 2 * 300 = 600 seconds (10 minutes).
+* Client A has pre-start fallback sample at 09:51:00Z (9 minutes before 10:00:00Z start, within tolerance threshold).
+* Client B has pre-start fallback sample at 09:48:00Z (12 minutes before 10:00:00Z start, outside tolerance threshold).
+
+### Expected result
+
+* Client A uses the 09:51:00Z sample as boundary baseline (accuracy `exact` or `bounded_interval`).
+* Client B cannot use the 09:48:00Z sample because it exceeds 2x collection interval tolerance; Client B starts delta calculation from the first in-window sample at 10:05:00Z (accuracy `lower_bound`).
+
+---
+
+## TC-USAGE-031: Result time window calculation
+
+### Test data
+
+Observations for requested window `[10:00:00Z, 11:00:00Z)` occur at `10:05:00Z` and `10:55:00Z`.
+
+### Expected result
+
+* `resultTimeWindow.startTime` = `"2026-07-27T10:05:00Z"` (earliest contributing sample in window).
+* `resultTimeWindow.endTime` = `"2026-07-27T10:55:00Z"` (latest contributing sample in window).
+* `requestedTimeWindow` remains `"2026-07-27T10:00:00Z"` to `"2026-07-27T11:00:00Z"`.
+
+---
+
+## TC-USAGE-032: Client truncation threshold and deterministic ordering
+
+### Test data
+
+501 active clients exist in the requested window.
+
+### Expected result
+
+* `totalClients` = 501.
+* `items[]` array length = 500.
+* `truncated` = `true`.
+* Returned 500 items are deterministically sorted by `total_data_usage` DESC, then station `mac` ASC (canonical lowercase) as tie-breaker.
 
 ---
 

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -45,13 +45,16 @@ Before executing the test cases:
 ```text
 device_availability_events
 device_availability_state
+device_availability_ingestion_checkpoint
+device_availability_ingestion_gaps
 timepoints
 wificlienthistory
 ```
 
-8. Gateway availability uses `device_availability_state` as the authoritative restart-safe state table and `device_availability_events` as the transition log. Kafka `disconnection` messages are treated as `offline`; Kafka `ping` and `capabilities` messages are treated as `online`. Every accepted newer source message updates `device_availability_state.last_event_time`. `DeviceInfo.lastContact` is contact/processing metadata and is not used for source-event ordering.
-9. Database records for the test gateway are cleared or isolated before each independent test.
-10. A valid authorization token is available for testing endpoint access.
+8. Gateway availability uses `device_availability_state` as the authoritative restart-safe state table and `device_availability_events` as the transition log. Kafka `disconnection` messages are treated as `offline`; Kafka `ping` and `capabilities` messages are treated as `online`. Exact transition counting requires serialNumber-scoped source-event ordering before state-machine processing. Every accepted source-newer message emitted by that ordering stage updates `device_availability_state.last_event_time`. `DeviceInfo.lastContact` is contact/processing metadata and is not used for source-event ordering.
+9. Availability exact-zero responses require durable per-serial coverage proof in `device_availability_ingestion_checkpoint` and no overlapping persisted gap in `device_availability_ingestion_gaps`.
+10. Database records for the test gateway are cleared or isolated before each independent test.
+11. A valid authorization token is available for testing endpoint access.
 
 Example test parameters:
 
@@ -914,7 +917,7 @@ Example messages:
 ### Expected result
 
 * No additional `online` event is inserted after the first online state.
-* `last_event_time` is updated to the latest newer ping source timestamp.
+* `last_event_time` is updated to the latest source-newer ping timestamp accepted by the per-serial ordering stage.
 * `last_idempotency_key` is updated to the latest accepted ping idempotency key.
 * `current_state` remains `online`.
 * `offline_count` remains `0`.
@@ -1367,7 +1370,7 @@ Example:
 
 * Only the first offline transition is stored.
 * Later same-state disconnection messages are ignored.
-* For newer repeated disconnection messages while `current_state = offline`, `last_event_time` advances.
+* For source-newer repeated disconnection messages accepted by the per-serial ordering stage while `current_state = offline`, `last_event_time` advances.
 * `last_idempotency_key`, `updated_at`, and metadata are updated for the latest accepted same-state message.
 * `offline_count` is `1`.
 
@@ -1479,7 +1482,7 @@ Verify that repeated online messages after an offline-to-online transition do no
 
 * Exactly one online transition event is inserted.
 * No additional offline event is inserted.
-* The newer repeated ping updates `last_event_time`, `last_idempotency_key`, `updated_at`, and metadata.
+* The source-newer repeated ping accepted by the per-serial ordering stage updates `last_event_time`, `last_idempotency_key`, `updated_at`, and metadata.
 * `offline_count` is unchanged.
 
 ---
@@ -1597,6 +1600,8 @@ Verify successful empty results.
 ### Preconditions
 
 * The requested range starts at or after `availabilityValidFrom`.
+* The gateway has a durable `device_availability_ingestion_checkpoint` with `coverage_start <= startTime` and `processed_through_event_time >= endTime`.
+* No `device_availability_ingestion_gaps` row overlaps `[startTime, endTime)`.
 * The cutover behavior for ranges beginning before `availabilityValidFrom` is covered by `TC-COMMON-023`.
 
 ### Steps
@@ -2019,7 +2024,9 @@ Verify that first-row creation is concurrency-safe and does not rely on locking 
 * Exactly one `device_availability_state` row exists.
 * The final state is `current_state = offline`.
 * No offline transition row is inserted because the prior state was unknown.
-* A full-coverage availability-summary response for a window containing these first observations reports `data.offline_count = 0`, `meta.coverage = "full"`, and `meta.accuracy = "exact"`.
+* An availability-summary response for a window containing these first observations does not report an exact zero, because the prior state boundary is unknown.
+* The response uses `meta.coverage = "partial"` and `meta.accuracy = "lower_bound"` when durable coverage begins at the first observation, or `meta.coverage = "none"` and `meta.accuracy = "not_applicable"` when no coverage proof exists.
+* `data.offline_count = 0` may be returned only as the count of stored offline transitions, not as proof that zero outages occurred in the requested interval.
 
 ---
 
@@ -2144,7 +2151,14 @@ last_event_time = 12:10
 
 ### Objective
 
-Verify that an event older than `device_availability_state.last_event_time` cannot change availability history.
+Verify that an event older than `device_availability_state.last_event_time`
+cannot change availability history after the per-serial ordering strategy has
+advanced beyond that source time.
+
+### Preconditions
+
+* The connection topic is serialNumber-keyed and source-event ordered, or the bounded reorder window has already closed for source times up to `12:10`.
+* No ordering strategy can still accept a `12:05` transition for this serialNumber.
 
 ### Steps
 
@@ -2201,6 +2215,36 @@ last_idempotency_key = ping-1210
 
 ---
 
+## TC-AVAIL-029B: Delayed offline before newer same-state ping is not lost
+
+### Objective
+
+Verify that out-of-order Kafka delivery does not silently drop an older offline
+transition when a newer same-state online ping arrives first.
+
+### Preconditions
+
+* Gateway state is initialized as online at `12:00`.
+* The deployment does not rely on raw Kafka arrival order unless the topic is keyed and source-event ordered by serialNumber.
+
+### Steps
+
+1. Deliver a ping with source `event_time = 12:10`.
+2. Deliver a disconnection for the same gateway with source `event_time = 12:05`.
+3. Flush the per-serial ordering mechanism for source times through `12:10`.
+4. Query `device_availability_state` and `device_availability_events`.
+
+### Expected result
+
+* The `12:05` disconnection is accepted as an offline transition.
+* The `12:10` ping is accepted as an online transition after the offline transition.
+* `device_availability_state.current_state = online`.
+* `device_availability_state.last_event_time = 12:10`.
+* `offline_count` for a full-coverage window containing `12:05` is `1`.
+* If the implementation cannot provide serial-keyed source-event ordering or a bounded reorder window for this sequence, the API must not mark the count as `meta.accuracy = "exact"`.
+
+---
+
 ## TC-AVAIL-030: First event is a disconnection
 
 ### Objective
@@ -2227,7 +2271,9 @@ counts observed online-to-offline transitions.
 
 * No `offline` transition event row is inserted.
 * A `device_availability_state` row is created with `current_state = offline` and `last_event_time` equal to the disconnection source timestamp.
-* A full-coverage availability-summary response for a window containing the first disconnection reports `data.offline_count = 0`, `meta.coverage = "full"`, and `meta.accuracy = "exact"`.
+* An availability-summary response for a window containing the first disconnection does not report an exact zero, because the prior state boundary is unknown.
+* The response uses `meta.coverage = "partial"` and `meta.accuracy = "lower_bound"` when durable coverage begins at the first observation, or `meta.coverage = "none"` and `meta.accuracy = "not_applicable"` when no coverage proof exists.
+* A full-coverage exact-zero response is allowed only for a requested window that begins after this state initialization boundary and is fully covered by the per-serial ingestion checkpoint.
 
 ---
 
@@ -4131,6 +4177,20 @@ sampleCount
 boundarySamplesUsed
 availabilityCoverage
 ```
+
+Expected `meta.availabilityCoverage` fields:
+
+```text
+coverageStart
+processedThrough
+allowedIngestionDelaySeconds
+ingestionGapKnown
+proofSource
+```
+
+`coverageStart` and `processedThrough` are derived from durable per-serial
+availability ingestion checkpoint state, and `ingestionGapKnown` reflects
+persisted gaps that overlap the requested interval.
 
 ---
 

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -587,7 +587,7 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 ### Request
 
 ```http
-GET /api/v1/devices/unknown.router/wifi-clients/bandwidth-consumption?timestampTill=invalid-date&lookbackHours=-5
+GET /api/v1/devices/unknown.router/wifi-clients/usage-summary?timestampTill=invalid-date&lookbackHours=-5
 ```
 
 Headers: missing `Authorization` header.

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -312,6 +312,7 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
+* Error is `invalid_timestamp`.
 * The value is rejected even though it matches the timestamp shape.
 * No database aggregation is performed.
 
@@ -329,6 +330,7 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
+* Error is `invalid_lookback`, not `invalid_timestamp`.
 
 ---
 
@@ -344,6 +346,7 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
+* Error is `invalid_lookback`, not `invalid_timestamp`.
 
 ---
 
@@ -359,7 +362,8 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
-* Error indicates that the maximum supported lookback was exceeded.
+* Error is `invalid_lookback`, not `invalid_timestamp`.
+* Error message may indicate that the maximum supported lookback was exceeded.
 
 ---
 
@@ -374,6 +378,7 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
+* Error is `invalid_timestamp`.
 
 ---
 
@@ -388,6 +393,7 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
+* Error is `invalid_lookback`, not `invalid_timestamp`.
 
 ---
 
@@ -548,6 +554,7 @@ Verify that transition history is stored separately from current state.
 * Required event fields exist:
 
 ```text
+id
 serialNumber
 board_id
 event_type
@@ -556,10 +563,16 @@ event_id
 idempotency_key
 reason
 connection_ip
+session_id
 metadata
 ```
 
-* `idempotency_key` is unique.
+* `id` exists and is the primary key.
+* `serialNumber` is non-null.
+* `event_type` is non-null.
+* `event_time` is non-null.
+* `idempotency_key` is non-null and unique.
+* `session_id` exists and is nullable.
 * At least one index supports lookup by `serialNumber` and `event_time`.
 * `event_type` accepts only stored transition values `online` and `offline`.
 
@@ -1455,7 +1468,7 @@ GET /api/v1/devices/60cf84f22290/availability-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
-* Error indicates invalid lookback value.
+* Error is `invalid_lookback`, not `invalid_timestamp`.
 
 ---
 
@@ -1472,6 +1485,7 @@ GET /api/v1/devices/60cf84f22290/availability-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
+* Error is `invalid_lookback`, not `invalid_timestamp`.
 
 ---
 
@@ -1488,7 +1502,8 @@ GET /api/v1/devices/60cf84f22290/availability-summary
 ### Expected result
 
 * HTTP `400 Bad Request`.
-* Error indicates that the supported lookback limit was exceeded.
+* Error is `invalid_lookback`, not `invalid_timestamp`.
+* Error message may indicate that the supported lookback limit was exceeded.
 
 ---
 

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -24,11 +24,11 @@ get_gateway_offline_count
 
 The specification and test suite are modularized into three distinct architectural components:
 1. **Public API Contract Specification**: OpenAPI 3.0 schemas (`openapi/owanalytics.yaml` v2.7.0) defining external REST endpoints, query parameters, HTTP status codes, and response envelopes.
-2. **Persistence & Pipeline Architecture Design**: Backend storage structures (`device_availability_events`, `device_availability_state`), Kafka event consumption/ordering semantics, and cutover/migration behavior.
+2. **Persistence & Pipeline Architecture Design**: Backend storage structures (`device_availability_events`, `device_availability_state`, `device_availability_ingestion_checkpoint`, `device_availability_ingestion_gaps`), Kafka event consumption/ordering semantics, and cutover/migration behavior.
 3. **Test Specification & Verification Matrix**: Independent verification matrix (this document) defining assertion criteria for API contracts, integration workflows, white-box database rules, and failure modes.
 
-> [!NOTE]
-> Approving or executing this test specification validates implementation compliance with defined assertion logic. It does not replace or bypass separate architectural design approval for backend production schema additions or Kafka pipeline designs.
+> [!IMPORTANT]
+> This PR reframes and defines the complete target contract and test specification suite. The specified production architecture changes—including four new availability persistence tables (`device_availability_events`, `device_availability_state`, `device_availability_ingestion_checkpoint`, `device_availability_ingestion_gaps`), Kafka event ordering/checkpointing semantics, cutover migration rules, and OpenAPI v2.7.0 endpoint schemas—constitute a production architecture specification. Approving or merging this test specification PR does NOT bypass separate explicit architecture design sign-off for backend schema additions and production Kafka pipeline changes prior to production deployment.
 
 The test cases cover:
 * API contract tests for request shapes, HTTP status codes, response schemas, parameter validation, filtering, and half-open time-range window semantics `[startTime, endTime)`.
@@ -174,10 +174,10 @@ GET /api/v1/devices/deadbeef1234/memory-summary
 
 ### Steps
 
-Call an API with a syntactically invalid router ID:
+Call an API with a syntactically invalid router ID (e.g. containing invalid dot-segment punctuation `.`):
 
 ```http
-GET /api/v1/devices/unknown-router/memory-summary
+GET /api/v1/devices/unknown.router/memory-summary
     ?timestampTill=2026-07-29T12:00:00Z
     &lookbackHours=24
 ```
@@ -371,6 +371,24 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 * Error is `invalid_timestamp`.
 * The value is rejected even though it matches the timestamp shape.
 * No database aggregation is performed.
+
+---
+
+## TC-COMMON-012A: Repeated timestampTill parameter
+
+### Request
+
+```http
+?timestampTill=2026-07-29T12:00:00Z
+&timestampTill=2026-07-29T13:00:00Z
+&lookbackHours=24
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error is `invalid_timestamp`.
+* Repeated `timestampTill` query parameters are ambiguous and must not be accepted by framework parameter binders silently selecting the first or last value. Handlers must inspect the raw query collection to enforce exactly one `timestampTill` parameter.
 
 ---
 
@@ -3669,15 +3687,17 @@ TX
 Samples arrive in this order:
 
 ```text
-10:20
-10:10
-10:30
+10:20 (RX = 3000, TX = 1500)
+10:10 (RX = 2000, TX = 1000)
+10:30 (RX = 5000, TX = 2500)
 ```
 
 ### Expected result
 
-* Samples are ordered by timestamp before processing, or stale records are discarded according to the stream rule.
-* Negative or duplicated usage is not produced.
+* All valid samples presented out of temporal order must be deterministically sorted by timestamp ASC (`10:10 -> 10:20 -> 10:30`) before differential calculation.
+* Valid out-of-order historical telemetry must NOT be discarded or treated as stale.
+* Deltas are calculated sequentially across the sorted stream: `(3000-2000) + (5000-3000) = 3000` RX bytes.
+* Under-counting or dropping valid out-of-order samples is prohibited. Negative or duplicated usage is not produced.
 
 ---
 
@@ -3732,8 +3752,9 @@ e2:51:95:ed:0f:28
 
 ### Expected result
 
-* MAC addresses are normalized.
-* Both records belong to one client result.
+* MAC addresses are normalized to canonical lowercase (`e2:51:95:ed:0f:28`).
+* Both records belong to one client result item with `mac: "e2:51:95:ed:0f:28"`.
+* Response `mac` field matches `^[0-9a-f]{2}(:[0-9a-f]{2}){5}$`.
 
 ---
 

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -1,0 +1,3264 @@
+# Analytics MCP APIs & Gateway Availability Service — Comprehensive Test Specification
+
+## 1. Scope
+
+This document defines the comprehensive test suite for the `ra-wlan-cloud-analytics` service, covering all five MCP tool endpoints and the background Gateway Availability tracking pipeline:
+
+```http
+GET /api/v1/devices/{routerId}/memory-summary
+GET /api/v1/devices/{routerId}/radio-temperature-summary
+GET /api/v1/devices/{routerId}/wifi-clients/usage-summary
+GET /api/v1/devices/{routerId}/wifi-clients/rssi-summary
+GET /api/v1/devices/{routerId}/availability-summary
+```
+
+The APIs correspond to these MCP tools:
+
+```text
+get_gateway_free_memory
+get_gateway_wifi_temp
+get_device_bandwidth_consumption
+get_device_rssi_quality
+get_gateway_offline_count
+```
+
+The test cases cover:
+* API contract tests for request shapes, HTTP status codes, response schemas, parameter validation, filtering, and half-open time-range window semantics `[startTime, endTime)`.
+* Service integration tests for Kafka topic consumption, OWPROV fallback resolution, `VenueCoordinator` maintained ownership map, process-level router resolution cache, and PostgreSQL storage queries.
+* Database/white-box tests for `device_availability_events`, `timepoints`, and `wificlienthistory` table schemas, constraints, and event counting behavior.
+* End-to-end physical device scenarios covering gateway shutdown, power restoration, cable removal, and reconnection flows.
+
+---
+
+# 2. Common Preconditions and Database Setup
+
+Before executing the test cases:
+
+1. Analytics service is running and connected to PostgreSQL.
+2. Analytics is consuming the Kafka `connection` topic.
+3. The test gateway is registered in OWPROV with a known `serialNumber`.
+4. The test gateway is associated with a venue and mapped to an Analytics board where applicable.
+5. `VenueCoordinator` contains the current `routerId → boardId` mapping.
+6. The test gateway regularly sends `ping` or `capabilities` messages (approximate interval: 2 minutes).
+7. The following storage tables are available:
+
+```text
+device_availability_events
+timepoints
+wificlienthistory
+```
+
+8. Gateway availability uses the existing persisted gateway state record as the authoritative state and `device_availability_events` as the transition log. Kafka `disconnection` messages are treated as `offline`; Kafka `ping` and `capabilities` messages are treated as `online`. Every newer message updates that record's `lastContact`; pings also update `lastPing`, and real offline transitions update `lastDisconnection`. This does not require a table named `device` or `devices`.
+9. Database records for the test gateway are cleared or isolated before each independent test.
+10. A valid authorization token is available for testing endpoint access.
+
+Example test parameters:
+
+```text
+routerId: 60cf84f22290
+boardId: board-test-01
+venueId: venue-test-01
+timestampTill: 2026-07-29T12:00:00Z
+lookbackHours: 24
+```
+
+---
+
+# 3. Common Service Integration and API Contract Test Cases
+
+## TC-COMMON-001: Valid router resolves from local ownership map
+
+### Steps
+
+1. Add the gateway to a monitored Analytics board.
+2. Confirm that `VenueCoordinator` contains:
+
+```text
+60cf84f22290 → board-test-01
+```
+
+3. Call the memory-summary, radio-temperature-summary, usage-summary, and rssi-summary APIs.
+4. Call the availability-summary API.
+
+### Expected result
+
+* The router is resolved using the maintained local map.
+* A full OWPROV inventory lookup is not required.
+* For memory, temperature, usage, and RSSI, Analytics queries metric data using:
+
+```text
+boardId = board-test-01
+serialNumber = 60cf84f22290
+```
+
+* For availability-summary:
+  * Current board and venue ownership are used for request authorization only.
+  * Historical availability events are queried by durable `serialNumber`.
+  * Historical `board_id` is nullable context and is not required to match the current board.
+* The request succeeds.
+
+---
+
+## TC-COMMON-002: Router resolves after local-map cache miss
+
+### Steps
+
+1. Remove or expire the gateway mapping from the local map.
+2. Keep the gateway registered in OWPROV.
+3. Call an API for the gateway.
+4. Observe the resolution process.
+
+### Expected result
+
+* Analytics performs a status-aware OWPROV inventory lookup.
+* The venue is read from `inventoryTag.venue`.
+* Board ownership is determined from the monitored venue device lists.
+* The local `routerId → boardId` map is refreshed.
+* The request succeeds.
+
+---
+
+## TC-COMMON-003: Gateway belongs to a child venue
+
+### Preconditions
+
+* Board monitors a parent venue with `monitorSubVenues = true`.
+* Gateway belongs to a child venue.
+
+### Steps
+
+1. Call each metric API using the gateway serial number.
+2. Observe board resolution.
+
+### Expected result
+
+* Gateway resolves to the parent venue's Analytics board.
+* The implementation does not require the gateway venue to be directly listed as the board venue.
+* Each API returns the gateway's data.
+
+---
+
+## TC-COMMON-004: Router is not found in OWPROV
+
+### Steps
+
+Call an API with a syntactically valid but nonexistent router ID:
+
+```http
+GET /api/v1/devices/deadbeef1234/memory-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=24
+```
+
+### Expected result
+
+* HTTP `404 Not Found`.
+* Response indicates that the inventory device was not found.
+* Analytics does not query another gateway's data.
+
+---
+
+## TC-COMMON-005: Invalid router ID syntax
+
+### Steps
+
+Call an API with a syntactically invalid router ID:
+
+```http
+GET /api/v1/devices/unknown-router/memory-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=24
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error is `invalid_router_id`.
+* OWPROV ownership lookup and metric aggregation are not executed.
+
+---
+
+## TC-COMMON-006: Router inventory has no venue
+
+### Preconditions
+
+* Router exists in OWPROV.
+* `inventoryTag.venue` is empty or missing.
+
+### Expected result
+
+* HTTP `404 Not Found`.
+* Request does not continue to metric aggregation.
+
+---
+
+## TC-COMMON-007: No Analytics board monitors the venue
+
+### Preconditions
+
+* Router and venue exist.
+* No Analytics board is configured for the venue.
+
+### Expected result
+
+* HTTP `404 Not Found`.
+* Response indicates that no Analytics board is configured.
+
+---
+
+## TC-COMMON-008: Router matches multiple boards
+
+### Preconditions
+
+* The same router is incorrectly present in two board device lists.
+* No deterministic ownership rule resolves the conflict.
+
+### Expected result
+
+* HTTP `409 Conflict`.
+* No arbitrary board is selected.
+* No metric data is returned.
+
+---
+
+
+
+## TC-COMMON-009: Valid timestamp and lookback
+
+### Request
+
+```http
+?timestampTill=2026-07-29T12:00:00Z
+&lookbackHours=24
+```
+
+### Expected result
+
+```text
+startTime = 2026-07-28T12:00:00Z
+endTime = 2026-07-29T12:00:00Z
+```
+
+Only samples inside the half-open range `[startTime, endTime)` are used.
+
+---
+
+## TC-COMMON-010: Invalid timestamp
+
+### Request
+
+```http
+?timestampTill=not-a-date
+&lookbackHours=24
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error identifies `timestampTill` as invalid.
+
+---
+
+## TC-COMMON-011: Unsupported timezone format or numeric offset
+
+### Objective
+
+Verify that non-UTC timezone formats, explicit numeric timezone offsets, or missing timezone designators are rejected.
+
+### Requests
+
+1. Request with explicit numeric timezone offset:
+
+```http
+GET /api/v1/devices/60cf84f22290/memory-summary
+    ?timestampTill=2026-07-29T12:00:00+05:30
+    &lookbackHours=24
+```
+
+2. Request with missing timezone designator:
+
+```http
+GET /api/v1/devices/60cf84f22290/memory-summary
+    ?timestampTill=2026-07-29T12:00:00
+    &lookbackHours=24
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Response resembles:
+
+```json
+{
+  "error": "invalid_timestamp",
+  "message": "timestampTill must be a valid UTC timestamp ending with 'Z'"
+}
+```
+
+* OWPROV ownership lookup and metric aggregation are not executed.
+
+---
+
+## TC-COMMON-012: Semantically invalid timestamp
+
+### Request
+
+```http
+?timestampTill=2026-99-99T88:77:66Z
+&lookbackHours=24
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* The value is rejected even though it matches the timestamp shape.
+* No database aggregation is performed.
+
+---
+
+## TC-COMMON-013: Zero lookback
+
+### Request
+
+```http
+?timestampTill=2026-07-29T12:00:00Z
+&lookbackHours=0
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+
+---
+
+## TC-COMMON-014: Negative lookback
+
+### Request
+
+```http
+?timestampTill=2026-07-29T12:00:00Z
+&lookbackHours=-1
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+
+---
+
+## TC-COMMON-015: Lookback exceeds configured maximum
+
+### Request
+
+```http
+?timestampTill=2026-07-29T12:00:00Z
+&lookbackHours=10000
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error indicates that the maximum supported lookback was exceeded.
+
+---
+
+## TC-COMMON-016: Missing timestamp
+
+### Request
+
+```http
+?lookbackHours=24
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+
+---
+
+## TC-COMMON-017: Missing lookback
+
+### Request
+
+```http
+?timestampTill=2026-07-29T12:00:00Z
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+
+---
+
+## TC-COMMON-018: Missing authorization token
+
+### Expected result
+
+* HTTP `401 Unauthorized`.
+* No gateway data is returned.
+
+---
+
+## TC-COMMON-019: User is not authorized for the gateway scope
+
+### Preconditions
+
+* Caller has a valid token.
+* Caller lacks `analytics.gateway_metrics.read` on the resolved board, venue and parent entity.
+
+### Expected result
+
+* HTTP `404 Not Found`.
+* Error is `not_found`.
+* The response does not reveal whether the gateway exists.
+
+---
+
+## TC-COMMON-020: Monitoring is disabled
+
+### Preconditions
+
+* Router ownership resolves successfully.
+* Monitoring is disabled for the resolved router scope.
+
+### Expected result
+
+* HTTP `409 Conflict`.
+* Error is `monitoring_disabled`.
+* Metric aggregation is not executed.
+
+---
+
+## TC-COMMON-021: Monitoring is not configured
+
+### Preconditions
+
+* Router ownership resolves successfully.
+* No monitoring configuration exists for the resolved router scope.
+
+### Expected result
+
+* HTTP `404 Not Found`.
+* Error is `monitoring_not_configured`.
+* Metric aggregation is not executed.
+
+---
+
+## TC-COMMON-022: Requested range outside retention
+
+### Request
+
+Use a valid router ID and a lookback window whose calculated `[startTime, endTime)` falls outside the configured monitoring retention window.
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error is `lookback_outside_retention`.
+* Metric aggregation is not executed.
+
+---
+
+## TC-COMMON-023: Availability range before cutover
+
+### Request
+
+Call `GET /api/v1/devices/{routerId}/availability-summary` with a calculated `startTime` before `availabilityValidFrom`.
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error is `availability_range_before_cutover`.
+* The API does not return `offline_count: 0` for pre-cutover ranges.
+
+---
+
+## TC-COMMON-024: Router-resolution cache expires
+
+### Preconditions
+
+* A positive router-resolution cache entry exists.
+* Its TTL has expired.
+
+### Expected result
+
+* The expired entry is not used for authorization or metric lookup.
+* Router ownership is refreshed before aggregation.
+* The response reflects the refreshed ownership context.
+
+---
+
+## TC-COMMON-025: Router ownership version changes
+
+### Preconditions
+
+* A positive router-resolution cache entry exists.
+* The current ownership version is newer than the cached entry's ownership version.
+
+### Expected result
+
+* The stale cache entry is invalidated.
+* Router ownership is refreshed before aggregation.
+* Stale ownership cannot grant access to another caller's router data.
+
+---
+
+
+
+# 4. Gateway Availability Service & availability-summary Test Cases
+
+## 4.1. Database/White-Box Validation Queries
+
+### Persisted gateway state check
+
+```text
+Lock and read the existing persisted gateway state record for:
+serialNumber = 60cf84f22290
+
+Verify these fields:
+connected
+lastContact
+lastPing
+lastConnection
+lastDisconnection
+```
+
+### Latest transition event query
+
+```sql
+SELECT *
+FROM device_availability_events
+WHERE serialNumber = '60cf84f22290'
+ORDER BY event_time DESC
+LIMIT 1;
+```
+
+### Availability history query
+
+```sql
+SELECT *
+FROM device_availability_events
+WHERE serialNumber = '60cf84f22290'
+ORDER BY event_time ASC;
+```
+
+### Offline event count query
+
+```sql
+SELECT COUNT(*)
+FROM device_availability_events
+WHERE serialNumber = ?
+  AND event_type = 'offline'
+  AND event_time >= ?
+  AND event_time < ?;
+```
+
+---
+
+## 4.2. Service Integration Functional Test Cases
+
+## TC-AVAIL-001: First ping initializes online state without transition event
+
+### Objective
+
+Verify that the first observed ping initializes the persisted gateway state record as online without creating an online transition event.
+
+### Preconditions
+
+* No availability event exists for the gateway.
+* The persisted gateway state record has no prior availability contact state:
+
+```text
+connected is unset or false only because the row is uninitialized
+lastContact is unset or 0
+```
+
+### Steps
+
+1. Start the gateway.
+2. Wait for the gateway to publish a `ping` message.
+3. Wait for Analytics to consume the message.
+4. Query the persisted gateway state record.
+5. Query `device_availability_events`.
+
+### Expected result
+
+* No `online` event is inserted.
+* No `offline` event is inserted.
+* The persisted gateway state record is updated:
+
+```text
+connected = true
+lastContact = ping timestamp
+lastPing = ping timestamp
+```
+
+* The availability API returns:
+
+```json
+{
+  "gw_uuid": "60cf84f22290",
+  "fetch_status": "success",
+  "offline_count": 0
+}
+```
+
+---
+
+## TC-AVAIL-002: Repeated pings while already online do not create duplicates
+
+### Objective
+
+Verify that regular gateway pings do not create repeated online transition events.
+
+### Preconditions
+
+* The persisted gateway state record has:
+
+```text
+connected = true
+lastContact < latest ping timestamp
+```
+
+### Steps
+
+1. Keep the gateway online.
+2. Allow it to send at least three ping messages.
+3. Wait for Analytics to process all messages.
+4. Query the persisted gateway state record.
+5. Query `device_availability_events`.
+
+Example messages:
+
+```text
+12:00 ping
+12:02 ping
+12:04 ping
+```
+
+### Expected result
+
+* No additional `online` event is inserted after the first online state.
+* `lastContact` is updated to the latest newer ping timestamp.
+* `lastPing` is updated to the latest newer ping timestamp.
+* `connected` remains `true`.
+* `offline_count` remains `0`.
+
+---
+
+## TC-AVAIL-003: Device is physically powered off
+
+### Objective
+
+Verify that physically powering off the gateway creates one offline transition.
+
+### Preconditions
+
+* Gateway is online.
+* The persisted gateway state record has `connected = true`.
+
+### Steps
+
+1. Confirm that the gateway is sending ping messages.
+2. Disconnect the gateway's power supply.
+3. Wait for the gateway/controller disconnection detection.
+4. Verify that a Kafka `disconnection` message is published.
+5. Wait for Analytics to process the message.
+6. Query the availability-event table.
+7. Call the availability-summary API.
+
+### Expected result
+
+* Exactly one `offline` event is inserted.
+* The persisted gateway state record is updated:
+
+```text
+connected = false
+lastContact = disconnection message timestamp
+lastDisconnection = disconnection message timestamp
+```
+
+* The event contains:
+
+```text
+serialNumber = 60cf84f22290
+event_type = offline
+event_time = disconnection message timestamp
+```
+
+* The API returns:
+
+```json
+{
+  "gw_uuid": "60cf84f22290",
+  "fetch_status": "success",
+  "offline_count": 1
+}
+```
+
+---
+
+## TC-AVAIL-004: Device operating system is shut down gracefully
+
+### Objective
+
+Verify that running a proper operating-system shutdown is counted as one offline occurrence.
+
+### Preconditions
+
+* Gateway is online.
+
+### Steps
+
+1. Connect to the gateway through SSH.
+2. Run:
+
+```bash
+sudo shutdown -h now
+```
+
+3. Wait for the gateway to stop communicating.
+4. Verify that a disconnection message reaches Kafka.
+5. Wait for Analytics processing.
+6. Query the event table.
+7. Call the availability-summary API.
+
+### Expected result
+
+* One offline transition is stored.
+* Repeated controller checks while the gateway remains shut down do not create more offline events.
+* `offline_count` increases by exactly `1`.
+
+---
+
+## TC-AVAIL-005: Device is disconnected from Ethernet
+
+### Objective
+
+Verify that removing the gateway's Ethernet connection creates one offline transition.
+
+### Preconditions
+
+* Gateway uses Ethernet for controller connectivity.
+* Gateway is online.
+
+### Steps
+
+1. Confirm that the gateway is sending pings.
+2. Disconnect the Ethernet cable.
+3. Wait for the disconnection timeout.
+4. Verify that a Kafka disconnection message is published.
+5. Query availability storage.
+6. Call the API.
+
+### Expected result
+
+* One offline event is stored.
+* `offline_count` increases by `1`.
+* Keeping the cable disconnected does not create repeated offline events.
+
+---
+
+## TC-AVAIL-006: Device Wi-Fi uplink is disconnected
+
+### Objective
+
+Verify that losing the gateway's Wi-Fi uplink creates an offline transition.
+
+### Preconditions
+
+* Gateway uses Wi-Fi uplink for cloud connectivity.
+* Gateway is online.
+
+### Steps
+
+1. Confirm that the gateway is online.
+2. Disable the gateway's uplink Wi-Fi interface or shut down its upstream access point.
+3. Wait for connection loss detection.
+4. Verify that a Kafka disconnection message is generated.
+5. Query `device_availability_events`.
+6. Call the API.
+
+### Expected result
+
+* One offline event is stored.
+* `offline_count` increases by exactly `1`.
+
+---
+
+## TC-AVAIL-007: Internet is unavailable but gateway remains powered on
+
+### Objective
+
+Verify that a powered-on gateway with no cloud connectivity is considered offline from the Analytics/controller perspective.
+
+### Preconditions
+
+* Gateway is online.
+* Gateway remains powered on during the test.
+
+### Steps
+
+1. Block the gateway's internet access using the upstream router or firewall.
+2. Keep local power and LAN connectivity available.
+3. Wait for the controller to detect that the gateway is no longer connected.
+4. Verify the disconnection Kafka message.
+5. Call the availability API.
+
+### Expected result
+
+* One offline transition is stored.
+* The gateway is considered offline even though it is still powered on.
+* The reason or metadata may indicate network or connection loss when available.
+* `offline_count` increases by `1`.
+
+---
+
+## TC-AVAIL-008: Gateway reconnects after physical power restoration
+
+### Objective
+
+Verify that restoring power changes the gateway state from offline to online without increasing the offline count.
+
+### Preconditions
+
+* Gateway is physically powered off.
+* One offline event already exists.
+
+### Steps
+
+1. Restore power to the gateway.
+2. Wait for the gateway to boot.
+3. Wait for the first `ping` or `capabilities` message.
+4. Query `device_availability_events`.
+5. Call the availability API.
+
+### Expected result
+
+* One `online` transition event is inserted.
+* No additional `offline` event is inserted.
+* The persisted gateway state record is updated:
+
+```text
+connected = true
+lastContact = ping or capabilities timestamp
+lastPing = ping timestamp when message type is ping
+lastConnection = ping or capabilities timestamp
+```
+
+* Existing offline count remains unchanged.
+
+Example history:
+
+```text
+12:10 offline
+12:15 online
+```
+
+API result:
+
+```json
+{
+  "gw_uuid": "60cf84f22290",
+  "fetch_status": "success",
+  "offline_count": 1
+}
+```
+
+---
+
+## TC-AVAIL-009: Ethernet connection is restored
+
+### Objective
+
+Verify recovery after an Ethernet disconnection.
+
+### Preconditions
+
+* Ethernet cable is disconnected.
+* One offline event already exists for the outage.
+
+### Steps
+
+1. Reconnect the Ethernet cable.
+2. Wait for the gateway to reconnect to the controller.
+3. Wait for a ping or capabilities message.
+4. Query availability storage.
+5. Call the API.
+
+### Expected result
+
+* One `online` transition event is inserted.
+* No additional offline event is inserted.
+* `connected` becomes `true`.
+* `lastContact` and the applicable online timestamp field are updated.
+* Offline count remains unchanged.
+
+---
+
+## TC-AVAIL-010: Multiple shutdown and recovery cycles
+
+### Objective
+
+Verify that each separate online-to-offline transition is counted once.
+
+### Preconditions
+
+* Gateway begins online.
+
+### Steps
+
+Perform the following sequence:
+
+```text
+12:00 ping          → online
+12:10 shutdown      → offline
+12:15 boot          → online
+13:00 disconnect    → offline
+13:05 reconnect     → online
+14:00 power off     → offline
+14:10 power on      → online
+```
+
+Call the API for a time range covering the entire sequence.
+
+### Expected result
+
+The event table contains:
+
+```text
+12:00 online
+12:10 offline
+12:15 online
+13:00 offline
+13:05 online
+14:00 offline
+14:10 online
+```
+
+The API returns:
+
+```json
+{
+  "gw_uuid": "60cf84f22290",
+  "fetch_status": "success",
+  "offline_count": 3
+}
+```
+
+---
+
+## TC-AVAIL-011: Repeated disconnection while already offline is ignored
+
+### Objective
+
+Verify that repeated offline messages do not create duplicate offline transitions.
+
+### Preconditions
+
+* The gateway has already produced one offline transition.
+* The persisted gateway state record has `connected = false`.
+
+### Steps
+
+1. Keep the gateway offline after the first disconnection.
+2. Deliver another newer `disconnection` message for the same gateway while `connected = false`.
+3. Query the availability-event table.
+4. Call the API.
+
+Example:
+
+```text
+12:10 disconnection
+12:12 disconnection
+12:14 disconnection
+```
+
+### Expected result
+
+* Only the first offline transition is stored.
+* Later same-state disconnection messages are ignored.
+* For newer repeated disconnection messages while `connected = false`, `lastContact` advances.
+* `lastDisconnection` remains the timestamp of the actual offline transition.
+* `offline_count` is `1`.
+
+---
+
+## TC-AVAIL-012: Duplicate Kafka delivery of the same event is ignored
+
+### Objective
+
+Verify storage-level idempotency when Kafka redelivers the same logical connection event.
+
+### Preconditions
+
+* Gateway is online.
+
+### Steps
+
+1. Shut down or disconnect the gateway.
+2. Capture the resulting Kafka disconnection message.
+3. Deliver the exact same Kafka message again.
+4. Query `device_availability_events`.
+5. Query the stored `idempotency_key` or `event_id`.
+6. Call the API.
+
+### Expected result
+
+* Both deliveries map to the same deterministic `idempotency_key` or source `event_id`.
+* Exactly one transition event row is inserted.
+* The duplicate delivery does not move `connected`, `lastContact`, `lastPing`, or `lastDisconnection`.
+* `offline_count` is `1`.
+
+---
+
+## TC-AVAIL-013: Repeated ping while already online is ignored
+
+### Objective
+
+Verify that repeated online messages after an offline-to-online transition do not create duplicate online rows.
+
+### Steps
+
+1. Reconnect or power on the gateway from an offline state.
+2. Capture the first ping that creates the online transition.
+3. Deliver another newer ping while the persisted gateway state record has `connected = true`.
+4. Query availability storage.
+
+### Expected result
+
+* Exactly one online transition event is inserted.
+* No additional offline event is inserted.
+* The newer repeated ping updates `lastContact` and `lastPing`.
+* `offline_count` is unchanged.
+
+---
+
+## TC-AVAIL-014: Gateway changes board after an offline event
+
+### Objective
+
+Verify that historical offline events remain queryable after board reassignment.
+
+### Preconditions
+
+* Gateway previously generated an offline event under Board A.
+* Gateway is later assigned to Board B.
+
+### Steps
+
+1. Generate an offline event while the gateway belongs to Board A.
+2. Reconnect the gateway.
+3. Reassign the gateway to Board B.
+4. Call the availability-summary API using the gateway serial number.
+
+### Expected result
+
+* The historical offline event remains available.
+* The query does not require the old or current board ID.
+* Offline count includes the event created under Board A.
+
+---
+
+## 4.3. API Contract Time-Range Test Cases
+
+## TC-AVAIL-015: Count events inside the requested lookback window
+
+### Objective
+
+Verify that only offline events inside the requested range are counted.
+
+### Test data
+
+```text
+10:00 offline
+12:00 offline
+14:00 offline
+```
+
+### Request
+
+```http
+GET /api/v1/devices/60cf84f22290/availability-summary
+    ?timestampTill=2026-07-29T15:00:00Z
+    &lookbackHours=4
+```
+
+The time window is:
+
+```text
+[11:00, 15:00)
+```
+
+### Expected result
+
+* The `10:00` event is excluded.
+* The `12:00` and `14:00` events are included.
+* `offline_count` is `2`.
+
+---
+
+## TC-AVAIL-016: Offline event exactly at start time
+
+### Objective
+
+Verify inclusive start-time handling.
+
+### Test data
+
+```text
+startTime = 12:00
+offline event = 12:00
+```
+
+### Expected result
+
+* The event is included.
+* Offline count increases by `1`.
+
+---
+
+## TC-AVAIL-017: Offline event exactly at end time
+
+### Objective
+
+Verify exclusive end-time handling.
+
+### Test data
+
+```text
+endTime = 16:00
+offline event = 16:00
+```
+
+### Expected result
+
+* The event is excluded.
+* Offline count does not increase.
+
+---
+
+## TC-AVAIL-018: No offline events in the requested range
+
+### Objective
+
+Verify successful empty results.
+
+### Steps
+
+1. Select a time range containing no offline events.
+2. Call the API.
+
+### Expected result
+
+```json
+{
+  "gw_uuid": "60cf84f22290",
+  "fetch_status": "success",
+  "offline_count": 0
+}
+```
+
+The API must not treat an empty result as an error.
+
+---
+
+## TC-AVAIL-019: Offline event exists outside the requested range
+
+### Objective
+
+Verify that old events do not affect the current range.
+
+### Test data
+
+```text
+Offline event: 48 hours ago
+Requested lookback: 24 hours
+```
+
+### Expected result
+
+```text
+offline_count = 0
+```
+
+---
+
+## 4.4. API Validation Test Cases
+
+## TC-AVAIL-020: Missing router ID
+
+### Request
+
+```http
+GET /api/v1/devices//availability-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=24
+```
+
+### Expected result
+
+* HTTP `404 Not Found` at the router/framework level.
+* The Analytics handler is not invoked because the `{routerId}` path segment is missing.
+* The documented Analytics error body is not required for this route-level failure.
+* No database state is changed.
+
+---
+
+## TC-AVAIL-021: Unknown router ID
+
+### Request
+
+```http
+GET /api/v1/devices/deadbeef1234/availability-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=24
+```
+
+### Expected result
+
+* HTTP `404 Not Found`.
+* Error is `not_found`.
+* It must not return another gateway's events.
+
+---
+
+## TC-AVAIL-022: Invalid router ID syntax
+
+### Objective
+
+Verify that syntactically invalid router IDs (such as non-hexadecimal values or invalid punctuation) are rejected with HTTP 400 before OWPROV ownership lookup or availability database queries are executed.
+
+### Requests
+
+1. Handler-level validation requests (non-hexadecimal or invalid punctuation):
+
+```http
+GET /api/v1/devices/unknown-router/availability-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=24
+
+GET /api/v1/devices/:::/availability-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=24
+```
+
+2. Framework / route-level security requests (path dot-segments):
+
+```http
+GET /api/v1/devices/./availability-summary
+GET /api/v1/devices/../availability-summary
+```
+
+### Expected result
+
+* For handler-level validation requests (`unknown-router`, `:::`):
+  * HTTP `400 Bad Request`.
+  * Response resembles:
+
+```json
+{
+  "error": "invalid_router_id",
+  "message": "routerId must be a valid 12-29 hex character gateway serial number"
+}
+```
+
+  * OWPROV resolution is not called.
+  * No availability query is executed.
+
+* For framework / route-level dot-segment requests (`.`, `..`):
+  * Requests are normalized or rejected by the HTTP server/framework layer before reaching the handler.
+  * Dot-segments are never passed to OWPROV ownership resolution.
+
+---
+
+## TC-AVAIL-023: Invalid timestamp format
+
+### Request
+
+```http
+GET /api/v1/devices/60cf84f22290/availability-summary
+    ?timestampTill=invalid-time
+    &lookbackHours=24
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error indicates invalid `timestampTill`.
+
+---
+
+## TC-AVAIL-024: Missing timestamp
+
+### Request
+
+```http
+GET /api/v1/devices/60cf84f22290/availability-summary
+    ?lookbackHours=24
+```
+
+### Expected result
+
+* Request is rejected according to the API contract.
+* No query is executed with an undefined time range.
+
+---
+
+## TC-AVAIL-025: Zero lookback hours
+
+### Request
+
+```http
+GET /api/v1/devices/60cf84f22290/availability-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=0
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error indicates invalid lookback value.
+
+---
+
+## TC-AVAIL-026: Negative lookback hours
+
+### Request
+
+```http
+GET /api/v1/devices/60cf84f22290/availability-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=-1
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+
+---
+
+## TC-AVAIL-027: Lookback exceeds maximum allowed range
+
+### Request
+
+```http
+GET /api/v1/devices/60cf84f22290/availability-summary
+    ?timestampTill=2026-07-29T12:00:00Z
+    &lookbackHours=999999
+```
+
+### Expected result
+
+* HTTP `400 Bad Request`.
+* Error indicates that the supported lookback limit was exceeded.
+
+---
+
+
+
+## 4.5. Concurrency and Reliability Test Cases
+
+## TC-AVAIL-028: Two consumers process concurrent disconnection messages
+
+### Objective
+
+Verify that concurrent processing cannot create duplicate offline transitions.
+
+### Preconditions
+
+* Gateway is online.
+
+### Steps
+
+1. Start with the persisted gateway state record locked state as `connected = true`.
+2. Deliver two disconnection messages for the same gateway concurrently.
+3. Query event storage.
+
+### Expected result
+
+* Gateway state check and event insertion happen inside one database transaction.
+* The persisted gateway state record is locked by `serialNumber` while processing.
+* Exactly one offline event row is inserted.
+* The persisted gateway state record ends with `connected = false` and `lastContact` equal to the accepted disconnection timestamp.
+* Offline count is `1`.
+
+---
+
+
+
+## TC-AVAIL-029: Stale out-of-order event is ignored
+
+### Objective
+
+Verify that an event older than the persisted gateway state record's `lastContact` cannot change availability history.
+
+### Steps
+
+1. Set the persisted gateway state record to:
+
+```text
+connected = true
+lastContact = 12:10
+lastPing = 12:10
+```
+
+2. Deliver a delayed `disconnection` message for the same gateway at `12:05`.
+3. Query the persisted gateway state record.
+4. Query `device_availability_events`.
+
+### Expected result
+
+* The stale `12:05` event is ignored.
+* No offline event row is inserted.
+* The persisted gateway state record remains:
+
+```text
+connected = true
+lastContact = 12:10
+lastPing = 12:10
+```
+
+---
+
+## TC-AVAIL-030: First event is a disconnection
+
+### Objective
+
+Verify that a first observed `disconnection` message creates an offline transition.
+
+### Preconditions
+
+* No availability event exists for the gateway.
+* The persisted gateway state record has:
+
+```text
+connected = true
+lastContact < disconnection timestamp
+```
+
+### Steps
+
+1. Deliver a `disconnection` message.
+3. Query `device_availability_events`.
+4. Call availability-summary for a window containing the event.
+
+### Expected result
+
+* One `offline` event row is inserted.
+* The event uses the gateway `serialNumber`.
+* The persisted gateway state record is updated to `connected = false`.
+* `offline_count` is `1`.
+
+---
+
+## TC-AVAIL-031: Separate gateways maintain independent latest states
+
+### Objective
+
+Verify that transition detection is scoped by `serialNumber`.
+
+### Steps
+
+1. Store an `offline` event for gateway A.
+2. Store an `online` event for gateway B.
+3. Deliver a repeated disconnection for gateway A.
+4. Deliver a disconnection for gateway B.
+5. Query `device_availability_events` for both serial numbers.
+
+### Expected result
+
+* Gateway A's repeated offline message is ignored.
+* Gateway B's online-to-offline transition is inserted.
+* Counts and latest states are not mixed across serial numbers.
+
+---
+
+## TC-AVAIL-032: Offline count includes only stored offline transitions
+
+### Objective
+
+Verify that online transition rows do not affect `offline_count`.
+
+### Steps
+
+1. Store this event sequence for one gateway:
+
+```text
+12:00 online
+12:10 offline
+12:15 online
+12:30 offline
+```
+
+2. Call availability-summary for a window containing the whole sequence.
+
+### Expected result
+
+* The API counts only the two stored `offline` rows.
+* Stored `online` rows are ignored by the offline count.
+* `offline_count` is `2`.
+
+---
+
+## 4.6. End-to-End Physical Device Scenario
+
+## TC-AVAIL-033: Complete shutdown, restart, disconnect and reconnect sequence
+
+### Objective
+
+Verify the complete real-device availability flow.
+
+### Steps
+
+1. Start the gateway and confirm it is online.
+2. Wait for at least one ping.
+3. Shut down the gateway using:
+
+```bash
+sudo shutdown -h now
+```
+
+4. Wait for one offline event.
+5. Keep the gateway shut down for at least five minutes.
+6. Confirm no additional offline events are created.
+7. Power on the gateway.
+8. Wait for recovery pings.
+9. Disconnect the Ethernet cable.
+10. Wait for another offline event.
+11. Keep the Ethernet cable disconnected for at least five minutes.
+12. Confirm no repeated offline event is stored.
+13. Reconnect Ethernet.
+14. Wait for recovery pings.
+15. Call the API for a time range covering the complete test.
+
+### Expected event sequence
+
+```text
+Initial ping                 → online event
+Device shutdown             → offline event 1
+Device remains shut down    → no new event
+Device powers on            → online event
+Ethernet disconnected       → offline event 2
+Ethernet remains unplugged  → no new event
+Ethernet reconnected        → online event
+```
+
+### Expected API response
+
+```json
+{
+  "gw_uuid": "60cf84f22290",
+  "fetch_status": "success",
+  "offline_count": 2
+}
+```
+
+---
+
+
+
+---
+
+# 5. Gateway Memory Summary Test Cases
+
+## Endpoint
+
+```http
+GET /api/v1/devices/{routerId}/memory-summary
+```
+
+Expected response:
+
+```json
+{
+  "min_memfree": 211374,
+  "max_memfree": 215050,
+  "avg_memfree": 212074.36
+}
+```
+
+---
+
+## TC-MEM-001: Calculate minimum, maximum and average memory
+
+### Test data
+
+```text
+Timestamp    memory_free    memory_total
+10:00        200000         512000
+10:10        250000         512000
+10:20        300000         512000
+```
+
+### Expected result
+
+```json
+{
+  "min_memfree": 200000,
+  "max_memfree": 300000,
+  "avg_memfree": 250000.0
+}
+```
+
+---
+
+## TC-MEM-002: Single valid memory sample
+
+### Test data
+
+```text
+memory_free = 212074
+memory_total = 512000
+```
+
+### Expected result
+
+```json
+{
+  "min_memfree": 212074,
+  "max_memfree": 212074,
+  "avg_memfree": 212074.0
+}
+```
+
+---
+
+## TC-MEM-003: Samples outside the requested range
+
+### Test data
+
+```text
+09:00 memory_free = 100000
+10:00 memory_free = 200000
+11:00 memory_free = 300000
+12:00 memory_free = 400000
+```
+
+Requested range:
+
+```text
+[10:00, 11:00)
+```
+
+### Expected result
+
+```json
+{
+  "min_memfree": 200000,
+  "max_memfree": 200000,
+  "avg_memfree": 200000.0
+}
+```
+
+The `09:00`, `11:00`, and `12:00` samples are excluded.
+
+---
+
+## TC-MEM-004: Samples exactly at range boundaries
+
+### Test data
+
+```text
+startTime sample = 200000
+endTime sample = 300000
+```
+
+### Expected result
+
+* The `startTime` sample is included.
+* The `endTime` sample is excluded.
+* The summary is calculated from the `startTime` sample only.
+
+---
+
+## TC-MEM-005: No memory samples
+
+### Expected result
+
+```json
+{
+  "min_memfree": null,
+  "max_memfree": null,
+  "avg_memfree": null
+}
+```
+
+* HTTP `200 OK`.
+
+---
+
+## TC-MEM-006: Historical row has no `resource_data`
+
+### Preconditions
+
+* Record was created before the memory schema migration.
+* `resource_data` is absent.
+
+### Expected result
+
+* Record is ignored.
+* Missing data is not interpreted as zero free memory.
+* If no valid rows remain, all summary fields are `null`.
+
+---
+
+## TC-MEM-007: Missing memory block in a new timepoint
+
+### Test data
+
+```json
+{
+  "unit": {
+    "cpu_load": "0.10"
+  }
+}
+```
+
+### Expected result
+
+* No valid memory sample is created for the summary.
+* `memory_free` is not counted as zero.
+
+---
+
+## TC-MEM-008: Legacy row marks resource block as absent
+
+### Test data
+
+```text
+resource_data is absent
+memory_free is absent
+memory_total is absent
+```
+
+### Expected result
+
+* Sample is ignored.
+* Missing optional fields are not represented as zero.
+* It does not make `min_memfree` equal to zero.
+
+---
+
+## TC-MEM-009: Genuine free memory value is zero
+
+### Preconditions
+
+The ingestion metadata proves that the memory block was present and reported:
+
+```text
+memory_free = 0
+memory_total > 0
+```
+
+### Expected result
+
+* The zero value is treated as a valid measured sample.
+* It may become `min_memfree`.
+
+---
+
+## TC-MEM-010: Very large unsigned memory values
+
+### Test data
+
+Use memory values greater than the 32-bit integer range.
+
+### Expected result
+
+* Values are stored and aggregated without integer overflow.
+* Average is calculated using a sufficiently wide numeric type.
+
+---
+
+## TC-MEM-011: Average contains decimal value
+
+### Test data
+
+```text
+memory_free samples:
+100
+101
+```
+
+### Expected result
+
+```text
+avg_memfree = 100.5
+```
+
+The result is not truncated to `100`.
+
+---
+
+## TC-MEM-012: Memory summary bounds and ordering
+
+### Expected result
+
+* `min_memfree`, `max_memfree`, and `avg_memfree` are never negative when they are not `null`.
+* When samples exist, the response satisfies:
+
+```text
+min_memfree <= avg_memfree <= max_memfree
+```
+
+---
+
+## TC-MEM-013: Data from another gateway on the same board
+
+### Test data
+
+* Gateway A and Gateway B belong to the same board.
+* Both have memory samples.
+
+### Expected result
+
+* Only rows where `serialNumber` matches the requested `routerId` are included.
+* Gateway B data does not affect Gateway A's result.
+
+---
+
+## TC-MEM-014: Data from the same gateway under a different board record
+
+### Expected result
+
+* Normal metric lookup uses the currently resolved board and matching serial number.
+* Unrelated board data is not mixed into the summary.
+
+---
+
+## TC-MEM-015: Schema migration preserves old timepoints
+
+### Steps
+
+1. Start with a database created before `resource_data` existed.
+2. Run the upgrade.
+3. Insert new memory-enabled rows.
+4. Call the API.
+
+### Expected result
+
+* Old records remain readable.
+* Old missing values are ignored.
+* New records contribute to the summary.
+* Migration does not delete historical timepoints.
+
+---
+
+# 6. Radio Temperature Summary Test Cases
+
+## Endpoint
+
+```http
+GET /api/v1/devices/{routerId}/radio-temperature-summary
+```
+
+Expected response:
+
+```json
+{
+  "min_wifi_temp_2.4G": 62,
+  "max_wifi_temp_2.4G": 70,
+  "avg_wifi_temp_2.4G": 66.64,
+  "min_wifi_temp_5G": 56,
+  "max_wifi_temp_5G": 65,
+  "avg_wifi_temp_5G": 60.38
+}
+```
+
+---
+
+## TC-TEMP-001: Aggregate 2.4 GHz and 5 GHz separately
+
+### Test data
+
+```text
+2.4 GHz: 60, 65, 70
+5 GHz:   50, 55, 60
+```
+
+### Expected result
+
+```json
+{
+  "min_wifi_temp_2.4G": 60,
+  "max_wifi_temp_2.4G": 70,
+  "avg_wifi_temp_2.4G": 65.0,
+  "min_wifi_temp_5G": 50,
+  "max_wifi_temp_5G": 60,
+  "avg_wifi_temp_5G": 55.0
+}
+```
+
+---
+
+## TC-TEMP-002: Only 2.4 GHz radio exists
+
+### Expected result
+
+```json
+{
+  "min_wifi_temp_2.4G": 60,
+  "max_wifi_temp_2.4G": 70,
+  "avg_wifi_temp_2.4G": 65.0,
+  "min_wifi_temp_5G": null,
+  "max_wifi_temp_5G": null,
+  "avg_wifi_temp_5G": null
+}
+```
+
+---
+
+## TC-TEMP-003: Only 5 GHz radio exists
+
+### Expected result
+
+* All 2.4 GHz fields are `null`.
+* 5 GHz fields contain the calculated values.
+
+---
+
+## TC-TEMP-004: No radio temperature data
+
+### Expected result
+
+```json
+{
+  "min_wifi_temp_2.4G": null,
+  "max_wifi_temp_2.4G": null,
+  "avg_wifi_temp_2.4G": null,
+  "min_wifi_temp_5G": null,
+  "max_wifi_temp_5G": null,
+  "avg_wifi_temp_5G": null
+}
+```
+
+* HTTP `200 OK`.
+
+---
+
+## TC-TEMP-005: Missing temperature field
+
+### Test data
+
+```json
+{
+  "band": 2
+}
+```
+
+### Expected result
+
+* Sample is ignored.
+* No synthetic temperature is inserted.
+* The value `20` is not generated automatically.
+
+---
+
+## TC-TEMP-006: Null temperature field
+
+### Test data
+
+```json
+{
+  "band": 5,
+  "wifi_temp": null
+}
+```
+
+### Expected result
+
+* Sample is excluded from aggregation.
+
+---
+
+## TC-TEMP-007: Pre-cutover temperature record
+
+### Test data
+
+```text
+temperature_migration_cutover_time = 2026-07-29T10:00:00Z
+sample time = 2026-07-29T09:59:59Z
+wifi_temp = 62
+```
+
+### Expected result
+
+* Sample is excluded because it is before `temperature_migration_cutover_time`.
+* It does not affect minimum, maximum or average.
+
+---
+
+## TC-TEMP-008: Post-cutover measured zero temperature
+
+### Preconditions
+
+The sample is at or after `temperature_migration_cutover_time`:
+
+```text
+wifi_temp = 0
+```
+
+### Expected result
+
+* The sample is included as a valid measured value.
+* It is not replaced with `20`.
+
+---
+
+## TC-TEMP-009: Post-cutover missing `wifi_temp`
+
+### Expected result
+
+* Temperature is excluded when `wifi_temp` is missing or `null`.
+* No synthetic fallback value is generated.
+
+---
+
+## TC-TEMP-010: Post-cutover present `wifi_temp`
+
+### Expected result
+
+* Numeric `wifi_temp` is included.
+
+---
+
+## TC-TEMP-011: Pre-cutover temperature equal to 20
+
+### Preconditions
+
+* Record timestamp is before `temperature_migration_cutover_time`.
+* `wifi_temp = 20`.
+
+### Expected result
+
+* The pre-cutover value is excluded because historical temperature values cannot reliably distinguish measured values from synthetic fallback values.
+* It does not affect minimum, maximum or average.
+
+---
+
+## TC-TEMP-012: Pre-cutover temperature other than 20
+
+### Test data
+
+```text
+Record timestamp is before temperature_migration_cutover_time
+wifi_temp = 62
+```
+
+### Expected result
+
+* The sample is excluded because all pre-cutover temperature records are ignored.
+
+---
+
+## TC-TEMP-013: Post-cutover temperature equal to 20
+
+### Test data
+
+```text
+Record timestamp is at or after temperature_migration_cutover_time
+wifi_temp = 20
+```
+
+### Expected result
+
+* The sample is included.
+* Post-cutover samples are not rejected only because the measured value is `20`.
+
+---
+
+## TC-TEMP-014: Mix of valid and invalid samples
+
+### Test data
+
+```text
+2.4 GHz:
+60 valid
+20 historical ambiguous
+65 valid
+null invalid
+70 valid
+```
+
+### Expected result
+
+```text
+min = 60
+max = 70
+avg = 65
+```
+
+Only `60`, `65`, and `70` are included.
+
+---
+
+## TC-TEMP-015: 6 GHz radio data is present
+
+### Test data
+
+```text
+band = 6
+wifi_temp = 58
+```
+
+### Expected result
+
+* 6 GHz data does not enter the 2.4 GHz or 5 GHz fields.
+* No incorrect band mapping occurs.
+
+---
+
+## TC-TEMP-016: Multiple radios using the same band
+
+### Test data
+
+Two 5 GHz radios publish valid temperatures.
+
+### Expected result
+
+* Samples from both 5 GHz radios are included in the 5 GHz summary.
+* They are not overwritten by the last radio entry.
+
+---
+
+## TC-TEMP-017: Temperature samples outside the requested range
+
+### Expected result
+
+* Only samples where `startTime <= sample_time < endTime` are included.
+
+---
+
+## TC-TEMP-018: Decimal average
+
+### Test data
+
+```text
+Temperatures: 60, 61
+```
+
+### Expected result
+
+```text
+average = 60.5
+```
+
+Average is not truncated.
+
+---
+
+## TC-TEMP-019: Malformed `radio_data`
+
+### Test data
+
+A timepoint contains invalid JSON in `radio_data`.
+
+### Expected result
+
+* The malformed record is skipped and logged.
+* Other valid records in the requested range are processed.
+* Service does not crash and does not return an internal error solely because one row is malformed.
+* Partial invalid data must not produce fabricated temperatures.
+
+---
+
+# 7. Wi-Fi Client Usage Summary Test Cases
+
+## Endpoint
+
+```http
+GET /api/v1/devices/{routerId}/wifi-clients/usage-summary
+```
+
+Expected response:
+
+```json
+[
+  {
+    "mac": "e2:51:95:ed:0f:28",
+    "rx_bytes": 106487500,
+    "tx_bytes": 3851250,
+    "total_bytes": 110338750,
+    "data_consume_rx": "851.90 Mb",
+    "data_consume_tx": "30.81 Mb",
+    "total_data_usage": "882.71 Mb",
+    "usage_accuracy": "exact",
+    "incomplete": false
+  }
+]
+```
+
+---
+
+## TC-USAGE-001: Basic cumulative-counter calculation
+
+### Test data
+
+```text
+Time     RX bytes    TX bytes
+10:00    1000        500
+10:10    3000        1500
+10:20    6000        2500
+```
+
+### Calculation
+
+```text
+RX delta = (3000 - 1000) + (6000 - 3000) = 5000
+TX delta = (1500 - 500) + (2500 - 1500) = 2000
+```
+
+### Expected result
+
+```text
+RX usage = 5000 bytes
+TX usage = 2000 bytes
+Total = 7000 bytes
+```
+
+The API converts the byte totals to decimal megabits.
+
+---
+
+## TC-USAGE-002: Pre-window baseline is available
+
+### Test data
+
+```text
+09:59 baseline: RX=1000, TX=500
+10:10 sample:   RX=3000, TX=1500
+10:20 sample:   RX=6000, TX=2500
+```
+
+Requested start time:
+
+```text
+10:00
+```
+
+### Expected result
+
+```text
+RX delta = 5000
+TX delta = 2000
+```
+
+The baseline itself is not counted as in-window traffic, but it is used to calculate the first delta.
+
+---
+
+## TC-USAGE-003: No pre-window baseline
+
+### Test data
+
+First in-window cumulative sample:
+
+```text
+RX=500000
+TX=100000
+```
+
+No earlier sample exists.
+
+### Expected result
+
+* First cumulative sample contributes a delta of zero.
+* The API does not assume all `500000` and `100000` bytes were generated inside the requested range.
+* Later sample deltas are counted normally.
+* The client response has `usage_accuracy: "lower_bound"`.
+* The client response has `incomplete: true`.
+
+---
+
+## TC-USAGE-004: Counter increases normally
+
+### Test data
+
+```text
+Previous RX = 1000
+Current RX = 1500
+```
+
+### Expected result
+
+```text
+RX delta = 500
+```
+
+---
+
+## TC-USAGE-005: Counter decreases because of reset
+
+### Test data
+
+```text
+Previous RX = 5000
+Current RX = 200
+```
+
+No confirmed fixed-width rollover exists.
+
+### Expected result
+
+* Delta for this sample is `0`.
+* `200` becomes the new baseline.
+* The implementation does not add `200` as traffic automatically.
+* The client response has `usage_accuracy: "lower_bound"`.
+* The client response has `incomplete: true`.
+
+---
+
+## TC-USAGE-006: Confirmed fixed-width counter rollover
+
+### Preconditions
+
+* Counter width and maximum are known.
+* Rollover is positively identified.
+
+### Test data
+
+```text
+counterMax = 65535
+previous = 65530
+current = 10
+```
+
+### Expected result
+
+```text
+delta = (65535 - 65530) + 10 + 1
+delta = 16
+```
+
+---
+
+## TC-USAGE-007: Client reconnect creates a new session
+
+### Test data
+
+```text
+Session A:
+RX 1000 → 5000
+
+Session B:
+RX 100 → 600
+```
+
+### Expected result
+
+* Deltas are calculated separately per session.
+* Session B's first value is not subtracted from Session A's last value.
+* Final result combines valid deltas for the same client MAC.
+
+---
+
+## TC-USAGE-008: Client moves between BSSIDs
+
+### Test data
+
+Same station MAC moves:
+
+```text
+BSSID A → BSSID B
+```
+
+### Expected result
+
+* Final response has one row for the station MAC.
+* BSSID A and BSSID B are separate counter streams unless a reliable session ID proves continuity.
+* Stream deltas are calculated before aggregation by MAC.
+
+---
+
+## TC-USAGE-009: Client moves between SSIDs
+
+### Expected result
+
+* SSID change creates a stream boundary when no reliable session identifier exists.
+* Counter decrease during the move does not create false usage.
+
+---
+
+## TC-USAGE-010: Client moves between 2.4 GHz and 5 GHz
+
+### Expected result
+
+* Radio or band change is used as a stream boundary when required.
+* Final result remains grouped by station MAC.
+
+---
+
+## TC-USAGE-011: Exact duplicate samples
+
+### Test data
+
+Two identical samples have the same:
+
+```text
+station MAC
+timestamp
+BSSID
+SSID
+band
+RX
+TX
+```
+
+### Expected result
+
+* Duplicate is removed before delta calculation.
+* Usage is not counted twice.
+
+---
+
+## TC-USAGE-012: Out-of-order sample
+
+### Test data
+
+Samples arrive in this order:
+
+```text
+10:20
+10:10
+10:30
+```
+
+### Expected result
+
+* Samples are ordered by timestamp before processing, or stale records are discarded according to the stream rule.
+* Negative or duplicated usage is not produced.
+
+---
+
+## TC-USAGE-013: Same timestamp with deterministic tie-breakers
+
+### Expected result
+
+* BSSID, SSID, radio or other stable fields provide deterministic ordering.
+* Exact duplicates are removed.
+* Two unrelated streams are not combined incorrectly.
+
+---
+
+## TC-USAGE-014: Multiple clients
+
+### Test data
+
+Associations contain three different station MAC addresses.
+
+### Expected result
+
+* Response contains one result per normalized MAC.
+* Counters are not mixed between clients.
+
+---
+
+## TC-USAGE-015: Same MAC appears in different letter case
+
+### Test data
+
+```text
+E2:51:95:ED:0F:28
+e2:51:95:ed:0f:28
+```
+
+### Expected result
+
+* MAC addresses are normalized.
+* Both records belong to one client result.
+
+---
+
+## TC-USAGE-016: RX traffic only
+
+### Expected result
+
+```text
+data_consume_rx > 0
+data_consume_tx = 0.00 Mb
+total_data_usage = RX usage
+```
+
+---
+
+## TC-USAGE-017: TX traffic only
+
+### Expected result
+
+```text
+data_consume_rx = 0.00 Mb
+data_consume_tx > 0
+total_data_usage = TX usage
+```
+
+---
+
+## TC-USAGE-018: No traffic change
+
+### Test data
+
+```text
+Previous RX = 5000
+Current RX = 5000
+Previous TX = 1000
+Current TX = 1000
+```
+
+### Expected result
+
+```text
+RX delta = 0
+TX delta = 0
+total = 0
+```
+
+---
+
+## TC-USAGE-019: No associated clients
+
+### Expected result
+
+```json
+[]
+```
+
+* HTTP `200 OK`.
+
+---
+
+## TC-USAGE-020: Association has missing counters
+
+### Expected result
+
+* Missing counter does not cause an exception.
+* Invalid sample is skipped or treated according to the explicit ingestion rule.
+* It must not produce a very large wrapped unsigned value.
+
+---
+
+## TC-USAGE-021: Byte-to-megabit conversion
+
+### Test data
+
+```text
+1,000,000 bytes
+```
+
+### Expected result
+
+```text
+8.00 Mb
+```
+
+The implementation uses:
+
+```text
+bytes * 8 / 1,000,000
+```
+
+---
+
+## TC-USAGE-022: Unit label matches calculation
+
+### Expected result
+
+* Decimal megabit conversion is labelled `Mb`.
+* If binary-byte conversion is used instead, it must not still be labelled `Mb`.
+* Response formatting follows the API contract.
+
+---
+
+## TC-USAGE-023: Total equals RX plus TX
+
+### Expected result
+
+For every client:
+
+```text
+total_bytes = rx_bytes + tx_bytes
+total_data_usage =
+    data_consume_rx + data_consume_tx
+```
+
+The total must be calculated before display rounding or with consistent rounding rules.
+
+---
+
+## TC-USAGE-024: Very large cumulative counters
+
+### Expected result
+
+* No integer overflow.
+* Deltas and conversion remain correct for 64-bit counters.
+
+---
+
+## TC-USAGE-025: Gateway filter prevents cross-device mixing
+
+### Preconditions
+
+The same client MAC connects to two gateways.
+
+### Expected result
+
+* Requested gateway's result includes only associations from:
+
+```text
+boardId = resolvedBoardId
+serialNumber = routerId
+```
+
+* Traffic from the second gateway is excluded.
+
+---
+
+## TC-USAGE-026: Malformed `ssid_data`
+
+### Expected result
+
+* Service does not crash.
+* Malformed record is skipped and logged.
+* Other valid records in the requested range are processed.
+* Fabricated usage is not returned.
+
+---
+
+# 8. Wi-Fi Client RSSI Summary Test Cases
+
+## Endpoint
+
+```http
+GET /api/v1/devices/{routerId}/wifi-clients/rssi-summary
+```
+
+RSSI categories:
+
+```text
+Excellent: RSSI >= -55
+Good:      -67 <= RSSI < -55
+Fair:      -75 <= RSSI < -67
+Poor:      RSSI < -75
+```
+
+Invalid RSSI:
+
+```text
+0
+positive values
+values below -127
+NULL
+```
+
+---
+
+## TC-RSSI-001: Excellent RSSI boundary
+
+### Test data
+
+```text
+RSSI = -55
+```
+
+### Expected result
+
+* Sample is classified as `excellent`.
+
+---
+
+## TC-RSSI-002: RSSI above excellent boundary
+
+### Test data
+
+```text
+RSSI = -40
+```
+
+### Expected result
+
+* Sample is classified as `excellent`.
+
+---
+
+## TC-RSSI-003: Good upper boundary
+
+### Test data
+
+```text
+RSSI = -56
+```
+
+### Expected result
+
+* Sample is classified as `good`.
+
+---
+
+## TC-RSSI-004: Good lower boundary
+
+### Test data
+
+```text
+RSSI = -67
+```
+
+### Expected result
+
+* Sample is classified as `good`.
+
+---
+
+## TC-RSSI-005: Fair upper boundary
+
+### Test data
+
+```text
+RSSI = -68
+```
+
+### Expected result
+
+* Sample is classified as `fair`.
+
+---
+
+## TC-RSSI-006: Fair lower boundary
+
+### Test data
+
+```text
+RSSI = -75
+```
+
+### Expected result
+
+* Sample is classified as `fair`.
+
+---
+
+## TC-RSSI-007: Poor boundary
+
+### Test data
+
+```text
+RSSI = -76
+```
+
+### Expected result
+
+* Sample is classified as `poor`.
+
+---
+
+## TC-RSSI-008: Minimum accepted RSSI
+
+### Test data
+
+```text
+RSSI = -127
+```
+
+### Expected result
+
+* Sample is valid.
+* It is classified as `poor`.
+
+---
+
+## TC-RSSI-009: RSSI below valid range
+
+### Test data
+
+```text
+RSSI = -128
+```
+
+### Expected result
+
+* Sample is ignored.
+
+---
+
+## TC-RSSI-010: RSSI equals zero
+
+### Expected result
+
+* Sample is ignored.
+* It does not enter any quality bucket.
+
+---
+
+## TC-RSSI-011: Positive RSSI
+
+### Test data
+
+```text
+RSSI = 20
+```
+
+### Expected result
+
+* Sample is ignored.
+
+---
+
+## TC-RSSI-012: Null RSSI
+
+### Expected result
+
+* Sample is ignored.
+
+---
+
+## TC-RSSI-013: Calculate percentages for one client
+
+### Test data
+
+```text
+Excellent samples: 4
+Good samples:      3
+Fair samples:      2
+Poor samples:      1
+```
+
+### Expected result
+
+```json
+{
+  "rssi_excellent_pct": 40.0,
+  "rssi_good_pct": 30.0,
+  "rssi_fair_pct": 20.0,
+  "rssi_poor_pct": 10.0,
+  "rssi_total_samples": 10
+}
+```
+
+---
+
+## TC-RSSI-014: Percentages require decimal rounding
+
+### Test data
+
+```text
+Excellent: 1
+Good: 1
+Fair: 1
+Total: 3
+```
+
+### Expected result
+
+```text
+Excellent = 33.33
+Good = 33.33
+Fair = 33.33
+Poor = 0.00
+```
+
+Percentages are rounded to two decimal places.
+
+---
+
+## TC-RSSI-015: Percentage sum after rounding
+
+### Expected result
+
+* Percentages are independently rounded to two decimal places.
+* A minor rounding result such as `99.99` or `100.01` is acceptable only if documented.
+* The implementation must not silently assign the rounding difference to an arbitrary category unless specified.
+
+---
+
+## TC-RSSI-016: All samples are excellent
+
+### Expected result
+
+```text
+excellent_pct = 100
+good_pct = 0
+fair_pct = 0
+poor_pct = 0
+```
+
+---
+
+## TC-RSSI-017: All samples are poor
+
+### Expected result
+
+```text
+excellent_pct = 0
+good_pct = 0
+fair_pct = 0
+poor_pct = 100
+```
+
+---
+
+## TC-RSSI-018: Valid and invalid samples mixed
+
+### Test data
+
+```text
+-50
+-60
+-70
+-80
+0
+20
+-128
+NULL
+```
+
+### Expected result
+
+* Total valid samples: `4`.
+* Each valid quality category has one sample.
+* Every percentage is `25%`.
+* Invalid samples do not affect `rssi_total_samples`.
+
+---
+
+## TC-RSSI-019: Multiple clients
+
+### Expected result
+
+* Each normalized station MAC has an independent sample count and percentages.
+* No RSSI samples are shared between clients.
+
+---
+
+## TC-RSSI-020: Same MAC with different case
+
+### Expected result
+
+* MAC is normalized.
+* Samples are aggregated into one response row.
+
+---
+
+## TC-RSSI-021: Client moves between BSSIDs
+
+### Expected result
+
+* RSSI samples remain grouped by station MAC.
+* BSSID movement does not create duplicate final client rows.
+
+---
+
+## TC-RSSI-022: No clients
+
+### Expected result
+
+```json
+[]
+```
+
+* HTTP `200 OK`.
+
+---
+
+## TC-RSSI-023: Client has only invalid samples
+
+### Expected result
+
+* The client is omitted from the response.
+* No percentage division by zero occurs.
+* `NaN` or infinity is never returned.
+
+---
+
+## TC-RSSI-024: Samples outside requested range
+
+### Expected result
+
+* Out-of-range RSSI samples are excluded.
+
+---
+
+## TC-RSSI-025: Gateway filtering
+
+### Preconditions
+
+The same client MAC appears on two gateways.
+
+### Expected result
+
+* Only samples associated with the requested gateway's timepoints are included.
+
+---
+
+## TC-RSSI-026: Malformed association entry
+
+### Expected result
+
+* Invalid association is skipped and logged.
+* Other valid associations in the requested range are processed.
+* Invalid association data does not crash the API.
+
+---
+
+# 9. Cross-API Consistency Test Cases
+
+## TC-CROSS-001: Same time range across all APIs
+
+### Steps
+
+Call all five APIs using identical:
+
+```text
+routerId
+timestampTill
+lookbackHours
+```
+
+### Expected result
+
+* Every API calculates the same requested `startTime` and `endTime` from `timestampTill` and `lookbackHours`.
+* Memory, usage, and RSSI apply the requested half-open aggregation window: `startTime <= sample_time < endTime`.
+* Temperature applies an effective aggregation window where `effective_start_time = max(startTime, temperature_migration_cutover_time)`, so pre-cutover temperature records are ignored even if they fall inside the requested window.
+* Availability applies the requested event window only when `startTime >= availabilityValidFrom`; otherwise the availability request is rejected according to the API contract.
+
+---
+
+## TC-CROSS-002: Router resolution reuse across separate MCP HTTP requests
+
+### Preconditions
+
+Five separate MCP metric HTTP requests are made for the same gateway `routerId`.
+
+### Expected result
+
+* Separate MCP metric calls are separate HTTP requests and do not share request-scoped state.
+* Router resolution reuse across different metric endpoints occurs through `VenueCoordinator`'s maintained `routerId -> boardId` map or the process-level router-resolution cache.
+* OWPROV is not queried on every request when the local `VenueCoordinator` map or unexpired process-level cache entry is present.
+
+---
+
+## TC-CROSS-003: Gateway has no metric data
+
+### Expected result
+
+```text
+Memory API:      null summary fields
+Temperature API: null summary fields
+Usage API:       []
+RSSI API:        []
+Availability:    fetch_status = success, offline_count = 0 (when startTime >= availabilityValidFrom)
+```
+
+* All metric responses use HTTP `200 OK` when queries succeed but return no data.
+* Availability returns `fetch_status = "success"` and `offline_count = 0` only when `startTime >= availabilityValidFrom`.
+* If `startTime < availabilityValidFrom`, Availability returns `400 Bad Request` with `error: "availability_range_before_cutover"`.
+
+---
+
+## TC-CROSS-004: Gateway is offline during the requested period
+
+### Expected result
+
+* Availability API reports the observed offline transition.
+* Other APIs return data available before shutdown within the requested range.
+* Lack of samples after shutdown does not erase earlier valid data.
+* Missing later samples are not converted into zero memory, zero temperature or zero RSSI.
+
+---
+
+## TC-CROSS-005: Data from another gateway is present
+
+### Expected result
+
+* Every API filters by the requested gateway identity.
+* Results from different gateways are not mixed.
+
+---
+
+## TC-CROSS-006: Board ownership changes during history window
+
+### Expected result
+
+* Memory, temperature, usage and RSSI follow the currently defined board-resolution/query design.
+* Availability history remains durable by `serialNumber`.
+* No historical availability event is lost due to reassignment.
+
+---
+
+## TC-CROSS-007: Database migration from previous release
+
+### Steps
+
+1. Start with a previous-version database.
+2. Run all required migrations.
+3. Retain old timepoints.
+4. Insert new-format timepoints and availability events.
+5. Call all APIs.
+
+### Expected result
+
+* Service starts successfully.
+* Existing data remains available.
+* Missing new fields in old rows are handled safely.
+* New fields are stored correctly.
+* Availability tables and indexes are created.
+* No existing data is deleted unintentionally.
+
+---
+
+# 10. Response Contract Test Cases
+
+## TC-CONTRACT-001: Memory response field names
+
+Expected exact fields:
+
+```text
+min_memfree
+max_memfree
+avg_memfree
+```
+
+---
+
+## TC-CONTRACT-002: Temperature response field names
+
+Expected exact fields:
+
+```text
+min_wifi_temp_2.4G
+max_wifi_temp_2.4G
+avg_wifi_temp_2.4G
+min_wifi_temp_5G
+max_wifi_temp_5G
+avg_wifi_temp_5G
+```
+
+All temperature fields are reported in degrees Celsius.
+
+---
+
+## TC-CONTRACT-003: Usage response field names
+
+Expected exact fields:
+
+```text
+mac
+rx_bytes
+tx_bytes
+total_bytes
+data_consume_rx
+data_consume_tx
+total_data_usage
+usage_accuracy
+incomplete
+```
+
+---
+
+## TC-CONTRACT-004: RSSI response field names
+
+Expected exact fields:
+
+```text
+mac
+rssi_excellent_pct
+rssi_good_pct
+rssi_fair_pct
+rssi_poor_pct
+rssi_total_samples
+```
+
+---
+
+## TC-CONTRACT-005: Availability response field names
+
+Expected exact fields:
+
+```text
+gw_uuid
+fetch_status
+offline_count
+```
+
+---
+
+## TC-CONTRACT-006: Bounded client summary arrays
+
+### Expected result
+
+* Usage and RSSI summary responses are arrays, not wrapper objects.
+* Each response contains at most 500 client summary items.
+* Results are ordered by normalized client MAC address ascending before the 500-client cap is applied.
+* If more than 500 clients match, the response contains the first 500 clients in that deterministic order.
+* The endpoints do not accept or require `limit` or `cursor` query parameters.
+
+---
+
+## TC-CONTRACT-007: Client MAC address format
+
+### Expected result
+
+* Usage and RSSI `mac` fields match `^[A-Fa-f0-9]{2}(:[A-Fa-f0-9]{2}){5}$`.
+* MAC addresses are returned as colon-separated six-octet values.
+* Arbitrary strings are not valid client MAC addresses in the response contract.
+
+---
+
+## TC-CONTRACT-008: Usage byte totals
+
+### Expected result
+
+For every usage summary item:
+
+```text
+total_bytes = rx_bytes + tx_bytes
+```
+
+---
+
+## TC-CONTRACT-009: No request body
+
+### Expected result
+
+* All five APIs work as GET requests without a request body.
+* Inputs are accepted only through the path and query parameters.
+
+---
+
+## TC-CONTRACT-010: JSON data types
+
+### Expected result
+
+* Memory min and max are numeric or `null`.
+* Memory average is numeric or `null`.
+* Temperature fields are numeric or `null`.
+* Usage fields are formatted strings using the documented unit.
+* RSSI percentages are numeric.
+* RSSI sample count is an integer.
+* Offline count is a non-negative integer.
+
+---
+
+# 11. Acceptance Criteria
+
+The PR implementation is functionally accepted when:
+
+1. All five endpoints are available in OpenAPI.
+2. Every endpoint uses the gateway serial number as `routerId`.
+3. Router ownership resolves correctly from the maintained local map.
+4. OWPROV fallback resolution distinguishes `404` and `409` status outcomes.
+5. Child-venue gateway resolution works.
+6. Timestamp and lookback validation is consistent.
+7. Memory aggregation ignores missing historical fields instead of treating them as zero.
+8. Temperature aggregation excludes synthetic or invalid fallback values.
+9. Client bandwidth is calculated from reset-safe counter deltas.
+10. A pre-window baseline is used when available.
+11. Counter resets, reconnects, BSSID changes and duplicates do not inflate usage.
+12. RSSI thresholds and boundary values are classified correctly.
+13. Invalid RSSI values are ignored.
+14. RSSI percentages are calculated per client.
+15. Usage and RSSI client-summary arrays are ordered by normalized MAC address and capped at 500 clients.
+16. Gateway shutdown and network loss create one offline transition each.
+17. Repeated pings and disconnections do not create duplicate transitions.
+18. Availability events remain queryable after board reassignment.
+19. Availability success responses include `fetch_status: "success"`.
+20. Empty successful queries return the documented empty response.
+21. Response field names and data types match the MCP contract exactly.
+22. Data from one gateway never appears in another gateway's response.

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -3975,14 +3975,21 @@ Query with `includeCalculationDetails=true` vs `includeCalculationDetails=false`
 
 ### Test data
 
+* Requested time window: `[10:00:00Z, 11:00:00Z)`.
 * Expected collection interval = 300 seconds (5 minutes). Tolerance threshold = 2 * 300 = 600 seconds (10 minutes).
-* Client A has pre-start fallback sample at 09:51:00Z (9 minutes before 10:00:00Z start, within tolerance threshold).
-* Client B has pre-start fallback sample at 09:48:00Z (12 minutes before 10:00:00Z start, outside tolerance threshold).
+* Client A samples:
+  * `09:51:00Z`: `rx_bytes = 1000000`, `tx_bytes = 1000000` (pre-start fallback sample, 9 minutes before start, within 2x tolerance)
+  * `10:30:00Z`: `rx_bytes = 2000000`, `tx_bytes = 2000000` (in-window observation proving presence)
+  * `11:00:00Z`: `rx_bytes = 3000000`, `tx_bytes = 3000000` (exact end-boundary sample at effective end)
+* Client B samples:
+  * `09:48:00Z`: `rx_bytes = 1000000`, `tx_bytes = 1000000` (pre-start fallback sample, 12 minutes before start, outside 2x tolerance)
+  * `10:30:00Z`: `rx_bytes = 2000000`, `tx_bytes = 2000000` (in-window observation proving presence)
+  * `11:00:00Z`: `rx_bytes = 3000000`, `tx_bytes = 3000000` (exact end-boundary sample at effective end)
 
 ### Expected result
 
-* Client A uses the 09:51:00Z sample as boundary baseline; expected accuracy is deterministically `bounded_interval` (because actual start 09:51 != effective start 10:00).
-* Client B cannot use the 09:48:00Z sample because it exceeds 2x collection interval tolerance; Client B starts delta calculation from the first in-window sample at 10:05:00Z (accuracy `lower_bound`).
+* Client A uses the 09:51:00Z sample as start boundary baseline and 11:00:00Z as exact end boundary; expected usage accuracy is deterministically `bounded_interval` (because `actual_start_time` 09:51 != `effective_start` 10:00).
+* Client B discards the 09:48:00Z sample because it exceeds 2x collection interval tolerance; Client B calculates delta starting from in-window sample at 10:30:00Z to exact end sample at 11:00:00Z, and is classified as `lower_bound`.
 
 ---
 

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -3107,23 +3107,24 @@ Expected response:
 ### Test data
 
 ```text
-temperature_migration_cutover_time = 2026-07-29T10:00:00Z
-sample time = 2026-07-29T09:59:59Z
-wifi_temp = 62
+temperatureMigrationCutoverTime = 2026-07-29T10:00:00Z
+API requested startTime = 2026-07-29T10:00:00Z
+Database contains historical row: sample time = 2026-07-29T09:59:59Z, wifi_temp = 62
 ```
 
 ### Expected result
 
-* Sample is excluded because it is before `temperature_migration_cutover_time`.
+* The pre-cutover database sample is excluded by the database query filter `timestamp >= startTime`.
 * It does not affect minimum, maximum or average.
+* Note: If API requested `startTime` were before `temperatureMigrationCutoverTime` (e.g. `09:55:00Z`), the request would return `400 Bad Request` per `TC-TEMP-017`.
 
 ---
 
-## TC-TEMP-008: Post-cutover measured zero temperature
+## TC-TEMP-008: Zero temperature treated as missing-sensor sentinel
 
 ### Preconditions
 
-The sample is at or after `temperature_migration_cutover_time`:
+The sample contains:
 
 ```text
 wifi_temp = 0
@@ -3131,8 +3132,9 @@ wifi_temp = 0
 
 ### Expected result
 
-* The sample is included as a valid measured value.
-* It is not replaced with `20`.
+* `wifi_temp = 0` is treated as an uninitialized or missing-sensor sentinel across all OpenWiFi telemetry.
+* The sample is excluded from temperature aggregation and does not contribute to min, max, or average calculations.
+* If all samples for a band have `wifi_temp = 0`, the response returns `null` for that band's min, max, and average fields.
 
 ---
 
@@ -3157,12 +3159,13 @@ wifi_temp = 0
 
 ### Preconditions
 
-* Record timestamp is before `temperature_migration_cutover_time`.
-* `wifi_temp = 20`.
+* `temperatureMigrationCutoverTime = 2026-07-29T10:00:00Z`.
+* API requested `startTime = 2026-07-29T10:00:00Z`.
+* Database contains pre-cutover record timestamp `2026-07-29T09:59:00Z` with `wifi_temp = 20`.
 
 ### Expected result
 
-* The pre-cutover value is excluded because historical temperature values cannot reliably distinguish measured values from synthetic fallback values.
+* The pre-cutover database row is excluded by `timestamp >= startTime` filtering because historical temperature values cannot reliably distinguish measured values from synthetic fallback values.
 * It does not affect minimum, maximum or average.
 
 ---
@@ -3172,13 +3175,14 @@ wifi_temp = 0
 ### Test data
 
 ```text
-Record timestamp is before temperature_migration_cutover_time
-wifi_temp = 62
+temperatureMigrationCutoverTime = 2026-07-29T10:00:00Z
+API requested startTime = 2026-07-29T10:00:00Z
+Database contains pre-cutover record timestamp 2026-07-29T09:55:00Z with wifi_temp = 62
 ```
 
 ### Expected result
 
-* The sample is excluded because all pre-cutover temperature records are ignored.
+* The sample is excluded by `timestamp >= startTime` filtering because all pre-cutover temperature records are ignored.
 
 ---
 
@@ -3202,13 +3206,16 @@ wifi_temp = 20
 
 ### Test data
 
+`temperatureMigrationCutoverTime` = `2026-07-29T10:00:00Z`
+API requested window: `startTime = 2026-07-29T10:00:00Z`, `endTime = 2026-07-29T10:05:00Z`
+
 ```text
-2.4 GHz:
-60 valid
-20 historical ambiguous
-65 valid
-null invalid
-70 valid
+2.4 GHz database samples:
+09:59:00Z  wifi_temp = 20   (pre-cutover DB row -> excluded by timestamp >= startTime)
+10:01:00Z  wifi_temp = 60   (post-cutover valid sample -> included)
+10:02:00Z  wifi_temp = 65   (post-cutover valid sample -> included)
+10:03:00Z  wifi_temp = null (missing sample -> excluded)
+10:04:00Z  wifi_temp = 70   (post-cutover valid sample -> included)
 ```
 
 ### Expected result
@@ -3219,7 +3226,7 @@ max = 70
 avg = 65
 ```
 
-Only `60`, `65`, and `70` are included.
+Only post-cutover valid samples `60`, `65`, and `70` are included. Pre-cutover DB row (`09:59:00Z`) and `null` are excluded.
 
 ---
 
@@ -3252,11 +3259,24 @@ Two 5 GHz radios publish valid temperatures.
 
 ---
 
-## TC-TEMP-017: Temperature samples outside the requested range
+## TC-TEMP-017: Requested range starts before temperature migration cutover
+
+### Test data
+
+Query requested `startTime` is strictly before `temperatureMigrationCutoverTime` (`startTime < temperatureMigrationCutoverTime`).
 
 ### Expected result
 
-* Only samples where `effective_start_time <= sample_time < endTime` are included, where `effective_start_time = max(startTime, temperature_migration_cutover_time)`.
+* HTTP `400 Bad Request`.
+* Response JSON envelope:
+
+```json
+{
+  "error": "temperature_range_before_cutover",
+  "message": "The requested summary interval starts before the temperature migration cutover timestamp."
+}
+```
+* No truncated or partial temperature summary is returned for pre-cutover intervals.
 
 ---
 
@@ -3290,6 +3310,87 @@ A timepoint contains invalid JSON in `radio_data`.
 * Other valid records in the requested range are processed.
 * Service does not crash and does not return an internal error solely because one row is malformed.
 * Partial invalid data must not produce fabricated temperatures.
+
+---
+
+## TC-CONFIG-TEMP-001: Valid file configuration starts service
+
+### Preconditions
+
+`temperature.migration_cutover_time = "2026-07-01T00:00:00Z"` in configuration file. `TEMPERATURE_MIGRATION_CUTOVER_TIME` environment variable is unset.
+
+### Expected result
+
+* Service initializes successfully.
+* `temperatureMigrationCutoverTime` is set to `2026-07-01T00:00:00Z`.
+
+---
+
+## TC-CONFIG-TEMP-002: Valid environment configuration starts service
+
+### Preconditions
+
+`TEMPERATURE_MIGRATION_CUTOVER_TIME = "2026-07-01T00:00:00Z"` in environment. `temperature.migration_cutover_time` configuration file key is unset.
+
+### Expected result
+
+* Service initializes successfully.
+* `temperatureMigrationCutoverTime` is set to `2026-07-01T00:00:00Z`.
+
+---
+
+## TC-CONFIG-TEMP-003: Environment configuration takes precedence over file configuration
+
+### Preconditions
+
+* Configuration file: `temperature.migration_cutover_time = "2026-06-01T00:00:00Z"`.
+* Environment variable: `TEMPERATURE_MIGRATION_CUTOVER_TIME = "2026-07-01T00:00:00Z"`.
+
+### Expected result
+
+* Service initializes successfully.
+* `temperatureMigrationCutoverTime` evaluates to `"2026-07-01T00:00:00Z"` (environment variable takes precedence).
+
+---
+
+## TC-CONFIG-TEMP-004: Missing configuration causes fatal startup failure
+
+### Preconditions
+
+Both `temperature.migration_cutover_time` file key and `TEMPERATURE_MIGRATION_CUTOVER_TIME` environment variable are absent or empty.
+
+### Expected result
+
+* Service fails startup immediately.
+* Logs a `FATAL` error: `FATAL: Missing required configuration 'temperature.migration_cutover_time'`.
+* Service process terminates with a non-zero exit code.
+
+---
+
+## TC-CONFIG-TEMP-005: Malformed timestamp causes fatal startup failure
+
+### Preconditions
+
+`temperature.migration_cutover_time = "invalid-date-string"`.
+
+### Expected result
+
+* Service fails startup immediately.
+* Logs a `FATAL` error: `FATAL: Unparseable configuration 'temperature.migration_cutover_time'`.
+* Service process terminates with a non-zero exit code.
+
+---
+
+## TC-CONFIG-TEMP-006: Timezone offset handling
+
+### Preconditions
+
+`temperature.migration_cutover_time = "2026-07-01T05:30:00+05:30"`.
+
+### Expected result
+
+* Timestamp is parsed and normalized to UTC `2026-07-01T00:00:00Z`.
+* Service initializes successfully with canonical UTC timestamp.
 
 ---
 

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -551,7 +551,7 @@ GET /api/v1/devices/60cf84f22290/memory-summary
 
 * HTTP `400 Bad Request`.
 * Error is `invalid_lookback_hours`, not `invalid_timestamp`.
-* Repeated `lookbackHours` query parameters are ambiguous and must not be accepted by picking the first or last value.
+* The value is rejected before integer overflow, wraparound, or truncation can affect range calculation.
 
 ---
 

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -670,7 +670,7 @@ Call `GET /api/v1/devices/{routerId}/availability-summary` with a calculated `st
 
 ### Objective
 
-Verify that the required restart-safe state table exists with deterministic fields and constraints.
+Verify that the required restart-safe state table exists with deterministic fields, sequence tracking, and constraints.
 
 ### Expected result
 
@@ -683,11 +683,13 @@ serialNumber
 board_id
 current_state
 last_event_time
+last_source_sequence
 last_idempotency_key
 updated_at
 metadata
 ```
 
+* `last_source_sequence` exists, is nullable (`BIGINT NULL`), and is stored as a 64-bit integer to preserve numeric ordering.
 * `current_state` accepts only `online`, `offline`, or `unknown`.
 * An index exists for `board_id` when board-scoped maintenance queries need it.
 
@@ -697,7 +699,7 @@ metadata
 
 ### Objective
 
-Verify that transition history is stored separately from current state.
+Verify that transition history is stored separately from current state with sequence-aware ordering indexes.
 
 ### Expected result
 
@@ -710,6 +712,7 @@ serialNumber
 board_id
 event_type
 event_time
+source_sequence
 event_id
 idempotency_key
 reason
@@ -722,31 +725,95 @@ metadata
 * `serialNumber` is non-null.
 * `event_type` is non-null.
 * `event_time` is non-null.
+* `source_sequence` exists, is nullable (`BIGINT NULL`), and is stored as a 64-bit integer.
 * `idempotency_key` is non-null and unique.
 * `session_id` exists and is nullable.
-* At least one index supports lookup by `serialNumber` and `event_time`.
+* Sequence-aware composite indexes exist to support deterministic event lookup and ordering, verified via `pg_get_indexdef()` or schema inspection:
+  * `availability_serial_time_index`: `(serialNumber ASC, event_time ASC, source_sequence ASC NULLS FIRST)`
+  * `availability_board_serial_time_index`: `(board_id ASC, serialNumber ASC, event_time ASC, source_sequence ASC NULLS FIRST)`
 * `event_type` accepts only stored transition values `online` and `offline`.
 
 ---
 
-## TC-AVAIL-SCHEMA-003: Availability migrations are idempotent
+## TC-AVAIL-SCHEMA-003: Availability migrations are idempotent across all availability tables
 
 ### Objective
 
-Verify that migration from a database without availability tables creates both required tables safely.
+Verify that migration from a database without availability objects, or with a partial prior release schema missing sequence columns or coverage tables, creates all four required tables and sequence columns safely and idempotently.
 
 ### Steps
 
-1. Start with a previous-version database that has no availability tables.
+1. Start with a database that has no availability objects, or a partial deployment database missing sequence columns or ingestion coverage tables.
 2. Run Analytics migrations.
 3. Run Analytics migrations again.
-4. Inspect the schema.
+4. Inspect the schema and table definitions.
 
 ### Expected result
 
-* `device_availability_events` and `device_availability_state` exist after migration.
-* Re-running migration does not drop or duplicate tables, indexes, or constraints.
+* All four availability storage objects exist after migration:
+  * `device_availability_state`
+  * `device_availability_events`
+  * `device_availability_ingestion_checkpoint`
+  * `device_availability_ingestion_gaps`
+* Both `source_sequence` (`device_availability_events`) and `last_source_sequence` (`device_availability_state`) exist as `BIGINT NULL`.
+* All sequence-aware indexes, primary keys, uniqueness constraints, and state check constraints exist.
+* Re-running migration does not drop, fail, or duplicate tables, columns, indexes, or constraints.
 * Existing `timepoints` and `wificlienthistory` data remains intact.
+
+---
+
+## TC-AVAIL-SCHEMA-004: Ingestion checkpoint table schema exists
+
+### Objective
+
+Verify that durable per-serial ingestion coverage watermarks are stored in a dedicated checkpoint table.
+
+### Expected result
+
+* `device_availability_ingestion_checkpoint` exists.
+* `serialNumber` is the primary key.
+* Required fields exist:
+
+```text
+serialNumber
+coverage_start
+processed_through_event_time
+partition
+offset
+ordering_strategy
+reorder_window_ms
+ingestion_gap_known
+updated_at
+metadata
+```
+
+* `coverage_start` and `processed_through_event_time` exist and are 64-bit integers (`BIGINT`).
+* `ingestion_gap_known` exists and is boolean.
+
+---
+
+## TC-AVAIL-SCHEMA-005: Ingestion gaps table schema exists
+
+### Objective
+
+Verify that persisted availability ingestion gaps are stored in a dedicated gaps table.
+
+### Expected result
+
+* `device_availability_ingestion_gaps` exists.
+* Required fields exist:
+
+```text
+serialNumber
+gap_start_event_time
+gap_end_event_time
+reason
+detected_at
+metadata
+```
+
+* `gap_start_event_time` and `gap_end_event_time` exist and are 64-bit integers (`BIGINT`).
+* An index exists to support range overlapping queries on `(serialNumber ASC, gap_start_event_time ASC, gap_end_event_time ASC)`.
 
 ---
 
@@ -757,6 +824,7 @@ SELECT serialNumber,
        board_id,
        current_state,
        last_event_time,
+       last_source_sequence,
        last_idempotency_key,
        updated_at,
        metadata
@@ -771,7 +839,7 @@ FOR UPDATE;
 SELECT *
 FROM device_availability_events
 WHERE serialNumber = '60cf84f22290'
-ORDER BY event_time DESC
+ORDER BY event_time DESC, source_sequence DESC NULLS LAST
 LIMIT 1;
 ```
 
@@ -781,7 +849,14 @@ LIMIT 1;
 SELECT *
 FROM device_availability_events
 WHERE serialNumber = '60cf84f22290'
-ORDER BY event_time ASC;
+ORDER BY event_time ASC, source_sequence ASC NULLS FIRST;
+```
+
+SQL composite sequence ordering rules:
+
+```text
+- Ascending queries use ORDER BY event_time ASC, source_sequence ASC NULLS FIRST so unsequenced events (source_sequence = NULL) at a timestamp sort before sequenced events at the same timestamp.
+- Descending queries use ORDER BY event_time DESC, source_sequence DESC NULLS LAST so the event with the highest sequence number at a timestamp sorts first, and unsequenced events sort last.
 ```
 
 ### Offline event count query
@@ -1738,6 +1813,8 @@ interval result when no durable availability coverage proof exists.
 * HTTP `200 OK` when the storage query itself succeeds.
 * `meta.coverage = "none"`.
 * `meta.accuracy = "not_applicable"`.
+* `meta.sampleCount = null`.
+* `meta.offlineEventCount = null`.
 * `meta.availabilityCoverage.proofSource = "unavailable"`.
 * `data.offline_count = null`.
 
@@ -2067,7 +2144,8 @@ Verify that first-row creation is concurrency-safe and does not rely on locking 
 * No offline transition row is inserted because the prior state was unknown.
 * An availability-summary response for a window containing these first observations does not report an exact zero, because the prior state boundary is unknown.
 * The response uses `meta.coverage = "partial"` and `meta.accuracy = "lower_bound"` when durable coverage begins at the first observation, or `meta.coverage = "none"` and `meta.accuracy = "not_applicable"` when no coverage proof exists.
-* `data.offline_count = 0` may be returned only as the count of stored offline transitions, not as proof that zero outages occurred in the requested interval.
+* When `meta.coverage = "partial"`, `data.offline_count = 0` is allowed as a lower-bound count of stored offline transitions.
+* When `meta.coverage = "none"`, `meta.sampleCount = null`, `meta.offlineEventCount = null`, and `data.offline_count = null`.
 
 ---
 
@@ -3226,19 +3304,34 @@ GET /api/v1/devices/{routerId}/wifi-clients/usage-summary
 Expected response:
 
 ```json
-[
-  {
-    "mac": "e2:51:95:ed:0f:28",
-    "rx_bytes": 106487500,
-    "tx_bytes": 3851250,
-    "total_bytes": 110338750,
-    "data_consume_rx": "106.49 MB",
-    "data_consume_tx": "3.85 MB",
-    "total_data_usage": "110.34 MB",
-    "usage_accuracy": "exact",
-    "incomplete": false
-  }
-]
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
+  },
+  "resultTimeWindow": {
+    "earliestActualStartTime": "2026-07-26T12:00:00Z",
+    "latestActualEndTime": "2026-07-27T12:00:00Z",
+    "boundaryFallbackUsed": false
+  },
+  "items": [
+    {
+      "mac": "e2:51:95:ed:0f:28",
+      "rx_bytes": 106487500,
+      "tx_bytes": 3851250,
+      "total_bytes": 110338750,
+      "data_consume_rx": "106.49 MB",
+      "data_consume_tx": "3.85 MB",
+      "total_data_usage": "110.34 MB",
+      "usage_accuracy": "exact",
+      "incomplete": false,
+      "segment_count": 1,
+      "boundary_fallback_used": false
+    }
+  ],
+  "totalClients": 1,
+  "truncated": false
+}
 ```
 
 ---
@@ -3589,7 +3682,20 @@ total = 0
 ### Expected result
 
 ```json
-[]
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
+  },
+  "resultTimeWindow": {
+    "earliestActualStartTime": null,
+    "latestActualEndTime": null,
+    "boundaryFallbackUsed": false
+  },
+  "items": [],
+  "totalClients": 0,
+  "truncated": false
+}
 ```
 
 * HTTP `200 OK`.
@@ -3643,15 +3749,16 @@ bytes / 1,000,000
 
 ### Expected result
 
-For every client:
+For every client, the total usage invariant is defined on raw byte counters, and each display field is derived using the documented unit formatter:
 
 ```text
 total_bytes = rx_bytes + tx_bytes
-total_data_usage =
-    data_consume_rx + data_consume_tx
+data_consume_rx  = format_bytes(rx_bytes)
+data_consume_tx  = format_bytes(tx_bytes)
+total_data_usage = format_bytes(total_bytes)
 ```
 
-The total must be calculated before display rounding or with consistent rounding rules.
+Direct string addition on formatted fields (e.g. `"10.00 MB" + "20.00 MB"`) is invalid because independent rounding of component display strings can differ from formatted raw byte totals. The test suite asserts `total_bytes = rx_bytes + tx_bytes` on raw integer counters, and verifies `data_consume_rx`, `data_consume_tx`, and `total_data_usage` independently against `format_bytes(...)`.
 
 ---
 
@@ -4021,7 +4128,20 @@ NULL
 ### Expected result
 
 ```json
-[]
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
+  },
+  "resultTimeWindow": {
+    "firstSampleTime": null,
+    "lastSampleTime": null,
+    "totalSamples": 0
+  },
+  "items": [],
+  "totalClients": 0,
+  "truncated": false
+}
 ```
 
 * HTTP `200 OK`.
@@ -4112,8 +4232,8 @@ Five separate MCP metric HTTP requests are made for the same gateway `routerId`.
 ```text
 Memory API:      null summary fields
 Temperature API: null summary fields
-Usage API:       []
-RSSI API:        []
+Usage API:       object envelope with items: [], totalClients: 0, truncated: false
+RSSI API:        object envelope with items: [], totalClients: 0, truncated: false
 Availability:    data.fetch_status = success, data.offline_count = 0, meta.coverage = full
 ```
 
@@ -4169,7 +4289,7 @@ Availability:    data.fetch_status = success, data.offline_count = 0, meta.cover
 * Existing data remains available.
 * Missing new fields in old rows are handled safely.
 * New fields are stored correctly.
-* Availability tables and indexes are created.
+* All four availability storage tables (`device_availability_state`, `device_availability_events`, `device_availability_ingestion_checkpoint`, `device_availability_ingestion_gaps`), both sequence columns (`source_sequence`, `last_source_sequence`), and associated sequence-aware indexes/constraints are created.
 * No existing data is deleted unintentionally.
 
 ---
@@ -4219,6 +4339,8 @@ data_consume_tx
 total_data_usage
 usage_accuracy
 incomplete
+segment_count
+boundary_fallback_used
 ```
 
 ---
@@ -4270,6 +4392,8 @@ coverage
 accuracy
 sampleCount
 offlineEventCount
+effectiveSamplingIntervalSeconds
+allowedGapSeconds
 boundarySamplesUsed
 availabilityCoverage
 ```
@@ -4288,21 +4412,32 @@ proofSource
 availability ingestion checkpoint state, and `ingestionGapKnown` reflects
 persisted gaps that overlap the requested interval.
 
-For availability responses, `sampleCount` and `offlineEventCount` both mean the
-number of offline transition rows contributing to `offline_count`; online
-transition rows do not contribute to either field. `boundarySamplesUsed` is
-data-dependent: `beforeStart` is `true` only when a pre-start boundary event was
-actually selected by the query setup, and event counting does not require a
-pre-start boundary event.
+For availability responses, `sampleCount` is retained for response-shape
+consistency with the other summary APIs. When `meta.coverage` is `"full"` or `"partial"`, `sampleCount` is defined as:
+
+```text
+sampleCount = offlineEventCount = offline_count
+```
+
+`sampleCount` and `offlineEventCount` both mean the number of offline transition rows in
+`device_availability_events` contributing to `offline_count`. Online recovery transition rows
+(`event_type = 'online'`) are stored in transition history for state tracking and `observedWindow` /
+`sourceWindow` bounds, but they do not contribute to `sampleCount`, `offlineEventCount`, or `offline_count`.
+For `"full"` or `"partial"` coverage, `sampleCount` always equals `offlineEventCount`.
+
+When `meta.coverage = "none"` and `meta.accuracy = "not_applicable"`, `sampleCount`, `offlineEventCount`,
+and `offline_count` are all `null`. `boundarySamplesUsed` is data-dependent: `beforeStart` is `true` only
+when a pre-start boundary event was actually selected by the query setup, and event counting does not require
+a pre-start boundary event.
 
 ---
 
-## TC-CONTRACT-006: Client summary array shape
+## TC-CONTRACT-006: Client summary envelope shape
 
 ### Expected result
 
-* Usage and RSSI summary responses are arrays, not wrapper objects.
-* The endpoints do not define `limit`, `cursor`, `totalClients`, or `truncated` response behavior unless those fields are added to the API contract first.
+* Usage (`GET /api/v1/devices/{routerId}/wifi-clients/usage-summary`) and RSSI (`GET /api/v1/devices/{routerId}/wifi-clients/rssi-summary`) summary responses are object envelopes containing `requestedTimeWindow`, `resultTimeWindow`, `items`, `totalClients`, and `truncated`.
+* When no clients match the requested interval, `items` is an empty array `[]`, `totalClients` is `0`, and `truncated` is `false`.
 
 ---
 
@@ -4354,13 +4489,16 @@ total_bytes         non-negative integer
 data_consume_rx     formatted string using the documented unit
 data_consume_tx     formatted string using the documented unit
 total_data_usage    formatted string using the documented unit
-usage_accuracy      enum string: "exact" or "lower_bound"
+usage_accuracy      enum string: "exact", "bounded_interval", or "lower_bound"
 incomplete          boolean
+segment_count       non-negative integer
+boundary_fallback_used boolean
 ```
 
 * RSSI percentages are numeric.
 * RSSI sample count is an integer.
-* Offline count is a non-negative integer.
+* Offline count is a non-negative integer when coverage is "full" or "partial".
+* It is null when coverage is "none" and accuracy is "not_applicable".
 
 ---
 
@@ -4382,7 +4520,7 @@ The PR implementation is functionally accepted when:
 12. RSSI thresholds and boundary values are classified correctly.
 13. Invalid RSSI values are ignored.
 14. RSSI percentages are calculated per client.
-15. Usage and RSSI client-summary responses use the documented array shape and do not invent pagination or truncation fields.
+15. Usage and RSSI client-summary responses use the documented object envelope shape (`requestedTimeWindow`, `resultTimeWindow`, `items`, `totalClients`, `truncated`) matching TC-CONTRACT-006.
 16. Gateway shutdown and network loss create one offline transition each.
 17. Repeated pings and disconnections do not create duplicate transitions.
 18. Availability events remain queryable after board reassignment.

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -2450,9 +2450,10 @@ counts observed online-to-offline transitions.
 
 * No `offline` transition event row is inserted.
 * A `device_availability_state` row is created with `current_state = offline` and `last_event_time` equal to the disconnection source timestamp.
-* An availability-summary response for a window containing the first disconnection does not report an exact zero, because the prior state boundary is unknown.
+* The checkpoint's `state_known_from` timestamp is set to this first observed event timestamp (or an unproven gap is recorded for `[coverage_start, initial_event_time)`).
+* An availability-summary response for a window containing the first disconnection does not report an exact zero, because `state_known_from > startTime` proves the prior state boundary is unknown.
 * The response uses `meta.coverage = "partial"` and `meta.accuracy = "lower_bound"` when durable coverage begins at the first observation, or `meta.coverage = "none"` and `meta.accuracy = "not_applicable"` when no coverage proof exists.
-* A full-coverage exact-zero response is allowed only for a requested window that begins after this state initialization boundary and is fully covered by the per-serial ingestion checkpoint.
+* A full-coverage exact-zero response is allowed only for a requested window that begins at or after `state_known_from` (`state_known_from <= startTime`) and is fully covered by the per-serial ingestion checkpoint (`processed_through_event_time >= endTime`).
 
 ---
 
@@ -2917,8 +2918,9 @@ min_memfree <= avg_memfree <= max_memfree
 }
 ```
 
-* The negative `memory_free` sample is treated as corrupted telemetry and excluded.
-* It cannot make `min_memfree` negative or affect the average.
+* Parsing and validation check numeric type, integral value, non-negative range (`>= 0`), and 64-bit non-overflow BEFORE unsigned conversion.
+* Field-level isolation: The negative `memory_free = -1` field is identified prior to unsigned casting and treated as invalid/unset (`null`), so it does not throw an exception or corrupt `memory_total = 512000` in the same sample.
+* The invalid `memory_free` field is excluded from `min_memfree`, `max_memfree`, and `avg_memfree`.
 
 ---
 
@@ -4348,7 +4350,7 @@ lookbackHours
 
 * Every API calculates the same requested `startTime` and `endTime` from `timestampTill` and `lookbackHours`.
 * Memory, usage, and RSSI apply the requested half-open aggregation window: `startTime <= sample_time < endTime`.
-* Temperature applies an effective aggregation window where `effective_start_time = max(startTime, temperature_migration_cutover_time)`, so pre-cutover temperature records are ignored even if they fall inside the requested window.
+* Temperature requires `startTime >= temperatureMigrationCutoverTime`; if requested `startTime < temperatureMigrationCutoverTime`, the temperature request is rejected with HTTP `400 Bad Request` (`error: "temperature_range_before_cutover"`) matching TC-TEMP-017 rather than clipping the requested range.
 * Availability applies the requested event window only when `startTime >= availabilityValidFrom`; otherwise the availability request is rejected according to the API contract.
 
 ---

--- a/analytics_mcp_api_test_cases.md
+++ b/analytics_mcp_api_test_cases.md
@@ -3147,11 +3147,20 @@ wifi_temp = 0
 
 ---
 
-## TC-TEMP-010: Post-cutover present `wifi_temp`
+## TC-TEMP-010: Post-cutover valid numeric `wifi_temp`
+
+### Preconditions
+
+A post-cutover sample contains a numeric `wifi_temp` value.
 
 ### Expected result
 
-* Numeric `wifi_temp` is included.
+* A post-cutover numeric `wifi_temp` is included only when all of the following hold:
+  * `-40 <= wifi_temp <= 125`
+  * `wifi_temp != 0`
+  * `wifi_temp != 255`
+* Explicit boundary values `-40` and `125` are valid inclusive measurements and are included in aggregation.
+* Sentinels and out-of-range values (`0`, `255`, `< -40`, and `> 125`) are excluded.
 
 ---
 

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -1985,7 +1985,6 @@ paths:
         - $ref: '#/components/parameters/RouterIdPath'
         - $ref: '#/components/parameters/TimestampTill'
         - $ref: '#/components/parameters/LookbackHours'
-        - $ref: '#/components/parameters/MetricRetrievalMode'
       responses:
         200:
           description: Return gateway free memory summary for the requested aggregation window.
@@ -2018,7 +2017,6 @@ paths:
         - $ref: '#/components/parameters/RouterIdPath'
         - $ref: '#/components/parameters/TimestampTill'
         - $ref: '#/components/parameters/LookbackHours'
-        - $ref: '#/components/parameters/MetricRetrievalMode'
       responses:
         200:
           description: Return Wi-Fi radio temperature summary for the effective aggregation window.
@@ -2088,7 +2086,6 @@ paths:
         - $ref: '#/components/parameters/RouterIdPath'
         - $ref: '#/components/parameters/TimestampTill'
         - $ref: '#/components/parameters/LookbackHours'
-        - $ref: '#/components/parameters/MetricRetrievalMode'
       responses:
         200:
           description: Return per-client RSSI quality percentages.

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -1862,9 +1862,13 @@ components:
             meta:
               properties:
                 coverage:
-                  const: full
+                  type: string
+                  enum:
+                    - full
                 accuracy:
-                  const: exact
+                  type: string
+                  enum:
+                    - exact
             data:
               properties:
                 offline_count:
@@ -1875,9 +1879,13 @@ components:
             meta:
               properties:
                 coverage:
-                  const: partial
+                  type: string
+                  enum:
+                    - partial
                 accuracy:
-                  const: lower_bound
+                  type: string
+                  enum:
+                    - lower_bound
             data:
               properties:
                 offline_count:
@@ -1888,13 +1896,17 @@ components:
             meta:
               properties:
                 coverage:
-                  const: none
+                  type: string
+                  enum:
+                    - none
                 accuracy:
-                  const: not_applicable
+                  type: string
+                  enum:
+                    - not_applicable
             data:
               properties:
                 offline_count:
-                  type: null
+                  nullable: true
 
     SystemCommandDetails:
       type: object

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -1496,16 +1496,16 @@ components:
             - bounded_interval
             - lower_bound
           description: >
-            exact when each contributing calculation segment has authoritative effective-boundary evidence
-            (actual_start <= effective_start and actual_end >= effective_end) and every counter reset,
-            rollover, or session transition is unambiguously proven and accounted for. bounded_interval
-            when exact effective-boundary samples are unavailable and fallback samples within two times
-            the configured telemetry sampling interval are used. lower_bound when no usable boundary pair
-            exists, when either fallback boundary exceeds tolerance, when an unconfirmed or ambiguous counter
-            reset/session change is detected, or when unbridgeable gaps prevent a complete differential
-            calculation. When a client was observed but no usage differential segment can be calculated,
-            return zero byte totals, usage_accuracy lower_bound, incomplete true, segment_count 0, and
-            boundary_fallback_used false.
+            exact when actual_start_time == effective_start_time and actual_end_time == effective_end_time
+            for every contributing calculation segment, with all counter resets, rollovers, or session
+            transitions unambiguously proven and accounted for. bounded_interval when exact effective-boundary
+            samples are unavailable and fallback samples within two times the configured telemetry sampling
+            interval are used (actual_start_time < effective_start_time or actual_end_time > effective_end_time).
+            lower_bound when no usable boundary pair exists, when either fallback boundary exceeds tolerance,
+            when an unconfirmed or ambiguous counter reset/session change is detected, or when unbridgeable
+            gaps prevent a complete differential calculation. When a client was observed but no usage
+            differential segment can be calculated, return zero byte totals, usage_accuracy lower_bound,
+            incomplete true, segment_count 0, and boundary_fallback_used false.
         incomplete:
           type: boolean
           description: True exactly when usage_accuracy is lower_bound; otherwise false.

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -57,6 +57,33 @@ components:
               value:
                 error: lookback_outside_retention
                 message: Requested range is outside the configured monitoring retention window
+    TemperatureAnalyticsBadRequest:
+      description: Invalid request or temperature range before the supported migration cutover.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TemperatureBadRequestError'
+          examples:
+            invalidRouterId:
+              value:
+                error: invalid_router_id
+                message: routerId must be a 12 to 29 character hexadecimal OWPROV gateway serial number
+            invalidTimestamp:
+              value:
+                error: invalid_timestamp
+                message: timestampTill must be a valid UTC timestamp in YYYY-MM-DDTHH:mm:ssZ format
+            invalidLookbackHours:
+              value:
+                error: invalid_lookback_hours
+                message: lookbackHours must be greater than 0 and within the configured monitoring retention
+            lookbackOutsideRetention:
+              value:
+                error: lookback_outside_retention
+                message: Requested range is outside the configured monitoring retention window
+            temperatureBeforeCutover:
+              value:
+                error: temperature_range_before_cutover
+                message: Temperature summary is only available for ranges starting at or after temperatureMigrationCutoverTime
     AvailabilityAnalyticsBadRequest:
       description: Invalid request or availability range before the supported cutover.
       content:
@@ -1095,6 +1122,23 @@ components:
             - invalid_timestamp
             - invalid_lookback_hours
             - lookback_outside_retention
+        message:
+          type: string
+
+    TemperatureBadRequestError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          enum:
+            - invalid_router_id
+            - invalid_timestamp
+            - invalid_lookback_hours
+            - lookback_outside_retention
+            - temperature_range_before_cutover
         message:
           type: string
 
@@ -2182,7 +2226,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/GatewayWifiTemperatureSummary'
         400:
-          $ref: '#/components/responses/CommonAnalyticsBadRequest'
+          $ref: '#/components/responses/TemperatureAnalyticsBadRequest'
         401:
           $ref: '#/components/responses/AnalyticsUnauthorized'
         404:

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -1985,6 +1985,7 @@ paths:
         - $ref: '#/components/parameters/RouterIdPath'
         - $ref: '#/components/parameters/TimestampTill'
         - $ref: '#/components/parameters/LookbackHours'
+        - $ref: '#/components/parameters/MetricRetrievalMode'
       responses:
         200:
           description: Return gateway free memory summary for the requested aggregation window.
@@ -2017,6 +2018,7 @@ paths:
         - $ref: '#/components/parameters/RouterIdPath'
         - $ref: '#/components/parameters/TimestampTill'
         - $ref: '#/components/parameters/LookbackHours'
+        - $ref: '#/components/parameters/MetricRetrievalMode'
       responses:
         200:
           description: Return Wi-Fi radio temperature summary for the effective aggregation window.
@@ -2086,6 +2088,7 @@ paths:
         - $ref: '#/components/parameters/RouterIdPath'
         - $ref: '#/components/parameters/TimestampTill'
         - $ref: '#/components/parameters/LookbackHours'
+        - $ref: '#/components/parameters/MetricRetrievalMode'
       responses:
         200:
           description: Return per-client RSSI quality percentages.

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -1496,18 +1496,15 @@ components:
             - bounded_interval
             - lower_bound
           description: >
-            exact when each segment's overlap with the requested interval can be calculated from
-            authoritative counter evidence exactly at effective_start and effective_end, without
-            counter resets or missing-sample gaps. bounded_interval when one or both exact boundary samples are
-            unavailable and the calculation uses the latest available starting sample at or before
-            effective_start and the earliest available ending sample at or after effective_end, with
-            both fallback samples within two times the configured telemetry sampling interval of
-            the effective boundaries. lower_bound when no usable boundary pair exists, when either fallback
-            boundary exceeds the tolerance, when any ambiguous counter reset/session change is
-            detected, or when gaps larger than two times the configured telemetry sampling
-            interval prevent a complete differential from being calculated. When a client was
-            observed but no usage differential segment can be calculated, return zero byte totals,
-            usage_accuracy lower_bound, incomplete true, segment_count 0, and
+            exact when each contributing calculation segment has authoritative effective-boundary evidence
+            (actual_start <= effective_start and actual_end >= effective_end) and every counter reset,
+            rollover, or session transition is unambiguously proven and accounted for. bounded_interval
+            when exact effective-boundary samples are unavailable and fallback samples within two times
+            the configured telemetry sampling interval are used. lower_bound when no usable boundary pair
+            exists, when either fallback boundary exceeds tolerance, when an unconfirmed or ambiguous counter
+            reset/session change is detected, or when unbridgeable gaps prevent a complete differential
+            calculation. When a client was observed but no usage differential segment can be calculated,
+            return zero byte totals, usage_accuracy lower_bound, incomplete true, segment_count 0, and
             boundary_fallback_used false.
         incomplete:
           type: boolean

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -2220,7 +2220,7 @@ paths:
         - $ref: '#/components/parameters/LookbackHours'
       responses:
         200:
-          description: Return Wi-Fi radio temperature summary for the effective aggregation window.
+          description: Return Wi-Fi radio temperature summary for the requested aggregation window.
           content:
             application/json:
               schema:

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -1679,7 +1679,7 @@ components:
 
     GatewayAvailabilityIngestionCoverage:
       type: object
-      description: Durable ingestion coverage proof for the requested gateway lookback window.
+      description: Durable ingestion coverage proof for the requested gateway lookback window. Full coverage requires coverageStart <= startTime, stateKnownFrom <= startTime, processedThrough >= endTime, and ingestionGapKnown == false.
       required:
         - coverageStart
         - processedThrough
@@ -1692,6 +1692,11 @@ components:
           format: date-time
           nullable: true
           description: ISO timestamp of earliest durable availability coverage; null when coverage is none.
+        stateKnownFrom:
+          type: string
+          format: date-time
+          nullable: true
+          description: ISO timestamp from which gateway availability state is authoritatively established; null when state is unproven or coverage is none.
         processedThrough:
           type: string
           format: date-time

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -234,7 +234,12 @@ components:
     LookbackHours:
       in: query
       name: lookbackHours
-      description: Number of hours to look back from timestampTill. Must be greater than 0 and less than or equal to maxLookbackHours, where maxLookbackHours is derived from the configured monitoringDuration; the resulting half-open range must fit inside the configured retention window.
+      description: >
+        Number of hours to look back from timestampTill. Must be greater than 0 and less than or equal to
+        maxLookbackHours, where maxLookbackHours is derived from the configured monitoringDuration; the
+        resulting half-open range must fit inside the configured retention window. Handlers must parse the
+        raw HTTP query parameter collection to ensure lookbackHours appears exactly once, is a non-fractional
+        integer, and does not overflow or repeat.
       schema:
         type: integer
         format: int32
@@ -1592,31 +1597,183 @@ components:
           type: boolean
           description: True when totalClients is greater than the number of returned items.
 
-    GatewayOfflineSummary:
+    GatewayAvailabilitySampleWindow:
       type: object
-      description: >
-        Gateway offline transition count. Count each transition from an online state to an
-        offline state whose offline event timestamp falls within [timestampTill - lookbackHours,
-        timestampTill). Repeated offline samples without an intervening online state are not
-        counted. The latest valid state before the start of the window is used to determine
-        whether the first in-window offline event is a transition. A gateway already offline
-        at the beginning of the requested window is not counted unless it transitions online
-        and then offline again within the window. Events exactly at timestampTill are excluded.
-        Unknown or missing states do not create offline transitions. Availability events do not
-        carry a separate staleness timeout; transition state is determined only from persisted
-        gateway availability events keyed by serial number. HTTP 200 represents successful
-        retrieval; no separate success status field is returned.
+      description: Sample window boundary timestamps for availability metadata.
+      required:
+        - firstSampleAt
+        - lastSampleAt
+      properties:
+        firstSampleAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: ISO timestamp of earliest contributing sample in window.
+        lastSampleAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: ISO timestamp of latest contributing sample in window.
+
+    GatewayAvailabilityBoundarySamplesUsed:
+      type: object
+      description: Indicators of whether boundary-assisted sampling selected events outside or at the window edge.
+      required:
+        - beforeStart
+        - atStart
+        - atEnd
+        - afterEnd
+      properties:
+        beforeStart:
+          type: boolean
+        atStart:
+          type: boolean
+        atEnd:
+          type: boolean
+        afterEnd:
+          type: boolean
+
+    GatewayAvailabilityIngestionCoverage:
+      type: object
+      description: Durable ingestion coverage proof for the requested gateway lookback window.
+      required:
+        - coverageStart
+        - processedThrough
+        - allowedIngestionDelaySeconds
+        - ingestionGapKnown
+        - proofSource
+      properties:
+        coverageStart:
+          type: string
+          format: date-time
+          nullable: true
+          description: ISO timestamp of earliest durable availability coverage; null when coverage is none.
+        processedThrough:
+          type: string
+          format: date-time
+          nullable: true
+          description: ISO timestamp through which availability ingestion is complete; null when coverage is none.
+        allowedIngestionDelaySeconds:
+          type: integer
+          minimum: 0
+          description: Allowed ingestion delay window in seconds.
+        ingestionGapKnown:
+          type: boolean
+          description: True when a known ingestion gap overlaps the requested window.
+        proofSource:
+          type: string
+          description: Proof source mechanism for availability coverage.
+
+    GatewayAvailabilityMeta:
+      type: object
+      description: Metadata proving availability coverage, accuracy, and window boundaries.
+      required:
+        - requestedWindow
+        - observedWindow
+        - sourceWindow
+        - contributingWindow
+        - selection
+        - coverage
+        - accuracy
+        - sampleCount
+        - offlineEventCount
+        - effectiveSamplingIntervalSeconds
+        - allowedGapSeconds
+        - boundarySamplesUsed
+        - availabilityCoverage
+      properties:
+        requestedWindow:
+          $ref: '#/components/schemas/RequestedTimeWindow'
+        observedWindow:
+          $ref: '#/components/schemas/GatewayAvailabilitySampleWindow'
+        sourceWindow:
+          $ref: '#/components/schemas/GatewayAvailabilitySampleWindow'
+        contributingWindow:
+          $ref: '#/components/schemas/GatewayAvailabilitySampleWindow'
+        selection:
+          type: string
+          enum:
+            - boundary_assisted
+          description: Boundary event selection strategy; always "boundary_assisted".
+          example: boundary_assisted
+        coverage:
+          type: string
+          enum:
+            - full
+            - partial
+            - none
+          description: full when durable ingestion coverage proves the complete interval; partial when coverage is incomplete; none when no coverage proof exists.
+        accuracy:
+          type: string
+          enum:
+            - exact
+            - lower_bound
+            - not_applicable
+          description: exact when coverage is full and complete; lower_bound when coverage is partial; not_applicable when coverage is none.
+        sampleCount:
+          type: integer
+          minimum: 0
+          nullable: true
+          description: Number of offline transition rows contributing to offline_count; null when coverage is none.
+        offlineEventCount:
+          type: integer
+          minimum: 0
+          nullable: true
+          description: Alias for sampleCount; null when coverage is none.
+        effectiveSamplingIntervalSeconds:
+          type: integer
+          minimum: 0
+        allowedGapSeconds:
+          type: integer
+          minimum: 0
+        boundarySamplesUsed:
+          $ref: '#/components/schemas/GatewayAvailabilityBoundarySamplesUsed'
+        availabilityCoverage:
+          $ref: '#/components/schemas/GatewayAvailabilityIngestionCoverage'
+
+    GatewayAvailabilityData:
+      type: object
+      description: Gateway availability state summary data.
       required:
         - gw_uuid
+        - fetch_status
         - offline_count
       properties:
         gw_uuid:
           $ref: '#/components/schemas/RouterId'
+        fetch_status:
+          type: string
+          enum:
+            - success
+          description: Status string for availability data retrieval; always "success" in HTTP 200 responses.
+          example: success
         offline_count:
           type: integer
           format: int64
           minimum: 0
-          description: Number of online-to-offline transitions in the requested half-open interval.
+          nullable: true
+          description: >
+            Number of online-to-offline transitions in the requested half-open interval.
+            Non-negative integer when coverage is "full" or "partial"; null when coverage is
+            "none" and accuracy is "not_applicable".
+
+    GatewayAvailabilitySummaryResponse:
+      type: object
+      description: >
+        Wrapped gateway availability summary response containing meta and data. Transition state
+        is determined using the restart-safe device_availability_state table, while
+        device_availability_events stores the counted transition history. The meta object
+        provides proof of coverage, accuracy, and boundary metadata. When coverage is "none"
+        and accuracy is "not_applicable", sampleCount, offlineEventCount, and offline_count
+        are all null.
+      required:
+        - meta
+        - data
+      properties:
+        meta:
+          $ref: '#/components/schemas/GatewayAvailabilityMeta'
+        data:
+          $ref: '#/components/schemas/GatewayAvailabilityData'
 
     SystemCommandDetails:
       type: object
@@ -2120,11 +2277,11 @@ paths:
         - $ref: '#/components/parameters/LookbackHours'
       responses:
         200:
-          description: Return gateway offline transition count.
+          description: Return wrapped gateway availability summary response with coverage proof and transition count.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GatewayOfflineSummary'
+                $ref: '#/components/schemas/GatewayAvailabilitySummaryResponse'
         400:
           $ref: '#/components/responses/AvailabilityAnalyticsBadRequest'
         401:

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -816,6 +816,31 @@ components:
           type: integer
           format: int64
 
+    DeviceResourceTimePoint:
+      type: object
+      description: Stored device resource telemetry including memory metrics.
+      properties:
+        memory_free:
+          type: integer
+          format: int64
+          nullable: true
+          description: Available free memory in bytes.
+        memory_total:
+          type: integer
+          format: int64
+          nullable: true
+          description: Total system memory in bytes.
+        memory_cached:
+          type: integer
+          format: int64
+          nullable: true
+          description: Cached memory in bytes.
+        memory_buffered:
+          type: integer
+          format: int64
+          nullable: true
+          description: Buffered memory in bytes.
+
     RadioTimePoint:
       type: object
       properties:
@@ -846,6 +871,11 @@ components:
         temperature:
           type: integer
           format: int64
+          description: Legacy alias for wifi_temp; Wi-Fi radio temperature in degrees Celsius.
+        wifi_temp:
+          type: integer
+          format: int64
+          description: Wi-Fi radio temperature in degrees Celsius.
         noise:
           type: integer
           format: int64
@@ -884,6 +914,8 @@ components:
             $ref: '#/components/schemas/RadioTimePoint'
         device_info:
           $ref: '#/components/schemas/DeviceInfo'
+        resource_data:
+          $ref: '#/components/schemas/DeviceResourceTimePoint'
 
     DeviceTimePointAnalysis:
       type: object
@@ -1643,7 +1675,7 @@ components:
 
     GatewayAvailabilitySampleWindow:
       type: object
-      description: Sample window boundary timestamps for availability metadata.
+      description: Sample window boundary timestamps for availability metadata. For sourceWindow, firstSampleAt maps to coverageStart (or stateKnownFrom) and lastSampleAt maps to processedThrough deterministically from checkpoint coverage.
       required:
         - firstSampleAt
         - lastSampleAt
@@ -1652,12 +1684,12 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: ISO timestamp of earliest contributing sample in window.
+          description: ISO timestamp of earliest contributing sample or checkpoint coverage start.
         lastSampleAt:
           type: string
           format: date-time
           nullable: true
-          description: ISO timestamp of latest contributing sample in window.
+          description: ISO timestamp of latest contributing sample or checkpoint processedThrough watermark.
 
     GatewayAvailabilityBoundarySamplesUsed:
       type: object
@@ -1682,6 +1714,7 @@ components:
       description: Durable ingestion coverage proof for the requested gateway lookback window. Full coverage requires coverageStart <= startTime, stateKnownFrom <= startTime, processedThrough >= endTime, and ingestionGapKnown == false.
       required:
         - coverageStart
+        - stateKnownFrom
         - processedThrough
         - allowedIngestionDelaySeconds
         - ingestionGapKnown

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -1869,11 +1869,20 @@ components:
                   type: string
                   enum:
                     - exact
+                sampleCount:
+                  type: integer
+                  minimum: 0
+                  nullable: false
+                offlineEventCount:
+                  type: integer
+                  minimum: 0
+                  nullable: false
             data:
               properties:
                 offline_count:
                   type: integer
                   minimum: 0
+                  nullable: false
         - description: Partial coverage lower_bound state
           properties:
             meta:
@@ -1886,11 +1895,20 @@ components:
                   type: string
                   enum:
                     - lower_bound
+                sampleCount:
+                  type: integer
+                  minimum: 0
+                  nullable: false
+                offlineEventCount:
+                  type: integer
+                  minimum: 0
+                  nullable: false
             data:
               properties:
                 offline_count:
                   type: integer
                   minimum: 0
+                  nullable: false
         - description: No coverage unavailable state
           properties:
             meta:
@@ -1903,10 +1921,20 @@ components:
                   type: string
                   enum:
                     - not_applicable
+                sampleCount:
+                  nullable: true
+                  enum:
+                    - null
+                offlineEventCount:
+                  nullable: true
+                  enum:
+                    - null
             data:
               properties:
                 offline_count:
                   nullable: true
+                  enum:
+                    - null
 
     SystemCommandDetails:
       type: object

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: OpenWiFi Analytics Service
   description: Definitions and APIs to analyze OpenWiFi network.
-  version: 2.6.0
+  version: 2.7.0
   license:
     name: BSD3
     url: https://github.com/routerarchitects/ra-wlan-cloud-analytics/blob/main/LICENSE
@@ -34,8 +34,396 @@ components:
       $ref: 'https://raw.githubusercontent.com/routerarchitects/ra-wlan-cloud-ucentralsec/main/openapi/owsec.yaml#/components/responses/Success'
     BadRequest:
       $ref: 'https://raw.githubusercontent.com/routerarchitects/ra-wlan-cloud-ucentralsec/main/openapi/owsec.yaml#/components/responses/BadRequest'
+    CommonAnalyticsBadRequest:
+      description: Invalid analytics request parameters.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CommonAnalyticsBadRequestError'
+          examples:
+            invalidRouterId:
+              value:
+                error: invalid_router_id
+                message: routerId must be a 12 to 29 character hexadecimal OWPROV gateway serial number
+            invalidTimestamp:
+              value:
+                error: invalid_timestamp
+                message: timestampTill must be a valid UTC timestamp in YYYY-MM-DDTHH:mm:ssZ format
+            invalidLookbackHours:
+              value:
+                error: invalid_lookback_hours
+                message: lookbackHours must be greater than 0 and within the configured monitoring retention
+            lookbackOutsideRetention:
+              value:
+                error: lookback_outside_retention
+                message: Requested range is outside the configured monitoring retention window
+    AvailabilityAnalyticsBadRequest:
+      description: Invalid request or availability range before the supported cutover.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AvailabilityBadRequestError'
+          examples:
+            invalidRouterId:
+              value:
+                error: invalid_router_id
+                message: routerId must be a 12 to 29 character hexadecimal OWPROV gateway serial number
+            invalidTimestamp:
+              value:
+                error: invalid_timestamp
+                message: timestampTill must be a valid UTC timestamp in YYYY-MM-DDTHH:mm:ssZ format
+            invalidLookbackHours:
+              value:
+                error: invalid_lookback_hours
+                message: lookbackHours must be greater than 0 and within the configured monitoring retention
+            lookbackOutsideRetention:
+              value:
+                error: lookback_outside_retention
+                message: Requested range is outside the configured monitoring retention window
+            availabilityBeforeCutover:
+              value:
+                error: availability_range_before_cutover
+                message: Availability history is only available for ranges starting at or after availabilityValidFrom
+    AnalyticsUnauthorized:
+      description: Bearer token is missing, invalid, or expired.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AnalyticsUnauthorizedError'
+          examples:
+            unauthorized:
+              value:
+                error: unauthorized
+                message: Missing, invalid, or expired bearer token
+    AnalyticsNotFound:
+      description: Router was not found, caller cannot access it, or monitoring is not configured for the resolved router scope. Public 404 responses for inventory missing, empty venue, board not configured, and access denied are intentionally collapsed to not_found unless monitoring is not configured.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AnalyticsNotFoundError'
+          examples:
+            notFound:
+              value:
+                error: not_found
+                message: Router was not found
+            monitoringNotConfigured:
+              value:
+                error: monitoring_not_configured
+                message: Monitoring is not configured for this router scope
+    AnalyticsConflict:
+      description: Monitoring is disabled or router ownership resolution found conflicting current board mappings.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AnalyticsConflictError'
+          examples:
+            monitoringDisabled:
+              value:
+                error: monitoring_disabled
+                message: Monitoring is disabled for this router scope
+            multipleBoards:
+              value:
+                error: multiple_boards
+                message: Router is mapped to multiple current boards
+    MemorySummaryInternalError:
+      description: Memory summary retrieval failed.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MemorySummaryInternalError'
+          examples:
+            memorySummaryFailed:
+              value:
+                error: memory_summary_query_failed
+                message: Unable to retrieve gateway memory history
+            internalError:
+              value:
+                error: internal_error
+                message: Internal error
+    RadioTemperatureSummaryInternalError:
+      description: Radio temperature summary retrieval failed.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RadioTemperatureSummaryInternalError'
+          examples:
+            radioTemperatureSummaryFailed:
+              value:
+                error: radio_temperature_summary_query_failed
+                message: Unable to retrieve gateway radio temperature history
+            internalError:
+              value:
+                error: internal_error
+                message: Internal error
+    WifiClientUsageInternalError:
+      description: Wi-Fi client usage summary retrieval failed.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/WifiClientUsageInternalError'
+          examples:
+            wifiClientUsageFailed:
+              value:
+                error: wifi_client_usage_query_failed
+                message: Unable to retrieve Wi-Fi client usage history
+            internalError:
+              value:
+                error: internal_error
+                message: Internal error
+    WifiClientRssiInternalError:
+      description: Wi-Fi client RSSI summary retrieval failed.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/WifiClientRssiInternalError'
+          examples:
+            wifiClientRssiFailed:
+              value:
+                error: wifi_client_rssi_query_failed
+                message: Unable to retrieve Wi-Fi client RSSI history
+            internalError:
+              value:
+                error: internal_error
+                message: Internal error
+    AvailabilityInternalError:
+      description: Availability summary retrieval failed.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AvailabilityInternalError'
+          examples:
+            availabilityQueryFailed:
+              value:
+                error: availability_query_failed
+                message: Unable to retrieve gateway availability history
+            internalError:
+              value:
+                error: internal_error
+                message: Internal error
+    AnalyticsBadGateway:
+      description: Upstream provisioning service is unavailable or returned an invalid response after cache fallback was exhausted.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AnalyticsBadGatewayError'
+          examples:
+            owprovUnavailable:
+              value:
+                error: owprov_unavailable
+                message: Upstream provisioning service is unavailable
+            owprovInvalidResponse:
+              value:
+                error: owprov_invalid_response
+                message: Upstream provisioning service returned an invalid response
 
+  parameters:
+    RouterIdPath:
+      in: path
+      name: routerId
+      required: true
+      description: Gateway serial number accepted by OWPROV inventory. Current supported router IDs are hexadecimal serial numbers such as dc6279652334; values containing path dot-segments, separators, UUID punctuation, or other non-hex characters are rejected before OWPROV ownership resolution.
+      schema:
+        $ref: '#/components/schemas/RouterId'
+    TimestampTill:
+      in: query
+      name: timestampTill
+      description: Exclusive UTC upper bound for the summary window. The value must match YYYY-MM-DDTHH:mm:ssZ, must be semantically parsed as a real date-time, and must reject invalid dates or times such as 2026-99-99T88:77:66Z. Fractional seconds and timezone offsets such as +05:30 are invalid.
+      schema:
+        $ref: '#/components/schemas/TimestampTill'
+      required: true
+    LookbackHours:
+      in: query
+      name: lookbackHours
+      description: Number of hours to look back from timestampTill. Must be greater than 0 and less than or equal to maxLookbackHours, where maxLookbackHours is derived from the configured monitoringDuration; the resulting half-open range must fit inside the configured retention window.
+      schema:
+        type: integer
+        format: int32
+        minimum: 1
+        example: 24
+      required: true
+    IncludeCalculationDetails:
+      in: query
+      name: includeCalculationDetails
+      description: >
+        Include per-segment usage calculation provenance in the response. Defaults to false.
+        When false or omitted, usage-summary returns concise per-client calculation quality
+        metadata only. When true, each returned client also includes calculation_segments for
+        diagnostics and troubleshooting.
+      schema:
+        type: boolean
+        default: false
+      required: false
   schemas:
+    RouterId:
+      type: string
+      minLength: 12
+      maxLength: 29
+      pattern: '^[A-Fa-f0-9]+$'
+      example: "dc6279652334"
+
+    TimestampTill:
+      type: string
+      format: date-time
+      pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$'
+      example: "2026-07-27T12:00:00Z"
+
+    RequestedTimeWindow:
+      type: object
+      required:
+        - startTime
+        - endTime
+      properties:
+        startTime:
+          type: string
+          format: date-time
+        endTime:
+          type: string
+          format: date-time
+
+    DifferentialResultTimeWindow:
+      type: object
+      description: >
+        Aggregate response envelope for usage differential calculations. earliestActualStartTime
+        is the minimum actual start timestamp among the server's internal calculable segments
+        contributing to returned clients. latestActualEndTime is the maximum actual end timestamp
+        among the server's internal calculable segments contributing to returned clients.
+        boundaryFallbackUsed is true when any internal calculable segment contributing to returned
+        clients used a fallback boundary. These values are identical whether or not
+        includeCalculationDetails is enabled. This describes the overall result envelope only; it
+        does not mean every client or segment used the entire envelope. When no returned client has
+        a calculable segment, earliestActualStartTime and latestActualEndTime are null and
+        boundaryFallbackUsed is false.
+      required:
+        - earliestActualStartTime
+        - latestActualEndTime
+        - boundaryFallbackUsed
+      properties:
+        earliestActualStartTime:
+          type: string
+          format: date-time
+          nullable: true
+        latestActualEndTime:
+          type: string
+          format: date-time
+          nullable: true
+        boundaryFallbackUsed:
+          type: boolean
+
+    SampleResultTimeWindow:
+      type: object
+      description: >
+        Aggregate response envelope for sample-based summaries. firstSampleTime and lastSampleTime
+        are calculated from valid samples contributing to the returned response items after any
+        response item limit is applied. They are null when no valid samples are used, and
+        totalSamples is 0.
+      required:
+        - firstSampleTime
+        - lastSampleTime
+        - totalSamples
+      properties:
+        firstSampleTime:
+          type: string
+          format: date-time
+          nullable: true
+        lastSampleTime:
+          type: string
+          format: date-time
+          nullable: true
+        totalSamples:
+          type: integer
+          minimum: 0
+
+    UsageCalculationSegment:
+      type: object
+      description: >
+        Per-segment calculation metadata for one cumulative counter segment that contributes to a
+        client MAC total. stream_id is an opaque identifier for the logical counter stream.
+        segment_id is an opaque identifier for a specific calculated segment within that stream,
+        such as a proven session or reset-bounded interval. Clients must not parse these
+        identifiers or depend on their format. effective_start_time and effective_end_time are the segment's overlap with the requested
+        interval after applying proven session start/end evidence. actual_start_time and
+        actual_end_time are the sample timestamps used for this segment differential.
+        boundary_fallback_used is true when either actual timestamp differs from the effective
+        boundary. accuracy describes this segment contribution before client aggregation.
+      required:
+        - stream_id
+        - segment_id
+        - segment_start_reason
+        - segment_end_reason
+        - effective_start_time
+        - effective_end_time
+        - actual_start_time
+        - actual_end_time
+        - boundary_fallback_used
+        - accuracy
+        - rx_bytes
+        - tx_bytes
+        - total_bytes
+      properties:
+        stream_id:
+          type: string
+          description: Opaque identifier scoped to this response. Clients must not persist it, compare it across requests, parse it, or depend on its format.
+        segment_id:
+          type: string
+          description: Opaque identifier scoped to this response. Clients must not persist it, compare it across requests, parse it, or depend on its format.
+        segment_start_reason:
+          type: string
+          enum:
+            - window_start
+            - session_start
+            - reset_start
+            - first_observed_sample
+        segment_end_reason:
+          type: string
+          enum:
+            - window_end
+            - session_end
+            - reset_end
+            - last_observed_sample
+        effective_start_time:
+          type: string
+          format: date-time
+          description: max(response.requestedTimeWindow.startTime, proven segment/session start).
+        effective_end_time:
+          type: string
+          format: date-time
+          description: min(response.requestedTimeWindow.endTime, proven segment/session end).
+        actual_start_time:
+          type: string
+          format: date-time
+        actual_end_time:
+          type: string
+          format: date-time
+        boundary_fallback_used:
+          type: boolean
+        accuracy:
+          type: string
+          enum:
+            - exact
+            - bounded_interval
+            - lower_bound
+        rx_bytes:
+          type: integer
+          format: int64
+          minimum: 0
+          description: RX bytes contributed by this segment.
+        tx_bytes:
+          type: integer
+          format: int64
+          minimum: 0
+          description: TX bytes contributed by this segment.
+        total_bytes:
+          type: integer
+          format: int64
+          minimum: 0
+          description: rx_bytes + tx_bytes for this segment.
+
+    MacAddress:
+      type: string
+      pattern: '^[0-9a-f]{2}(:[0-9a-f]{2}){5}$'
+      description: Canonical lowercase colon-separated MAC address.
+      example: "e2:51:95:ed:0f:28"
+
     ObjectInfo:
       type: object
       properties:
@@ -689,6 +1077,547 @@ components:
           items:
             $ref: '#/components/schemas/TagIntPair'
 
+    CommonAnalyticsBadRequestError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          enum:
+            - invalid_router_id
+            - invalid_timestamp
+            - invalid_lookback_hours
+            - lookback_outside_retention
+        message:
+          type: string
+
+    AvailabilityBadRequestError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          enum:
+            - invalid_router_id
+            - invalid_timestamp
+            - invalid_lookback_hours
+            - lookback_outside_retention
+            - availability_range_before_cutover
+        message:
+          type: string
+
+    AnalyticsUnauthorizedError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          enum:
+            - unauthorized
+        message:
+          type: string
+
+    AnalyticsNotFoundError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          enum:
+            - not_found
+            - monitoring_not_configured
+        message:
+          type: string
+
+    AnalyticsConflictError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          enum:
+            - monitoring_disabled
+            - multiple_boards
+        message:
+          type: string
+
+    AnalyticsBadGatewayError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          enum:
+            - owprov_unavailable
+            - owprov_invalid_response
+        message:
+          type: string
+
+    MemorySummaryInternalError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          enum:
+            - memory_summary_query_failed
+            - internal_error
+        message:
+          type: string
+
+    RadioTemperatureSummaryInternalError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          enum:
+            - radio_temperature_summary_query_failed
+            - internal_error
+        message:
+          type: string
+
+    WifiClientUsageInternalError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          enum:
+            - wifi_client_usage_query_failed
+            - internal_error
+        message:
+          type: string
+
+    WifiClientRssiInternalError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          enum:
+            - wifi_client_rssi_query_failed
+            - internal_error
+        message:
+          type: string
+
+    AvailabilityInternalError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          enum:
+            - availability_query_failed
+            - internal_error
+        message:
+          type: string
+
+    GatewayMemorySummary:
+      type: object
+      description: >
+        Gateway free memory summary in bytes. Memory statistics are arithmetic aggregations of
+        stored memory_free samples whose timestamps fall within the requested half-open window.
+        They are not time-weighted. When samples exist, all values are nonnegative and satisfy
+        min_memfree <= avg_memfree <= max_memfree. When no valid memory samples exist, all three
+        fields are null.
+      required:
+        - min_memfree
+        - max_memfree
+        - avg_memfree
+      properties:
+        min_memfree:
+          type: integer
+          format: int64
+          minimum: 0
+          nullable: true
+          description: Minimum reported free memory in bytes for the requested aggregation window.
+        max_memfree:
+          type: integer
+          format: int64
+          minimum: 0
+          nullable: true
+          description: Maximum reported free memory in bytes for the requested aggregation window.
+        avg_memfree:
+          type: number
+          format: double
+          minimum: 0
+          nullable: true
+          description: Arithmetic average of reported free-memory samples in bytes for the requested aggregation window.
+
+    GatewayWifiTemperatureSummary:
+      type: object
+      description: >
+        Wi-Fi radio temperature summary. The 2.4 GHz JSON property names intentionally use
+        the dotted `2.4G` suffix to match the MCP API wire contract; clients should treat
+        these as literal JSON keys, not property paths. Temperature statistics are arithmetic
+        aggregations of valid radio temperature samples whose timestamps fall within the
+        requested half-open window. They are not time-weighted. For gateways with multiple
+        radios in the same band, all valid samples for that band are combined directly rather
+        than averaging each radio first. Null applies independently per band: a band returns
+        null min, max, and average values when that band has no valid temperature samples,
+        even if another band has samples. A valid radio temperature sample is a present,
+        finite Celsius value where -40 <= temperature <= 125, excluding 0 because current
+        telemetry uses it as a missing-sensor sentinel. Missing, null, non-numeric, NaN,
+        infinite, 0, 255, and out-of-range values are excluded from aggregation.
+      required:
+        - min_wifi_temp_2.4G
+        - max_wifi_temp_2.4G
+        - avg_wifi_temp_2.4G
+        - min_wifi_temp_5G
+        - max_wifi_temp_5G
+        - avg_wifi_temp_5G
+      properties:
+        min_wifi_temp_2.4G:
+          type: number
+          format: double
+          minimum: -40
+          maximum: 125
+          nullable: true
+          description: Minimum reported 2.4 GHz Wi-Fi radio temperature in degrees Celsius for the effective aggregation window. Literal MCP JSON key; dotted suffix is required for compatibility.
+        max_wifi_temp_2.4G:
+          type: number
+          format: double
+          minimum: -40
+          maximum: 125
+          nullable: true
+          description: Maximum reported 2.4 GHz Wi-Fi radio temperature in degrees Celsius for the effective aggregation window. Literal MCP JSON key; dotted suffix is required for compatibility.
+        avg_wifi_temp_2.4G:
+          type: number
+          format: double
+          minimum: -40
+          maximum: 125
+          nullable: true
+          description: Arithmetic average of reported 2.4 GHz Wi-Fi radio temperature samples in degrees Celsius for the effective aggregation window. Literal MCP JSON key; dotted suffix is required for compatibility.
+        min_wifi_temp_5G:
+          type: number
+          format: double
+          minimum: -40
+          maximum: 125
+          nullable: true
+          description: Minimum reported 5 GHz Wi-Fi radio temperature in degrees Celsius for the effective aggregation window.
+        max_wifi_temp_5G:
+          type: number
+          format: double
+          minimum: -40
+          maximum: 125
+          nullable: true
+          description: Maximum reported 5 GHz Wi-Fi radio temperature in degrees Celsius for the effective aggregation window.
+        avg_wifi_temp_5G:
+          type: number
+          format: double
+          minimum: -40
+          maximum: 125
+          nullable: true
+          description: Arithmetic average of reported 5 GHz Wi-Fi radio temperature samples in degrees Celsius for the effective aggregation window.
+
+    ClientBandwidthConsumption:
+      type: object
+      description: >
+        Per-client usage totals. Raw byte counters are authoritative; total_bytes is always
+        rx_bytes + tx_bytes. Formatted string fields are display-only decimal megabytes using
+        bytes / 1,000,000, formatted with exactly two decimal places using round-half-up
+        rounding, followed by the literal " MB" suffix. Wi-Fi usage is a cumulative-counter
+        differential summary. For an uninterrupted stream, delta = ending counter value - starting
+        counter value. For confirmed independent session splits or resets, calculate each proven
+        stream segment separately and sum the segment differentials; do not sum raw cumulative
+        counter values. Accuracy is evaluated against each segment's overlap with the requested
+        interval: effective_start = max(windowStart, proven_session_start) and effective_end =
+        min(timestampTill, proven_session_end). Exact calculation requires authoritative counter
+        evidence at both effective boundaries for each contributing calculation segment. When
+        exact effective-boundary samples are unavailable, the starting sample is the latest
+        available sample at or before effective_start and the ending sample is the earliest
+        available sample at or after effective_end. Fallback boundary samples are usable only when
+        each is within two times the configured telemetry sampling interval from its effective
+        boundary. requestedTimeWindow reports the client-requested boundaries, and concise summary
+        metadata reports the aggregate calculation quality without exposing segment-level
+        provenance in the default response.
+        Intermediate samples are used to detect resets, rollovers, duplicate or out-of-order
+        telemetry, session changes, and missing-sample gaps; proven segment deltas may be summed,
+        but raw cumulative values are never summed as usage. bounded_interval means the value is
+        calculated over an interval containing the segment's effective overlap with the requested
+        interval; when counters are monotonic and uninterrupted, the value is greater than or equal
+        to usage in that effective overlap.
+        If the boundary tolerance is exceeded, no usable bounding sample pair exists, or resets or
+        stream/session changes prevent that guarantee, the direction contributes the sum of safely
+        provable nonnegative segment deltas and the client usage is lower_bound. A fixed-width
+        rollover may remain exact or bounded_interval only when the counter width is known and the
+        maximum possible counter increase during the observation gap cannot exceed one full counter
+        range; otherwise classify the stream as lower_bound. The expected collection interval is
+        the configured telemetry sampling interval for the resolved router scope; if it cannot be
+        resolved reliably, fallback boundary samples cannot qualify as bounded_interval and exact
+        boundary samples are required to avoid lower_bound.
+      required:
+        - mac
+        - rx_bytes
+        - tx_bytes
+        - total_bytes
+        - data_consume_rx
+        - data_consume_tx
+        - total_data_usage
+        - usage_accuracy
+        - incomplete
+        - segment_count
+        - boundary_fallback_used
+      properties:
+        mac:
+          $ref: '#/components/schemas/MacAddress'
+        rx_bytes:
+          type: integer
+          format: int64
+          minimum: 0
+        tx_bytes:
+          type: integer
+          format: int64
+          minimum: 0
+        total_bytes:
+          type: integer
+          format: int64
+          minimum: 0
+        data_consume_rx:
+          type: string
+          description: Display-only decimal megabytes derived from rx_bytes / 1,000,000. Format using exactly two decimal places, round-half-up rounding, and the literal " MB" suffix. Use raw byte fields for calculations.
+          example: 106.49 MB
+        data_consume_tx:
+          type: string
+          description: Display-only decimal megabytes derived from tx_bytes / 1,000,000. Format using exactly two decimal places, round-half-up rounding, and the literal " MB" suffix. Use raw byte fields for calculations.
+          example: 3.85 MB
+        total_data_usage:
+          type: string
+          description: Display-only decimal megabytes derived from total_bytes / 1,000,000. Format using exactly two decimal places, round-half-up rounding, and the literal " MB" suffix. Use raw byte fields for calculations.
+          example: 110.34 MB
+        usage_accuracy:
+          type: string
+          enum:
+            - exact
+            - bounded_interval
+            - lower_bound
+          description: >
+            exact when each segment's overlap with the requested interval can be calculated from
+            authoritative counter evidence exactly at effective_start and effective_end, without
+            counter resets or missing-sample gaps. bounded_interval when one or both exact boundary samples are
+            unavailable and the calculation uses the latest available starting sample at or before
+            effective_start and the earliest available ending sample at or after effective_end, with
+            both fallback samples within two times the configured telemetry sampling interval of
+            the effective boundaries. lower_bound when no usable boundary pair exists, when either fallback
+            boundary exceeds the tolerance, when any ambiguous counter reset/session change is
+            detected, or when gaps larger than two times the configured telemetry sampling
+            interval prevent a complete differential from being calculated. When a client was
+            observed but no usage differential segment can be calculated, return zero byte totals,
+            usage_accuracy lower_bound, incomplete true, segment_count 0, and
+            boundary_fallback_used false.
+        incomplete:
+          type: boolean
+          description: True exactly when usage_accuracy is lower_bound; otherwise false.
+        segment_count:
+          type: integer
+          minimum: 0
+          description: >
+            Number of calculable differential segments contributing to this client total. This is
+            0 when the client has qualifying observations but no usable counter interval from
+            which a differential segment can be calculated.
+        boundary_fallback_used:
+          type: boolean
+          description: >
+            True when at least one calculable segment contributing to this client used a fallback
+            boundary sample; false when no contributing segment used fallback boundaries or when
+            segment_count is 0.
+        calculation_segments:
+          type: array
+          description: >
+            Optional diagnostic per-segment calculation metadata. This property is absent when
+            includeCalculationDetails is false or omitted, and is present for every returned client
+            when includeCalculationDetails=true. The array is intended for diagnostics,
+            troubleshooting, and calculation provenance, not ordinary MCP decisions. Client rx_bytes
+            equals the sum of calculation_segments[].rx_bytes, client tx_bytes equals the sum of
+            calculation_segments[].tx_bytes, client total_bytes equals the sum of
+            calculation_segments[].total_bytes, segment_count equals calculation_segments.length,
+            and boundary_fallback_used is true when any segment has boundary_fallback_used=true.
+            This array is empty when the client has qualifying observations but no usable counter
+            interval from which a differential segment can be calculated; in that case rx_bytes,
+            tx_bytes, and total_bytes are 0, usage_accuracy is lower_bound, incomplete is true,
+            segment_count is 0, and boundary_fallback_used is false.
+          items:
+            $ref: '#/components/schemas/UsageCalculationSegment'
+
+    ClientBandwidthConsumptionResponse:
+      type: object
+      description: >
+        Wrapped Wi-Fi usage differential summary. requestedTimeWindow is always the requested
+        interval. resultTimeWindow summarizes the server's internal calculable segment envelope
+        across returned clients and is identical whether or not includeCalculationDetails is
+        enabled. The default response omits calculation_segments and returns concise
+        segment_count and boundary_fallback_used metadata for each client. When
+        includeCalculationDetails=true, calculation_segments is present on every returned client.
+        When no clients are returned, items is empty, totalClients is 0, truncated is false,
+        resultTimeWindow.earliestActualStartTime and resultTimeWindow.latestActualEndTime are null,
+        and resultTimeWindow.boundaryFallbackUsed is false. The same null resultTimeWindow
+        timestamp behavior applies when returned clients have no calculable segments.
+      required:
+        - requestedTimeWindow
+        - resultTimeWindow
+        - items
+        - totalClients
+        - truncated
+      properties:
+        requestedTimeWindow:
+          $ref: '#/components/schemas/RequestedTimeWindow'
+        resultTimeWindow:
+          $ref: '#/components/schemas/DifferentialResultTimeWindow'
+        items:
+          type: array
+          maxItems: 500
+          description: >
+            Clients ordered by total_bytes descending. Clients with equal
+            total_bytes are ordered by normalized MAC address ascending.
+            Only the first 500 clients are returned.
+          items:
+            $ref: '#/components/schemas/ClientBandwidthConsumption'
+        totalClients:
+          type: integer
+          minimum: 0
+          description: Total number of distinct client MAC addresses having at least one qualifying usage sample in or bounding the requested interval, calculated before applying the 500-client limit. A qualifying usage sample has a canonical client MAC address and nonnegative cumulative rx_bytes or tx_bytes counters. Exact usage requires authoritative counter evidence at each segment's effective boundaries; bounded_interval usage reports the actual bounding sample timestamps used.
+        truncated:
+          type: boolean
+          description: True when totalClients is greater than the number of returned items.
+
+    ClientRssiQuality:
+      type: object
+      description: >
+        Per-client RSSI quality percentages calculated from valid RSSI samples only. RSSI
+        categories use dBm thresholds: excellent is RSSI >= -55, good is -67 <= RSSI < -55,
+        fair is -75 <= RSSI < -67, and poor is RSSI < -75. RSSI values of 0, positive RSSI
+        values, values below -127, and missing RSSI values are excluded. Clients with no
+        valid RSSI samples are omitted. Percentages use valid samples as the denominator and
+        are independently rounded to two decimal places, so they may sum to slightly above
+        or below 100 because of rounding.
+      required:
+        - mac
+        - rssi_excellent_pct
+        - rssi_good_pct
+        - rssi_fair_pct
+        - rssi_poor_pct
+        - rssi_total_samples
+      properties:
+        mac:
+          $ref: '#/components/schemas/MacAddress'
+        rssi_excellent_pct:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 100
+          description: Percentage of valid RSSI samples where RSSI >= -55 dBm.
+        rssi_good_pct:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 100
+          description: Percentage of valid RSSI samples where -67 dBm <= RSSI < -55 dBm.
+        rssi_fair_pct:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 100
+          description: Percentage of valid RSSI samples where -75 dBm <= RSSI < -67 dBm.
+        rssi_poor_pct:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 100
+          description: Percentage of valid RSSI samples where -127 dBm <= RSSI < -75 dBm.
+        rssi_total_samples:
+          type: integer
+          format: int64
+          minimum: 1
+          description: Number of valid RSSI samples used as the denominator for the percentage fields.
+
+    ClientRssiQualityResponse:
+      type: object
+      description: >
+        Wrapped RSSI quality summary. requestedTimeWindow is always the requested interval.
+        resultTimeWindow summarizes valid RSSI samples contributing to the returned items after
+        applying the 500-client response limit. resultTimeWindow.firstSampleTime is the earliest
+        valid RSSI sample contributing to items[], resultTimeWindow.lastSampleTime is the latest
+        valid RSSI sample contributing to items[], and resultTimeWindow.totalSamples equals the sum
+        of items[].rssi_total_samples. When no clients are returned, items is empty, totalClients
+        is 0, truncated is false,
+        resultTimeWindow.firstSampleTime and resultTimeWindow.lastSampleTime are null, and
+        resultTimeWindow.totalSamples is 0.
+      required:
+        - requestedTimeWindow
+        - resultTimeWindow
+        - items
+        - totalClients
+        - truncated
+      properties:
+        requestedTimeWindow:
+          $ref: '#/components/schemas/RequestedTimeWindow'
+        resultTimeWindow:
+          $ref: '#/components/schemas/SampleResultTimeWindow'
+        items:
+          type: array
+          maxItems: 500
+          description: >
+            Clients ordered by normalized MAC address ascending.
+            Only the first 500 clients are returned.
+          items:
+            $ref: '#/components/schemas/ClientRssiQuality'
+        totalClients:
+          type: integer
+          minimum: 0
+          description: Total number of distinct client MAC addresses having at least one valid RSSI sample in the requested interval, calculated before applying the 500-client limit.
+        truncated:
+          type: boolean
+          description: True when totalClients is greater than the number of returned items.
+
+    GatewayOfflineSummary:
+      type: object
+      description: >
+        Gateway offline transition count. Count each transition from an online state to an
+        offline state whose offline event timestamp falls within [timestampTill - lookbackHours,
+        timestampTill). Repeated offline samples without an intervening online state are not
+        counted. The latest valid state before the start of the window is used to determine
+        whether the first in-window offline event is a transition. A gateway already offline
+        at the beginning of the requested window is not counted unless it transitions online
+        and then offline again within the window. Events exactly at timestampTill are excluded.
+        Unknown or missing states do not create offline transitions. Availability events do not
+        carry a separate staleness timeout; transition state is determined only from persisted
+        gateway availability events keyed by serial number. HTTP 200 represents successful
+        retrieval; no separate success status field is returned.
+      required:
+        - gw_uuid
+        - offline_count
+      properties:
+        gw_uuid:
+          $ref: '#/components/schemas/RouterId'
+        offline_count:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Number of online-to-offline transitions in the requested half-open interval.
+
     SystemCommandDetails:
       type: object
       properties:
@@ -1043,6 +1972,171 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         404:
           $ref: '#/components/responses/NotFound'
+
+  /devices/{routerId}/memory-summary:
+    get:
+      tags:
+        - Device Metrics
+      operationId: getGatewayMemorySummary
+      summary: Retrieve gateway free memory summary for a lookback window.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/RouterIdPath'
+        - $ref: '#/components/parameters/TimestampTill'
+        - $ref: '#/components/parameters/LookbackHours'
+      responses:
+        200:
+          description: Return gateway free memory summary for the requested aggregation window.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GatewayMemorySummary'
+        400:
+          $ref: '#/components/responses/CommonAnalyticsBadRequest'
+        401:
+          $ref: '#/components/responses/AnalyticsUnauthorized'
+        404:
+          $ref: '#/components/responses/AnalyticsNotFound'
+        409:
+          $ref: '#/components/responses/AnalyticsConflict'
+        500:
+          $ref: '#/components/responses/MemorySummaryInternalError'
+        502:
+          $ref: '#/components/responses/AnalyticsBadGateway'
+
+  /devices/{routerId}/radio-temperature-summary:
+    get:
+      tags:
+        - Device Metrics
+      operationId: getGatewayRadioTemperatureSummary
+      summary: Retrieve gateway Wi-Fi radio temperature summary for a lookback window.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/RouterIdPath'
+        - $ref: '#/components/parameters/TimestampTill'
+        - $ref: '#/components/parameters/LookbackHours'
+      responses:
+        200:
+          description: Return Wi-Fi radio temperature summary for the effective aggregation window.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GatewayWifiTemperatureSummary'
+        400:
+          $ref: '#/components/responses/CommonAnalyticsBadRequest'
+        401:
+          $ref: '#/components/responses/AnalyticsUnauthorized'
+        404:
+          $ref: '#/components/responses/AnalyticsNotFound'
+        409:
+          $ref: '#/components/responses/AnalyticsConflict'
+        500:
+          $ref: '#/components/responses/RadioTemperatureSummaryInternalError'
+        502:
+          $ref: '#/components/responses/AnalyticsBadGateway'
+
+  /devices/{routerId}/wifi-clients/usage-summary:
+    get:
+      tags:
+        - Device Metrics
+      operationId: getWifiClientUsageSummary
+      summary: Retrieve per-client Wi-Fi usage summary for a gateway lookback window.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/RouterIdPath'
+        - $ref: '#/components/parameters/TimestampTill'
+        - $ref: '#/components/parameters/LookbackHours'
+        - $ref: '#/components/parameters/IncludeCalculationDetails'
+      responses:
+        200:
+          description: >
+            Return reset-safe per-client Wi-Fi usage differential summaries. By default, each
+            client contains concise calculation quality metadata only. When
+            includeCalculationDetails=true, each client also includes diagnostic
+            calculation_segments. resultTimeWindow values are identical for both response shapes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientBandwidthConsumptionResponse'
+        400:
+          $ref: '#/components/responses/CommonAnalyticsBadRequest'
+        401:
+          $ref: '#/components/responses/AnalyticsUnauthorized'
+        404:
+          $ref: '#/components/responses/AnalyticsNotFound'
+        409:
+          $ref: '#/components/responses/AnalyticsConflict'
+        500:
+          $ref: '#/components/responses/WifiClientUsageInternalError'
+        502:
+          $ref: '#/components/responses/AnalyticsBadGateway'
+
+  /devices/{routerId}/wifi-clients/rssi-summary:
+    get:
+      tags:
+        - Device Metrics
+      operationId: getWifiClientRssiSummary
+      summary: Retrieve per-client RSSI quality summary for a gateway lookback window.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/RouterIdPath'
+        - $ref: '#/components/parameters/TimestampTill'
+        - $ref: '#/components/parameters/LookbackHours'
+      responses:
+        200:
+          description: Return per-client RSSI quality percentages.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientRssiQualityResponse'
+        400:
+          $ref: '#/components/responses/CommonAnalyticsBadRequest'
+        401:
+          $ref: '#/components/responses/AnalyticsUnauthorized'
+        404:
+          $ref: '#/components/responses/AnalyticsNotFound'
+        409:
+          $ref: '#/components/responses/AnalyticsConflict'
+        500:
+          $ref: '#/components/responses/WifiClientRssiInternalError'
+        502:
+          $ref: '#/components/responses/AnalyticsBadGateway'
+
+  /devices/{routerId}/availability-summary:
+    get:
+      tags:
+        - Device Metrics
+      operationId: getGatewayAvailabilitySummary
+      summary: Retrieve gateway offline transition count for a lookback window.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/RouterIdPath'
+        - $ref: '#/components/parameters/TimestampTill'
+        - $ref: '#/components/parameters/LookbackHours'
+      responses:
+        200:
+          description: Return gateway offline transition count.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GatewayOfflineSummary'
+        400:
+          $ref: '#/components/responses/AvailabilityAnalyticsBadRequest'
+        401:
+          $ref: '#/components/responses/AnalyticsUnauthorized'
+        404:
+          $ref: '#/components/responses/AnalyticsNotFound'
+        409:
+          $ref: '#/components/responses/AnalyticsConflict'
+        500:
+          $ref: '#/components/responses/AvailabilityInternalError'
+        502:
+          $ref: '#/components/responses/AnalyticsBadGateway'
 
   /board/{id}/timepoints:
     get:

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -44,7 +44,7 @@ components:
             invalidRouterId:
               value:
                 error: invalid_router_id
-                message: routerId must be a 12 to 29 character hexadecimal OWPROV gateway serial number
+                message: routerId must be a valid path-safe OWPROV gateway serial number (1 to 64 alphanumeric characters, hyphens, or underscores)
             invalidTimestamp:
               value:
                 error: invalid_timestamp
@@ -67,7 +67,7 @@ components:
             invalidRouterId:
               value:
                 error: invalid_router_id
-                message: routerId must be a 12 to 29 character hexadecimal OWPROV gateway serial number
+                message: routerId must be a valid path-safe OWPROV gateway serial number (1 to 64 alphanumeric characters, hyphens, or underscores)
             invalidTimestamp:
               value:
                 error: invalid_timestamp
@@ -94,7 +94,7 @@ components:
             invalidRouterId:
               value:
                 error: invalid_router_id
-                message: routerId must be a 12 to 29 character hexadecimal OWPROV gateway serial number
+                message: routerId must be a valid path-safe OWPROV gateway serial number (1 to 64 alphanumeric characters, hyphens, or underscores)
             invalidTimestamp:
               value:
                 error: invalid_timestamp
@@ -248,7 +248,7 @@ components:
       in: path
       name: routerId
       required: true
-      description: Gateway serial number accepted by OWPROV inventory. Current supported router IDs are hexadecimal serial numbers such as dc6279652334; values containing path dot-segments, separators, UUID punctuation, or other non-hex characters are rejected before OWPROV ownership resolution.
+      description: Gateway serial number accepted by OWPROV inventory. Path-safe serial identifiers (1 to 64 alphanumeric characters, hyphens, and underscores; free of path separators and dot-segments) are accepted by syntax validation and resolved via OWPROV. Values containing path dot-segments, path separators, or spaces are rejected before OWPROV ownership resolution.
       schema:
         $ref: '#/components/schemas/RouterId'
     TimestampTill:
@@ -288,9 +288,9 @@ components:
   schemas:
     RouterId:
       type: string
-      minLength: 12
-      maxLength: 29
-      pattern: '^[A-Fa-f0-9]+$'
+      minLength: 1
+      maxLength: 64
+      pattern: '^[a-zA-Z0-9_-]+$'
       example: "dc6279652334"
 
     TimestampTill:
@@ -1387,8 +1387,8 @@ components:
       description: >
         Per-client usage totals. Raw byte counters are authoritative; total_bytes is always
         rx_bytes + tx_bytes. Formatted string fields are display-only decimal megabytes using
-        bytes / 1,000,000, formatted with exactly two decimal places using round-half-up
-        rounding, followed by the literal " MB" suffix. Wi-Fi usage is a cumulative-counter
+        bytes / 1,000,000, formatted with standard floating point two decimal places
+        and the literal " MB" suffix. Wi-Fi usage is a cumulative-counter
         differential summary. For an uninterrupted stream, delta = ending counter value - starting
         counter value. For confirmed independent session splits or resets, calculate each proven
         stream segment separately and sum the segment differentials; do not sum raw cumulative
@@ -1447,15 +1447,15 @@ components:
           minimum: 0
         data_consume_rx:
           type: string
-          description: Display-only decimal megabytes derived from rx_bytes / 1,000,000. Format using exactly two decimal places, round-half-up rounding, and the literal " MB" suffix. Use raw byte fields for calculations.
+          description: Display-only decimal megabytes derived from rx_bytes / 1,000,000. Format using standard floating point two decimal places and the literal " MB" suffix. Use raw byte fields for calculations.
           example: 106.49 MB
         data_consume_tx:
           type: string
-          description: Display-only decimal megabytes derived from tx_bytes / 1,000,000. Format using exactly two decimal places, round-half-up rounding, and the literal " MB" suffix. Use raw byte fields for calculations.
+          description: Display-only decimal megabytes derived from tx_bytes / 1,000,000. Format using standard floating point two decimal places and the literal " MB" suffix. Use raw byte fields for calculations.
           example: 3.85 MB
         total_data_usage:
           type: string
-          description: Display-only decimal megabytes derived from total_bytes / 1,000,000. Format using exactly two decimal places, round-half-up rounding, and the literal " MB" suffix. Use raw byte fields for calculations.
+          description: Display-only decimal megabytes derived from total_bytes / 1,000,000. Format using standard floating point two decimal places and the literal " MB" suffix. Use raw byte fields for calculations.
           example: 110.34 MB
         usage_accuracy:
           type: string
@@ -1547,7 +1547,7 @@ components:
         totalClients:
           type: integer
           minimum: 0
-          description: Total number of distinct client MAC addresses having at least one qualifying usage sample in or bounding the requested interval, calculated before applying the 500-client limit. A qualifying usage sample has a canonical client MAC address and nonnegative cumulative rx_bytes or tx_bytes counters. Exact usage requires authoritative counter evidence at each segment's effective boundaries; bounded_interval usage reports the actual bounding sample timestamps used.
+          description: Total number of distinct client MAC addresses having at least one in-window observation or proven session overlap during the requested interval [startTime, endTime), calculated before applying the 500-client limit. Outside-window bounding samples are used solely for calculating boundary deltas of clients with proven in-window presence. Exact usage requires authoritative counter evidence at each segment's effective boundaries; bounded_interval usage reports the actual bounding sample timestamps used.
         truncated:
           type: boolean
           description: True when totalClients is greater than the number of returned items.

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -1856,6 +1856,45 @@ components:
           $ref: '#/components/schemas/GatewayAvailabilityMeta'
         data:
           $ref: '#/components/schemas/GatewayAvailabilityData'
+      oneOf:
+        - description: Full coverage exact state
+          properties:
+            meta:
+              properties:
+                coverage:
+                  const: full
+                accuracy:
+                  const: exact
+            data:
+              properties:
+                offline_count:
+                  type: integer
+                  minimum: 0
+        - description: Partial coverage lower_bound state
+          properties:
+            meta:
+              properties:
+                coverage:
+                  const: partial
+                accuracy:
+                  const: lower_bound
+            data:
+              properties:
+                offline_count:
+                  type: integer
+                  minimum: 0
+        - description: No coverage unavailable state
+          properties:
+            meta:
+              properties:
+                coverage:
+                  const: none
+                accuracy:
+                  const: not_applicable
+            data:
+              properties:
+                offline_count:
+                  type: null
 
     SystemCommandDetails:
       type: object


### PR DESCRIPTION
## Summary

This PR adds a comprehensive test specification for the Analytics MCP APIs in `ra-wlan-cloud-analytics`.

## Covered APIs

* `GET /api/v1/devices/{routerId}/memory-summary`
* `GET /api/v1/devices/{routerId}/radio-temperature-summary`
* `GET /api/v1/devices/{routerId}/wifi-clients/usage-summary`
* `GET /api/v1/devices/{routerId}/wifi-clients/rssi-summary`
* `GET /api/v1/devices/{routerId}/availability-summary`


