### PR TITLE
docs: MCP analytics API specifications

### DIFF
--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -9,14 +9,24 @@ This document defines the request format, response format, and implementation lo
 - `get_gateway_offline_count`
 
 The specification is structured across three distinct component layers:
-1. **Public API Contract Specifications**: External OpenAPI schemas (`openapi/owanalytics.yaml`) defining HTTP requests, parameter validation, and response envelopes.
+1. **MCP Analytics Behavior Specification**: Intended HTTP requests, parameter validation, response envelopes, and ownership/error semantics for future MCP-facing Analytics handlers.
 2. **Persistence & Pipeline Architecture Design**: Internal storage structures (`device_availability_events`, `device_availability_state`, `device_availability_ingestion_checkpoint`, `device_availability_ingestion_gaps`), Kafka event consumption/ordering, and cutover semantics.
 3. **Test Specifications Matrix**: Independent verification matrix documented in `analytics_mcp_api_test_cases.md`.
 
 > [!IMPORTANT]
-> The specified production architecture changes—including four new availability persistence structures (`device_availability_events`, `device_availability_state`, `device_availability_ingestion_checkpoint`, `device_availability_ingestion_gaps`), Kafka event ordering/checkpointing rules, cutover migration rules, and OpenAPI v2.7.0 endpoint schemas—constitute a production architecture specification. Approving or merging this test specification PR does NOT bypass separate explicit architecture design sign-off for backend schema additions and production Kafka pipeline changes prior to production deployment.
+> This PR does not update `openapi/owanalytics.yaml` and does not publish a
+> functional OpenAPI contract for these MCP analytics endpoints. The OpenAPI
+> contract/schema update is a follow-up deliverable. The specified production
+> architecture changes—including four new availability persistence structures
+> (`device_availability_events`, `device_availability_state`,
+> `device_availability_ingestion_checkpoint`,
+> `device_availability_ingestion_gaps`), Kafka event ordering/checkpointing
+> rules, and cutover migration rules—constitute a production architecture
+> specification. Approving or merging this test specification PR does NOT bypass
+> separate explicit architecture design sign-off for backend schema additions and
+> production Kafka pipeline changes prior to production deployment.
 
-The API contracts match the MCP tool names and response fields from the provided CSV.
+The intended API behavior matches the MCP tool names and response fields from the provided CSV.
 
 ---
 
@@ -2908,15 +2918,16 @@ Repository:
 routerarchitects/ra-wlan-cloud-analytics
 ```
 
-## OpenAPI
+## OpenAPI Follow-up Deliverable
 
-Update:
+This PR does not make these functional OpenAPI changes. A follow-up PR must
+update:
 
 ```text
 openapi/owanalytics.yaml
 ```
 
-Add:
+That follow-up should add:
 
 ```yaml
 /devices/{routerId}/memory-summary:
@@ -2926,9 +2937,9 @@ Add:
 /devices/{routerId}/wifi-clients/rssi-summary:
 ```
 
-Each MCP analytics operation must explicitly declare bearer-only security so it
-does not inherit the existing top-level OpenAPI `bearerAuth OR ApiKeyAuth`
-contract:
+That follow-up must also ensure each MCP analytics operation explicitly declares
+bearer-only security so it does not inherit the existing top-level OpenAPI
+`bearerAuth OR ApiKeyAuth` contract:
 
 ```yaml
 security:

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -723,12 +723,19 @@ Do not represent missing memory fields as `0`. A missing `memory_free` value and
 
 ### Ingestion Logic
 
+Ingestion should preserve syntactically valid source telemetry and avoid
+analytics-specific semantic validation. Parse each memory field independently,
+persist fields that can be represented as nonnegative 64-bit integers, and omit
+only the malformed field. Do not apply cross-field checks such as
+`memory_free <= memory_total` during ingestion; those checks belong to the
+aggregation layer so raw telemetry remains available for troubleshooting.
+
 ```cpp
 AnalyticsObjects::DeviceResourceTimePoint resource;
 
 // Validate numeric type, integral value, non-negative range (>= 0), and 64-bit non-overflow before unsigned conversion.
-// Field-level rejection policy: invalid free, total, cached, or buffered values are omitted independently.
-// Invalid cached/buffered values must not invalidate an otherwise valid memory_free observation.
+// Field-level preservation policy: malformed free, total, cached, or buffered values are omitted independently.
+// Do not apply analytics-specific semantic checks, such as free <= total, at ingestion time.
 auto parseMemoryField = [](const Poco::JSON::Object::Ptr &obj, const std::string &key) -> std::optional<uint64_t> {
     if (!obj->has(key) || obj->isNull(key)) return std::nullopt;
     try {
@@ -757,6 +764,13 @@ if (freeVal || totalVal || cachedVal || bufferedVal) {
 
 ### Aggregation Logic
 
+Aggregation decides whether a preserved memory sample is usable for the
+free-memory summary. `memory_free` is the required field for this aggregation.
+`memory_total` is optional and is used only when present and valid for the
+`memory_free <= memory_total` consistency check. `memory_cached` and
+`memory_buffered` are unrelated to the free-memory summary and must not affect
+sample inclusion.
+
 Use the current `timepoints` table plus parsed JSON fields:
 
 ```text
@@ -780,14 +794,12 @@ Return:
   avg_memfree = sum(memory_free samples) / sample_count
 ```
 
-Memory values are bytes and must be nonnegative. `memory_free` is the required
-field for this aggregation. `memory_total` is optional and is used only when it
-is valid; if valid `memory_total` is present, `memory_free` must not exceed
-`memory_total`. Corrupted samples that violate this consistency rule are ignored
-rather than contributing to the summary. Invalid `memory_cached` or
-`memory_buffered` values are ignored field-by-field and must not cause a valid
-`memory_free` sample to be dropped. For successful responses with samples, the
-invariant is:
+Memory values are bytes and must be nonnegative. If both `memory_free` and valid
+`memory_total` are present, `memory_free` must not exceed `memory_total`.
+Samples that violate this consistency rule are ignored rather than contributing
+to the summary. Invalid or missing `memory_cached` or `memory_buffered` values
+are ignored field-by-field and must not cause a valid `memory_free` sample to be
+dropped. For successful responses with samples, the invariant is:
 
 ```text
 min_memfree <= avg_memfree <= max_memfree

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -160,7 +160,7 @@ the latest available starting sample at or before the effective start and the
 earliest available ending sample at or after the effective end. Each fallback
 boundary sample must be within two times the configured telemetry sampling
 interval from the effective boundary. When fallback samples are used, the
-default response exposes the requested time range, aggregate result time window,
+default response exposes `requestedWindow`, `observedWindow`,
 usage accuracy, segment count, and fallback status. Effective boundaries and
 per-segment actual sample timestamps are included only when
 `includeCalculationDetails=true`.
@@ -215,7 +215,8 @@ invalid_lookback_hours:
   zero, negative, or greater than maxLookbackHours.
 
 lookback_outside_retention:
-  the calculated [startTime, endTime) window is outside the configured retention window.
+  the calculated [startTime, endTime) window starts before the retained data window
+  or ends after the configured request upper bound.
 ```
 
 A valid timestamp with an invalid `lookbackHours` value must not return `invalid_timestamp`. Internally, query `timepoints.timestamp` and `wificlienthistory.timestamp` using epoch seconds.
@@ -226,28 +227,35 @@ Handlers must load the monitoring configuration for the resolved router ownershi
 
 ```text
 monitoringDuration = configured monitoring retention duration
-retentionEnd = min(currentServerTime + allowedClockSkewSeconds, monitoringConfigurationExpiry)
-retentionStart = retentionEnd - monitoringDuration
+requestEndLimit = min(currentServerTime + allowedClockSkewSeconds, monitoringConfigurationExpiry)
+retentionDataEnd = min(currentServerTime, monitoringConfigurationExpiry)
+retentionStart = retentionDataEnd - monitoringDuration
 
 If monitoring has been enabled for less time than monitoringDuration:
-  retentionStart = max(monitoringEnabledAt, retentionEnd - monitoringDuration)
+  retentionStart = max(monitoringEnabledAt, retentionDataEnd - monitoringDuration)
 ```
 
 Use the configured duration and effective retention timestamps instead of calendar assumptions so leap years, partial-year retention, recently enabled monitoring, and changed retention policies behave consistently.
-Use the same `currentServerTime + allowedClockSkewSeconds` upper bound for both
-future timestamp validation and retention validation. A `timestampTill` value
-inside the allowed skew window must not be rejected as
-`lookback_outside_retention` merely because it is later than
-`currentServerTime`, unless it also exceeds `monitoringConfigurationExpiry`.
+Do not derive `retentionStart` from `currentServerTime + allowedClockSkewSeconds`;
+the skew allowance is a request upper-bound tolerance, not an extension that
+slides the retained historical window forward.
 
-The requested half-open range must fit inside the configured retention window:
+The requested half-open range must satisfy:
 
 ```text
 startTime >= retentionStart
-endTime <= retentionEnd
+endTime <= requestEndLimit
 ```
 
-If the requested range is outside the configured retention window, return `400 Bad Request` with `error: "lookback_outside_retention"`.
+If `endTime > retentionDataEnd` but `endTime <= requestEndLimit`, accept the
+request as within clock skew tolerance. Query and report the exact requested
+`[startTime, endTime)` window; do not clamp `endTime` to `retentionDataEnd` and
+do not reject solely because the request extends slightly beyond
+`currentServerTime`.
+
+If the requested range violates `startTime >= retentionStart` or
+`endTime <= requestEndLimit`, return `400 Bad Request` with
+`error: "lookback_outside_retention"`.
 
 When monitoring is disabled:
 
@@ -303,15 +311,15 @@ telemetry sampling interval from the effective boundary. These fallback samples
 can fall outside `[startTime, endTime)`, so the response must expose:
 
 ```text
-requestedTimeWindow.startTime = startTime
-requestedTimeWindow.endTime = endTime
-resultTimeWindow.earliestActualStartTime =
+requestedWindow.startTime = startTime
+requestedWindow.endTime = endTime
+observedWindow.earliestActualStartTime =
   earliest actual starting sample used by any calculable segment contributing
   to returned clients
-resultTimeWindow.latestActualEndTime =
+observedWindow.latestActualEndTime =
   latest actual ending sample used by any calculable segment contributing
   to returned clients
-resultTimeWindow.boundaryFallbackUsed =
+observedWindow.boundaryFallbackUsed =
   true when any calculable segment contributing to returned clients used a
   fallback boundary sample
 ```
@@ -1119,11 +1127,11 @@ consumers. Segment-level provenance is verbose and is omitted unless
 
 ```json
 {
-  "requestedTimeWindow": {
+  "requestedWindow": {
     "startTime": "2026-07-26T12:00:00Z",
     "endTime": "2026-07-27T12:00:00Z"
   },
-  "resultTimeWindow": {
+  "observedWindow": {
     "earliestActualStartTime": "2026-07-26T11:55:00Z",
     "latestActualEndTime": "2026-07-27T12:05:00Z",
     "boundaryFallbackUsed": true
@@ -1174,7 +1182,7 @@ consumers. Segment-level provenance is verbose and is omitted unless
 }
 ```
 
-`resultTimeWindow` is aggregate response metadata:
+`observedWindow` is aggregate response metadata:
 
 ```text
 earliestActualStartTime =
@@ -1198,11 +1206,11 @@ When no clients are returned:
 
 ```json
 {
-  "requestedTimeWindow": {
+  "requestedWindow": {
     "startTime": "2026-07-26T12:00:00Z",
     "endTime": "2026-07-27T12:00:00Z"
   },
-  "resultTimeWindow": {
+  "observedWindow": {
     "earliestActualStartTime": null,
     "latestActualEndTime": null,
     "boundaryFallbackUsed": false
@@ -1219,11 +1227,11 @@ return the safely provable minimum with `segment_count: 0`:
 
 ```json
 {
-  "requestedTimeWindow": {
+  "requestedWindow": {
     "startTime": "2026-08-05T12:00:00Z",
     "endTime": "2026-08-05T13:00:00Z"
   },
-  "resultTimeWindow": {
+  "observedWindow": {
     "earliestActualStartTime": null,
     "latestActualEndTime": null,
     "boundaryFallbackUsed": false
@@ -1252,7 +1260,7 @@ return the safely provable minimum with `segment_count: 0`:
 
 Use `includeCalculationDetails=true` only for diagnostics, troubleshooting, or
 calculation provenance. Ordinary MCP decisions should use `usage_accuracy`,
-`segment_count`, `boundary_fallback_used`, and the aggregate `resultTimeWindow`.
+`segment_count`, `boundary_fallback_used`, and `observedWindow`.
 
 ```http
 GET /api/v1/devices/60cf84f22290/wifi-clients/usage-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24&includeCalculationDetails=true
@@ -1282,11 +1290,11 @@ Example detailed response for the same calculated result:
 
 ```json
 {
-  "requestedTimeWindow": {
+  "requestedWindow": {
     "startTime": "2026-07-26T12:00:00Z",
     "endTime": "2026-07-27T12:00:00Z"
   },
-  "resultTimeWindow": {
+  "observedWindow": {
     "earliestActualStartTime": "2026-07-26T11:55:00Z",
     "latestActualEndTime": "2026-07-27T12:05:00Z",
     "boundaryFallbackUsed": true
@@ -1409,11 +1417,11 @@ return the safely provable minimum with no calculation segments:
 
 ```json
 {
-  "requestedTimeWindow": {
+  "requestedWindow": {
     "startTime": "2026-08-05T12:00:00Z",
     "endTime": "2026-08-05T13:00:00Z"
   },
-  "resultTimeWindow": {
+  "observedWindow": {
     "earliestActualStartTime": null,
     "latestActualEndTime": null,
     "boundaryFallbackUsed": false
@@ -1752,7 +1760,7 @@ authoritative counter evidence exactly at each segment's `effective_start` and
 `effective_end`, where effective boundaries are clipped to proven session
 lifetime and the requested window. If fallback samples within tolerance are used,
 classify the result as `bounded_interval`. The default response exposes the
-requested time window, aggregate result time window, and fallback summary
+requested window, observed window, and fallback summary
 fields. When `includeCalculationDetails=true`, each returned segment
 additionally exposes its effective and actual boundary timestamps. Do not add a
 cumulative counter directly unless it is known to represent traffic that started inside the
@@ -1855,7 +1863,7 @@ Aggregate stream-level deltas by station MAC (including only clients with in-win
     ↓
 Convert bytes to decimal megabytes
     ↓
-Return wrapped response with requestedTimeWindow, resultTimeWindow, items,
+Return wrapped response with requestedWindow, observedWindow, items,
 totalClients, and truncated
 ```
 
@@ -1898,11 +1906,11 @@ None
 
 ```json
 {
-  "requestedTimeWindow": {
+  "requestedWindow": {
     "startTime": "2026-07-26T12:00:00Z",
     "endTime": "2026-07-27T12:00:00Z"
   },
-  "resultTimeWindow": {
+  "observedWindow": {
     "firstSampleTime": "2026-07-26T12:01:00Z",
     "lastSampleTime": "2026-07-27T11:58:00Z",
     "totalSamples": 170
@@ -1930,7 +1938,7 @@ None
 }
 ```
 
-`resultTimeWindow` for RSSI is scoped to returned `items[]` after applying the
+`observedWindow` for RSSI is scoped to returned `items[]` after applying the
 500-client response limit:
 
 ```text
@@ -1948,11 +1956,11 @@ For empty RSSI results:
 
 ```json
 {
-  "requestedTimeWindow": {
+  "requestedWindow": {
     "startTime": "2026-07-26T12:00:00Z",
     "endTime": "2026-07-27T12:00:00Z"
   },
-  "resultTimeWindow": {
+  "observedWindow": {
     "firstSampleTime": null,
     "lastSampleTime": null,
     "totalSamples": 0

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -303,7 +303,7 @@ A sample exactly at `11:00` belongs only to Request 2.
 All device metric handlers must enforce authorization before returning data:
 
 ```text
-1. Authenticate the bearer token.
+1. Authenticate the bearer token from Authorization: Bearer <token>.
    If the token is missing, invalid, or expired, return 401 Unauthorized.
 2. Resolve the caller's accessible entity, venue, and board scope from the token.
 3. Resolve routerId to its current router ownership context.
@@ -311,6 +311,10 @@ All device metric handlers must enforce authorization before returning data:
 5. Return 404 Not Found when the router exists but the caller cannot access it.
 6. Return 404 Not Found when the router does not exist.
 ```
+
+The MCP analytics endpoints are bearer-token endpoints. Do not allow `X-API-KEY`
+authentication for these endpoints unless this specification is explicitly
+updated to define API-key semantics and error precedence.
 
 Required permission:
 
@@ -767,7 +771,15 @@ Do not query `device_timepoints.memory_free` unless a separate normalized table 
 ### Handler Flow
 
 ```text
-Validate routerId
+Authenticate bearer token
+    ↓
+Validate routerId syntax
+    ↓
+Inspect raw query parameters for exactly one timestampTill and lookbackHours
+    ↓
+Parse timestampTill and lookbackHours
+    ↓
+Calculate start_time with checked epoch arithmetic
     ↓
 Call ResolveRouterIdContext(client, routerId)
     ↓
@@ -775,9 +787,7 @@ If status is not Success, map RouterIdResolutionStatus to HTTP response
     ↓
 Use result.venueId and result.resolvedBoardId
     ↓
-Parse timestampTill
-    ↓
-Calculate start_time
+Validate lookbackHours against monitoring duration and retention
     ↓
 Query timepoints and read resource_data.memory_free samples
     ↓
@@ -2858,6 +2868,15 @@ Add:
 /devices/{routerId}/availability-summary:
 /devices/{routerId}/wifi-clients/usage-summary:
 /devices/{routerId}/wifi-clients/rssi-summary:
+```
+
+Each MCP analytics operation must explicitly declare bearer-only security so it
+does not inherit the existing top-level OpenAPI `bearerAuth OR ApiKeyAuth`
+contract:
+
+```yaml
+security:
+  - bearerAuth: []
 ```
 
 ---

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -300,6 +300,22 @@ timestamp < endTime
 
 `timestampTill` is the exclusive upper bound. This prevents adjacent requests from double-counting samples or events at the shared boundary.
 
+MCP analytics responses that include window metadata must use common temporal
+field names:
+
+```text
+requestedWindow.startTime
+requestedWindow.endTime
+observedWindow.startTime
+observedWindow.endTime
+```
+
+`observedWindow` must contain only the common temporal fields `startTime` and
+`endTime`. Endpoint-specific metadata must not be added inside
+`observedWindow`, and endpoints must not introduce alternate temporal field
+names such as `firstSampleAt`, `firstSampleTime`, `earliestActualStartTime`, or
+`latestActualEndTime`.
+
 For cumulative-counter differential summaries, exact effective-boundary samples
 are preferred. For endpoints with proven session lifetimes, effective boundaries
 are the requested boundaries clipped to the proven session start and end. For
@@ -313,15 +329,12 @@ can fall outside `[startTime, endTime)`, so the response must expose:
 ```text
 requestedWindow.startTime = startTime
 requestedWindow.endTime = endTime
-observedWindow.earliestActualStartTime =
+observedWindow.startTime =
   earliest actual starting sample used by any calculable segment contributing
   to returned clients
-observedWindow.latestActualEndTime =
+observedWindow.endTime =
   latest actual ending sample used by any calculable segment contributing
   to returned clients
-observedWindow.boundaryFallbackUsed =
-  true when any calculable segment contributing to returned clients used a
-  fallback boundary sample
 ```
 
 When no calculable usage segment exists for an observed client, the client
@@ -1132,9 +1145,8 @@ consumers. Segment-level provenance is verbose and is omitted unless
     "endTime": "2026-07-27T12:00:00Z"
   },
   "observedWindow": {
-    "earliestActualStartTime": "2026-07-26T11:55:00Z",
-    "latestActualEndTime": "2026-07-27T12:05:00Z",
-    "boundaryFallbackUsed": true
+    "startTime": "2026-07-26T11:55:00Z",
+    "endTime": "2026-07-27T12:05:00Z"
   },
   "items": [
     {
@@ -1185,17 +1197,13 @@ consumers. Segment-level provenance is verbose and is omitted unless
 `observedWindow` is aggregate response metadata:
 
 ```text
-earliestActualStartTime =
+startTime =
   minimum actual_start_time among the server's internal calculable segments
   contributing to returned clients
 
-latestActualEndTime =
+endTime =
   maximum actual_end_time among the server's internal calculable segments
   contributing to returned clients
-
-boundaryFallbackUsed =
-  true when any internal calculable segment contributing to returned clients
-  used a fallback boundary sample
 ```
 
 It describes only the overall result envelope. It does not mean every client or
@@ -1211,9 +1219,8 @@ When no clients are returned:
     "endTime": "2026-07-27T12:00:00Z"
   },
   "observedWindow": {
-    "earliestActualStartTime": null,
-    "latestActualEndTime": null,
-    "boundaryFallbackUsed": false
+    "startTime": null,
+    "endTime": null
   },
   "items": [],
   "totalClients": 0,
@@ -1232,9 +1239,8 @@ return the safely provable minimum with `segment_count: 0`:
     "endTime": "2026-08-05T13:00:00Z"
   },
   "observedWindow": {
-    "earliestActualStartTime": null,
-    "latestActualEndTime": null,
-    "boundaryFallbackUsed": false
+    "startTime": null,
+    "endTime": null
   },
   "items": [
     {
@@ -1295,9 +1301,8 @@ Example detailed response for the same calculated result:
     "endTime": "2026-07-27T12:00:00Z"
   },
   "observedWindow": {
-    "earliestActualStartTime": "2026-07-26T11:55:00Z",
-    "latestActualEndTime": "2026-07-27T12:05:00Z",
-    "boundaryFallbackUsed": true
+    "startTime": "2026-07-26T11:55:00Z",
+    "endTime": "2026-07-27T12:05:00Z"
   },
   "items": [
     {
@@ -1422,9 +1427,8 @@ return the safely provable minimum with no calculation segments:
     "endTime": "2026-08-05T13:00:00Z"
   },
   "observedWindow": {
-    "earliestActualStartTime": null,
-    "latestActualEndTime": null,
-    "boundaryFallbackUsed": false
+    "startTime": null,
+    "endTime": null
   },
   "items": [
     {
@@ -1911,9 +1915,8 @@ None
     "endTime": "2026-07-27T12:00:00Z"
   },
   "observedWindow": {
-    "firstSampleTime": "2026-07-26T12:01:00Z",
-    "lastSampleTime": "2026-07-27T11:58:00Z",
-    "totalSamples": 170
+    "startTime": "2026-07-26T12:01:00Z",
+    "endTime": "2026-07-27T11:58:00Z"
   },
   "items": [
     {
@@ -1942,14 +1945,11 @@ None
 500-client response limit:
 
 ```text
-firstSampleTime =
+startTime =
   earliest valid RSSI sample contributing to items[]
 
-lastSampleTime =
+endTime =
   latest valid RSSI sample contributing to items[]
-
-totalSamples =
-  SUM(items[].rssi_total_samples)
 ```
 
 For empty RSSI results:
@@ -1961,9 +1961,8 @@ For empty RSSI results:
     "endTime": "2026-07-27T12:00:00Z"
   },
   "observedWindow": {
-    "firstSampleTime": null,
-    "lastSampleTime": null,
-    "totalSamples": 0
+    "startTime": null,
+    "endTime": null
   },
   "items": [],
   "totalClients": 0,
@@ -2100,16 +2099,16 @@ None
       "endTime": "2026-07-27T12:00:00Z"
     },
     "observedWindow": {
-      "firstSampleAt": "2026-07-26T13:15:00Z",
-      "lastSampleAt": "2026-07-27T09:45:00Z"
+      "startTime": "2026-07-26T13:15:00Z",
+      "endTime": "2026-07-27T09:45:00Z"
     },
     "sourceWindow": {
-      "firstSampleAt": "2026-07-26T11:55:00Z",
-      "lastSampleAt": "2026-07-27T12:00:00Z"
+      "startTime": "2026-07-26T11:55:00Z",
+      "endTime": "2026-07-27T12:00:00Z"
     },
     "contributingWindow": {
-      "firstSampleAt": "2026-07-26T13:15:00Z",
-      "lastSampleAt": "2026-07-27T09:45:00Z"
+      "startTime": "2026-07-26T13:15:00Z",
+      "endTime": "2026-07-27T09:45:00Z"
     },
     "selection": "boundary_assisted",
     "coverage": "full",
@@ -2869,16 +2868,16 @@ Use an HTTP error:
       "endTime": "2026-07-27T12:00:00Z"
     },
     "observedWindow": {
-      "firstSampleAt": null,
-      "lastSampleAt": null
+      "startTime": null,
+      "endTime": null
     },
     "sourceWindow": {
-      "firstSampleAt": "2026-07-26T11:55:00Z",
-      "lastSampleAt": "2026-07-26T11:55:00Z"
+      "startTime": "2026-07-26T11:55:00Z",
+      "endTime": "2026-07-26T11:55:00Z"
     },
     "contributingWindow": {
-      "firstSampleAt": null,
-      "lastSampleAt": null
+      "startTime": null,
+      "endTime": null
     },
     "selection": "boundary_assisted",
     "coverage": "full",

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -10,7 +10,7 @@ This document defines the request format, response format, and implementation lo
 
 This specification is structured across two in-scope component areas:
 1. **MCP Analytics Behavior Specification**: Intended HTTP requests, parameter validation, response envelopes, and ownership/error semantics for future MCP-facing Analytics handlers.
-2. **Persistence & Pipeline Architecture Design**: Internal storage structures (`device_availability_events`, `device_availability_state`, `device_availability_ingestion_checkpoint`, `device_availability_ingestion_gaps`), Kafka event consumption/ordering, and cutover semantics.
+2. **Persistence & Pipeline Architecture Design**: Internal storage structures (`device_availability_events`, `device_availability_state`), Kafka event consumption/ordering, Kafka offset commit semantics, and cutover semantics.
 
 Follow-up deliverables:
 - OpenAPI contract/schema updates in `openapi/owanalytics.yaml`.
@@ -20,11 +20,9 @@ Follow-up deliverables:
 > This PR does not update `openapi/owanalytics.yaml` and does not publish a
 > functional OpenAPI contract for these MCP analytics endpoints. The OpenAPI
 > contract/schema update is a follow-up deliverable. The specified production
-> architecture changes—including four new availability persistence structures
-> (`device_availability_events`, `device_availability_state`,
-> `device_availability_ingestion_checkpoint`,
-> `device_availability_ingestion_gaps`), Kafka event ordering/checkpointing
-> rules, and cutover migration rules—constitute a production architecture
+> architecture changes—including two new availability persistence structures
+> (`device_availability_events`, `device_availability_state`), Kafka event
+> ordering and offset commit rules, and cutover migration rules—constitute a production architecture
 > specification. Approving or merging this behavior specification PR does NOT bypass
 > separate explicit architecture design sign-off for backend schema additions and
 > production Kafka pipeline changes prior to production deployment.
@@ -317,9 +315,7 @@ observedWindow.endTime
 
 `observedWindow` must contain only the common temporal fields `startTime` and
 `endTime`. Endpoint-specific metadata must not be added inside
-`observedWindow`, and endpoints must not introduce alternate temporal field
-names such as `firstSampleAt`, `firstSampleTime`, `earliestActualStartTime`, or
-`latestActualEndTime`.
+`observedWindow`.
 
 For cumulative-counter differential summaries, exact effective-boundary samples
 are preferred. For endpoints with proven session lifetimes, effective boundaries
@@ -2122,17 +2118,7 @@ None
       "startTime": "2026-07-26T13:15:00Z",
       "endTime": "2026-07-27T09:45:00Z"
     },
-    "coverage": "full",
-    "accuracy": "exact",
-    "offlineEventCount": 6,
-    "availabilityCoverage": {
-      "coverageStart": "2026-07-26T11:55:00Z",
-      "stateKnownFrom": "2026-07-26T11:55:00Z",
-      "processedThrough": "2026-07-27T12:00:00Z",
-      "allowedIngestionDelaySeconds": 0,
-      "ingestionGapKnown": false,
-      "proofSource": "serial_partition_checkpoint"
-    }
+    "offlineEventCount": 6
   },
   "data": {
     "gw_uuid": "60cf84f22290",
@@ -2146,8 +2132,8 @@ For availability responses, `observedWindow` is the actual event-time range
 represented by the availability data used to produce the response. It is derived
 from offline transition events that contributed to `offline_count`; when no
 offline transition events contribute, both `observedWindow.startTime` and
-`observedWindow.endTime` are `null`. Completeness and ingestion progress are
-reported separately in `availabilityCoverage`.
+`observedWindow.endTime` are `null`. The response does not report Kafka consumer
+progress or lag as availability-domain data.
 
 ## API Logic
 
@@ -2290,50 +2276,99 @@ Constraints:
 
 `device_availability_events` stores only online/offline transition history. `device_availability_state` stores the authoritative current state and the latest accepted source availability ordering key.
 
-`last_event_time` and `last_source_sequence` form the persisted source ordering key after events have passed the required per-serial ordering mechanism. `last_event_time` must be populated from the normalized Kafka source timestamp (`event_time`), and `last_source_sequence` must be populated from a reliable source sequence, source offset within the producing system, or another deterministic 64-bit numeric value (`BIGINT`) when one exists. `source_sequence` and `last_source_sequence` are stored as `BIGINT NULL` so SQL and application-layer index and comparator operations preserve numeric order (`10 > 2`). The composite key is used for stale detection only after Analytics has established that no older transition for the same serialNumber can still be accepted. `DeviceInfo.lastContact` may remain local contact or processing metadata, but it must not be used to order source events because Kafka delivery can be delayed.
+`last_event_time` and `last_source_sequence` form the persisted source ordering key after events have been consumed in Kafka partition order for the gateway. `last_event_time` must be populated from the normalized Kafka source timestamp (`event_time`), and `last_source_sequence` must be populated from a reliable source sequence, source offset within the producing system, or another deterministic 64-bit numeric value (`BIGINT`) when one exists. `source_sequence` and `last_source_sequence` are stored as `BIGINT NULL` so SQL and application-layer index and comparator operations preserve numeric order (`10 > 2`). The composite key is used for duplicate detection, stale-event protection, same-timestamp ordering, and defensive validation. `DeviceInfo.lastContact` may remain local contact or processing metadata, but it must not be used to order source events because Kafka delivery can be delayed.
 
-Add persisted ingestion coverage tables for availability exactness:
+Do not add Analytics-owned ingestion progress or durable data-loss tables for availability.
 
-```text
-device_availability_ingestion_checkpoint
-----------------------------------------
-serialNumber
-coverage_start
-state_known_from
-processed_through_event_time
-partition
-offset
-ordering_strategy
-reorder_window_ms
-ingestion_gap_known
-updated_at
-metadata
-
-device_availability_ingestion_gaps
-----------------------------------
-serialNumber
-gap_start_event_time
-gap_end_event_time
-reason
-detected_at
-metadata
-```
-
-`processed_through_event_time` is a source-event-time watermark, not a Kafka processing-time or `DeviceInfo.lastContact` value. `state_known_from` stores the earliest source event timestamp from which gateway state is authoritatively established. When initial state is unproven (such as a first observed disconnection initializing state without prior state history), `state_known_from` is set to the timestamp of the first observed transition or explicit state proof (or an unproven gap is persisted in `device_availability_ingestion_gaps` for `[coverage_start, initial_observation_time)`). Kafka topic, partition, and offset are stored only as proof metadata.
-
-For availability coverage decisions over a requested interval `[startTime, endTime)`:
+Kafka consumer offsets are the source of truth for ingestion progress, replay after service restart, redelivery of uncommitted messages, consumer lag, and consumer-group rebalances. Analytics-owned availability state is limited to:
 
 ```text
-coverageTargetEnd = endTime - allowedIngestionDelaySeconds
+device_availability_events
+device_availability_state
 ```
 
-An exact result (`meta.coverage = "full"`, `meta.accuracy = "exact"`) is allowed only when the serialNumber checkpoint proves `coverage_start <= startTime`, `state_known_from <= startTime` (or no unproven initial gap), `processed_through_event_time >= endTime`, and no persisted gap overlaps `[startTime, endTime)`.
+Kafka topic, partition, offset, message key, and consumer timestamp may be stored in event or state `metadata` for diagnostics only. They must not form the logical availability event identity and must not be persisted as an Analytics ingestion-progress record.
 
-Evaluating coverage against `coverageTargetEnd = endTime - allowedIngestionDelaySeconds` does not prove that there were no offline transitions in `[coverageTargetEnd, endTime)`. Therefore, if `processed_through_event_time < endTime` (even when `processed_through_event_time >= coverageTargetEnd`), the requested interval `[startTime, endTime)` is not fully covered up to `endTime` and must be reported as partial coverage (`meta.coverage = "partial"`, `meta.accuracy = "lower_bound"`) with the effective/observed window covered so far ending at `processed_through_event_time` (or `coverageTargetEnd`). Set `allowedIngestionDelaySeconds` to the configured maximum tolerated ingestion/source-message delay for availability queries, and return it in `meta.availabilityCoverage`.
+Expected Kafka and database processing contract:
 
-The checkpoint must be advanced durably with event processing. For a message that changes availability state or updates same-state metadata, the state update, optional transition insert, and checkpoint update must commit in one database transaction before the corresponding Kafka offset is committed. Rebalances and restarts must reload the checkpoint and any persisted reorder-buffer state needed by the selected ordering strategy. If the implementation cannot prove continuity after a restart, rebalance, topic retention truncation, skipped unparseable connection message, reorder-window overflow, or offset discontinuity, it must persist an ingestion gap and stop returning exact coverage for overlapping ranges.
+```text
+Kafka message received
+normalize and validate event
+BEGIN database transaction
+lock/load device_availability_state for serialNumber
+apply idempotency and source ordering checks
+insert device_availability_events transition when required
+update device_availability_state
+COMMIT database transaction
+commit Kafka offset
+```
 
-When one serialNumber has no recent messages, do not infer coverage from an empty event table. The API may return an exact zero only if that serialNumber has a durable checkpoint whose `processed_through_event_time` reaches `endTime`; otherwise the result is partial/lower-bound or unavailable according to the coverage rules. A partition-level or source-level watermark may be used instead of per-message checkpoint advancement only if it is durable, serialNumber-scoped for the queried gateway, and can prove that no earlier source event for that gateway remains unprocessed.
+This is an at-least-once processing contract. The Kafka offset must not be committed before the database transaction succeeds. If the service crashes before the database commit, Kafka replays the message after restart. If the service crashes after the database commit but before the Kafka offset commit, Kafka may redeliver the message and storage-level idempotency must make the replay harmless. Kafka auto-commit must not acknowledge messages ahead of successful database commits.
+
+Restart and rebalance recovery must use the stable Kafka consumer group:
+
+```text
+1. consumer joins the same Kafka consumer group
+2. Kafka resumes from the last committed offset for assigned partitions
+3. messages after that offset are replayed
+4. Analytics loads device_availability_state for each serialNumber as messages arrive
+5. idempotency and ordering checks prevent duplicate transition rows
+6. processing continues and offsets are committed only after DB commit
+```
+
+Concrete restart scenario:
+
+```text
+offset 100 -> ping -> DB committed, Kafka offset committed
+offset 101 -> disconnection -> DB committed, Kafka offset committed
+offset 102 -> ping -> DB committed, service crashes before Kafka offset commit
+
+After restart:
+consumer rejoins the same consumer group
+Kafka resumes from the last committed position
+offset 102 may be replayed
+device_availability_state already reflects offset 102
+device_availability_events idempotency prevents a duplicate transition row
+offset 102 is committed after the replay transaction succeeds or no-ops safely
+consumer continues with offset 103
+```
+
+Consumer-group rebalance and partition reassignment follow the same rule: Kafka
+assigns partitions to a consumer in the stable group, resumes from committed
+offsets, and redelivers any messages whose offsets were not committed.
+
+Normal Kafka lag is not an Analytics data gap. If the producer is at offset 5000 and the consumer is at offset 4500, the service should keep consuming until it catches up. Operational monitoring should expose Kafka consumer lag through Kafka or observability metrics, not through availability-domain tables or API fields.
+
+Exceptional Kafka data-loss conditions are operational incidents, not normal availability-domain state. Examples include Kafka retention expiring before the consumer caught up, a topic being deleted or recreated, or offsets being manually reset past unprocessed data. Log, alert, and metric these conditions. Do not introduce Analytics-owned durable data-loss records unless a separate product requirement explicitly calls for historical completeness auditing.
+
+Final availability ingestion architecture:
+
+```text
+                 Kafka connection topic
+                         |
+                key = serialNumber
+                         |
+                         v
+                 Kafka consumer group
+                         |
+                partition ordering
+                         |
+                         v
+             normalize connection event
+                         |
+                         v
+              DB transaction / serial lock
+                   /              \
+                  v                v
+device_availability_state   device_availability_events
+       current state          transition history
+                  \                /
+                   \              /
+                    DB COMMIT
+                         |
+                         v
+                commit Kafka offset
+```
 
 Add a `DeviceAvailabilityEvent` REST/storage object with `to_json` and `from_json` support in:
 
@@ -2348,32 +2383,22 @@ Update `StorageService`:
 src/StorageService.h
   include storage/storage_device_availability_events.h
   include storage/storage_device_availability_state.h
-  include storage/storage_device_availability_ingestion_checkpoint.h
-  include storage/storage_device_availability_ingestion_gaps.h
   add DeviceAvailabilityEventsDB accessor
   add DeviceAvailabilityStateDB accessor
-  add DeviceAvailabilityIngestionCheckpointDB accessor
-  add DeviceAvailabilityIngestionGapsDB accessor
   add std::unique_ptr<DeviceAvailabilityEventsDB>
   add std::unique_ptr<DeviceAvailabilityStateDB>
-  add std::unique_ptr<DeviceAvailabilityIngestionCheckpointDB>
-  add std::unique_ptr<DeviceAvailabilityIngestionGapsDB>
 
 src/StorageService.cpp
   construct DeviceAvailabilityEventsDB
   construct DeviceAvailabilityStateDB
-  construct DeviceAvailabilityIngestionCheckpointDB
-  construct DeviceAvailabilityIngestionGapsDB
   call DeviceAvailabilityEventsDB->Create()
   call DeviceAvailabilityStateDB->Create()
-  call DeviceAvailabilityIngestionCheckpointDB->Create()
-  call DeviceAvailabilityIngestionGapsDB->Create()
   include availability retention cleanup if retention should match board timepoint cleanup
 ```
 
-Add a DB upgrade/migration path for the new tables. Existing deployments will start with no historical availability events. Define a fixed `availabilityValidFrom` timestamp as the deployment/migration time when availability-event persistence starts. The API should return `offline_count: 0` as an exact result only for successful empty queries whose requested range starts at or after `availabilityValidFrom` and is covered by the per-serial ingestion checkpoint; do not infer old events from `lastDisconnection`.
+Add a DB upgrade/migration path for the new tables. Existing deployments will start with no historical availability events. Define a fixed `availabilityValidFrom` timestamp as the deployment/migration time when availability-event persistence starts. The API should return `offline_count: 0` for successful empty queries whose requested range starts at or after `availabilityValidFrom`; do not infer old events from `lastDisconnection`.
 
-Add all availability storage files to `CMakeLists.txt`, including `storage_device_availability_events.*`, `storage_device_availability_state.*`, `storage_device_availability_ingestion_checkpoint.*`, and `storage_device_availability_ingestion_gaps.*`. Register database migration/upgrade logic for all availability tables so fresh databases and upgraded deployments create the event table, state table, checkpoint table, gap table, indexes, uniqueness constraints, and state constraints consistently.
+Add all availability storage files to `CMakeLists.txt`, including `storage_device_availability_events.*` and `storage_device_availability_state.*`. Register database migration/upgrade logic for these availability tables so fresh databases and upgraded deployments create the event table, state table, indexes, uniqueness constraints, and state constraints consistently.
 
 ### Ingestion Hook
 
@@ -2558,27 +2583,26 @@ The same delivered logical connection event must always produce the same `idempo
 Ordering rule:
 
 ```text
-Availability transition detection must process connection events in source-event
-order for each serialNumber.
+Connection events must be produced to Kafka with Kafka key = serialNumber.
+The producer must publish messages for one serialNumber in source-event order.
+Kafka partition ordering is then the primary ordering guarantee for all
+availability events belonging to one gateway.
 
-The preferred implementation is to produce Kafka connection messages in
-source-event order with serialNumber as the Kafka message key, so all events for
-one gateway are in one partition and retain gateway event order. If the source
-topic cannot provide that guarantee, Analytics must add a bounded event-time
-reorder window or an equivalent serialNumber-scoped ordering mechanism before
-applying the transition state machine.
+Source timestamps and source sequences remain useful for duplicate detection,
+stale-event protection, same-timestamp ordering, and defensive validation. They
+must not be used to build a second durable Analytics ingestion watermark.
 
-A newer same-state online event must not advance last_event_time in a way that
-causes an older offline transition for the same serialNumber to be discarded
-silently. If a deployment intentionally chooses best-effort counting instead of
-per-serial ordering, that lower-accuracy behavior must be documented separately
-and surfaced to callers; it must not be reported as exact availability counting.
+If the source topic cannot provide serialNumber keying and producer-side
+per-serial ordering, Kafka alone cannot guarantee exact transition history for
+that gateway. Treat that as a producer/topic contract violation or a separate
+architecture requirement; do not add an Analytics PostgreSQL ingestion-progress or data-loss
+tracking system to compensate.
 ```
 
 Atomic transition and insert rule:
 
 ```text
-For each valid connection message emitted by the per-serial ordering stage:
+For each valid connection message consumed in Kafka partition order:
   BEGIN
 
   acquire a serialNumber-scoped transaction lock before reading state
@@ -2611,8 +2635,8 @@ For each valid connection message emitted by the per-serial ordering stage:
         if idempotency_key equals last_idempotency_key:
           treat the message as an exact duplicate
         else:
-          persist an ingestion ambiguity gap for this serialNumber, event_time, and source_sequence
-          treat the message as ambiguous, not exact
+          treat the message as ambiguous duplicate-source data
+          log and metric the ambiguity
         do not insert an availability event
         do not update device_availability_state
         COMMIT
@@ -2622,8 +2646,8 @@ For each valid connection message emitted by the per-serial ordering stage:
       if idempotency_key equals last_idempotency_key:
         treat the message as an exact duplicate
       else:
-        persist an ingestion ambiguity gap for this serialNumber and event_time
-        treat the message as unordered / ambiguous, not exact
+        treat the message as ambiguous duplicate-source data
+        log and metric the ambiguity
       do not insert an availability event
       do not update device_availability_state
       COMMIT
@@ -2680,10 +2704,11 @@ The storage method must return whether a row was inserted. Duplicate events that
 the unique idempotency constraint must not be treated as new offline transitions and
 must not move `device_availability_state` backward or forward.
 
-This transaction shape assumes the selected ordering strategy has already made
-the message eligible for state-machine processing. Do not apply this scalar
-`last_event_time` staleness check directly to raw Kafka arrival order unless the
-connection topic is keyed by serialNumber and source-event ordered.
+This transaction shape assumes the connection topic is keyed by serialNumber and
+the producer publishes per-serial events in source-event order. Do not apply this
+state machine to a topic that can deliver out-of-order messages for one
+serialNumber unless a separate architecture explicitly defines that ordering
+guarantee outside Analytics PostgreSQL ingestion-progress or data-loss tables.
 ```
 
 Equivalent transaction shape:
@@ -2727,9 +2752,9 @@ Two different logical events with the same `event_time` must be ordered by a
 deterministic 64-bit numeric `source_sequence` (`BIGINT`). Exact Kafka redelivery
 should be identified by the idempotency key. If two different logical events share
 the same `event_time` and lack comparable non-null source sequences, or have identical
-source sequences, Analytics must persist an ingestion ambiguity gap for that source time
-and downgrade overlapping availability queries to partial/lower-bound coverage instead
-of silently discarding one transition as non-advancing or guessing order arbitrarily.
+source sequences, Analytics cannot deterministically order them. Log and metric
+the ambiguity, do not insert a counted transition for the ambiguous message, and
+do not create an Analytics ingestion-progress or data-loss table.
 ```
 
 ### Store Only State Transitions
@@ -2747,7 +2772,7 @@ Incorrect:
 every ping → store online event
 ```
 
-Every ping should not be treated as a new online transition. However, every source-newer ping that is accepted by the per-serial ordering stage must still update `device_availability_state.last_event_time` and metadata.
+Every ping should not be treated as a new online transition. However, every source-newer ping that is accepted after Kafka partition-ordered consumption must still update `device_availability_state.last_event_time` and metadata.
 
 Ping handling:
 
@@ -2773,11 +2798,9 @@ Example:
 12:10 ping source event
 ```
 
-If Kafka delivers the `12:10` ping before the `12:05` disconnection and the
-topic does not guarantee serialNumber ordering, Analytics must not immediately
-advance `last_event_time` to `12:10` and then reject the delayed `12:05`
-disconnection. With a bounded reorder window, both messages are ordered by
-source time before transition processing:
+With Kafka key = serialNumber and producer-side per-serial ordering, Kafka
+preserves the gateway event order even when the consumer processes the messages
+later:
 
 ```text
 12:05 disconnection -> insert offline event, current_state=offline, last_event_time=12:05
@@ -2785,9 +2808,10 @@ source time before transition processing:
 ```
 
 The final current state is online, and the outage from `12:05` to `12:10` remains
-present in transition history. If the implementation lacks serial-keyed
-source-event ordering or a bounded reorder window, this case is only best-effort
-and must not be surfaced as exact availability counting.
+present in transition history. If the topic is not keyed by serialNumber or the
+producer publishes events for one serialNumber out of order, Kafka cannot provide
+the required per-gateway transition ordering. Treat that as an operational or
+producer-contract issue; do not model it with Analytics ingestion-progress or data-loss tables.
 
 Kafka delay example:
 
@@ -2803,7 +2827,7 @@ The `12:03` disconnection is not stale because it is newer than `device_availabi
 Review conclusion:
 
 ```text
-The implementation requires `device_availability_state` unless a future design explicitly names an existing persistent table with the same fields and locking guarantees. `last_event_time` must be updated for every source-newer ping, capabilities, or disconnection message accepted by the per-serial ordering stage, even when no availability transition event is inserted. `DeviceInfo.lastContact` remains contact/processing metadata and is not the source-event ordering field.
+The implementation requires `device_availability_state` unless a future design explicitly names an existing persistent table with the same fields and locking guarantees. `last_event_time` must be updated for every source-newer ping, capabilities, or disconnection message accepted after Kafka partition-ordered consumption, even when no availability transition event is inserted. `DeviceInfo.lastContact` remains contact/processing metadata and is not the source-event ordering field.
 ```
 
 ### Calculation
@@ -2831,10 +2855,6 @@ If startTime < availabilityValidFrom:
 If startTime >= availabilityValidFrom:
   query device_availability_events normally
 ```
-
-For `meta.coverage = "none"` and `meta.accuracy = "not_applicable"`, return
-`data.offline_count = null`. Do not return a numeric `0` when the API has no
-coverage proof for the requested interval.
 
 Rejecting pre-cutover ranges prevents a successful zero response from meaning either
 "no outages occurred" or "Analytics was not collecting availability events yet."
@@ -2880,17 +2900,7 @@ Use an HTTP error:
       "startTime": null,
       "endTime": null
     },
-    "coverage": "full",
-    "accuracy": "exact",
-    "offlineEventCount": 0,
-    "availabilityCoverage": {
-      "coverageStart": "2026-07-20T00:00:00Z",
-      "stateKnownFrom": "2026-07-20T00:00:00Z",
-      "processedThrough": "2026-07-27T12:01:00Z",
-      "allowedIngestionDelaySeconds": 60,
-      "ingestionGapKnown": false,
-      "proofSource": "serial_partition_checkpoint"
-    }
+    "offlineEventCount": 0
   },
   "data": {
     "gw_uuid": "60cf84f22290",
@@ -2900,16 +2910,15 @@ Use an HTTP error:
 }
 ```
 
-An exact zero is valid only when availability coverage proves the complete requested interval up to `endTime`: `coverageStart <= startTime`, `stateKnownFrom <= startTime`, `processedThrough >= endTime`, `ingestionGapKnown = false`, and `proofSource != "unavailable"`. When `processedThrough < endTime` (even if `processedThrough >= endTime - allowedIngestionDelaySeconds`), the requested interval is not fully covered up to `endTime` and a zero matching event count must be reported as partial/lower-bound (`meta.coverage = "partial"`), or as unavailable with `offline_count: null` when no coverage proof exists.
+A zero result means no offline transition rows are currently persisted for the
+requested post-cutover interval. Kafka consumer lag is operational state and is
+not represented as availability-domain response metadata.
 
 `offlineEventCount` is the number of offline transition rows in
 `device_availability_events` that contribute to `offline_count`. Online recovery
 transition rows (`event_type = 'online'`) are stored in transition history for
 state tracking, but they do not contribute to `observedWindow`,
 `offlineEventCount`, or `offline_count`.
-
-When `meta.coverage = "none"` and `meta.accuracy = "not_applicable"`,
-`offlineEventCount` and `offline_count` are both `null`.
 
 ### Internal Error
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -727,17 +727,16 @@ Do not represent missing memory fields as `0`. A missing `memory_free` value and
 AnalyticsObjects::DeviceResourceTimePoint resource;
 
 // Validate numeric type, integral value, non-negative range (>= 0), and 64-bit non-overflow before unsigned conversion.
-// Sample-level rejection policy for negative telemetry: If ANY present memory field (free, total, cached, buffered) is negative (< 0), non-numeric, or invalid, mark the entire memory sample invalid and omit resource_data so the entire corrupted memory timepoint is excluded during aggregation.
-bool sampleValid = true;
-auto parseMemoryField = [&sampleValid](const Poco::JSON::Object::Ptr &obj, const std::string &key) -> std::optional<uint64_t> {
+// Field-level rejection policy: invalid free, total, cached, or buffered values are omitted independently.
+// Invalid cached/buffered values must not invalidate an otherwise valid memory_free observation.
+auto parseMemoryField = [](const Poco::JSON::Object::Ptr &obj, const std::string &key) -> std::optional<uint64_t> {
     if (!obj->has(key) || obj->isNull(key)) return std::nullopt;
     try {
-        if (!obj->isNumeric(key)) { sampleValid = false; return std::nullopt; }
+        if (!obj->isNumeric(key)) return std::nullopt;
         int64_t val = obj->getElement<int64_t>(key);
-        if (val < 0) { sampleValid = false; return std::nullopt; }
+        if (val < 0) return std::nullopt;
         return static_cast<uint64_t>(val);
     } catch (...) {
-        sampleValid = false;
         return std::nullopt;
     }
 };
@@ -747,7 +746,7 @@ auto totalVal = parseMemoryField(memory, "total");
 auto cachedVal = parseMemoryField(memory, "cached");
 auto bufferedVal = parseMemoryField(memory, "buffered");
 
-if (sampleValid) {
+if (freeVal || totalVal || cachedVal || bufferedVal) {
     if (freeVal)     resource.memory_free = *freeVal;
     if (totalVal)    resource.memory_total = *totalVal;
     if (cachedVal)   resource.memory_cached = *cachedVal;
@@ -770,9 +769,10 @@ Load TimePointDB records where:
 For each record:
   read record.resource_data.memory_free
   ignore missing resource_data
-  include the sample only when memory_free is present
-  exclude the sample if any present memory value is negative
-  exclude the sample if memory_total is present and memory_free > memory_total
+  include the sample only when memory_free is present and valid
+  use memory_total only when present and valid for the free <= total consistency check
+  exclude the sample if valid memory_total is present and memory_free > memory_total
+  ignore invalid or missing memory_total, memory_cached, and memory_buffered without invalidating memory_free
 
 Return:
   min_memfree = min(memory_free samples)
@@ -780,7 +780,14 @@ Return:
   avg_memfree = sum(memory_free samples) / sample_count
 ```
 
-Memory values are bytes and must be nonnegative. If `memory_total` is present, `memory_free` must not exceed `memory_total`; corrupted samples that violate this consistency rule are ignored rather than contributing to the summary. For successful responses with samples, the invariant is:
+Memory values are bytes and must be nonnegative. `memory_free` is the required
+field for this aggregation. `memory_total` is optional and is used only when it
+is valid; if valid `memory_total` is present, `memory_free` must not exceed
+`memory_total`. Corrupted samples that violate this consistency rule are ignored
+rather than contributing to the summary. Invalid `memory_cached` or
+`memory_buffered` values are ignored field-by-field and must not cause a valid
+`memory_free` sample to be dropped. For successful responses with samples, the
+invariant is:
 
 ```text
 min_memfree <= avg_memfree <= max_memfree

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -8,10 +8,13 @@ This document defines the request format, response format, and implementation lo
 - `get_device_rssi_quality`
 - `get_gateway_offline_count`
 
-The specification is structured across three distinct component layers:
+This specification is structured across two in-scope component areas:
 1. **MCP Analytics Behavior Specification**: Intended HTTP requests, parameter validation, response envelopes, and ownership/error semantics for future MCP-facing Analytics handlers.
 2. **Persistence & Pipeline Architecture Design**: Internal storage structures (`device_availability_events`, `device_availability_state`, `device_availability_ingestion_checkpoint`, `device_availability_ingestion_gaps`), Kafka event consumption/ordering, and cutover semantics.
-3. **Test Specifications Matrix**: Independent verification matrix documented in `analytics_mcp_api_test_cases.md`.
+
+Follow-up deliverables:
+- OpenAPI contract/schema updates in `openapi/owanalytics.yaml`.
+- Independent test specification matrix in `analytics_mcp_api_test_cases.md`.
 
 > [!IMPORTANT]
 > This PR does not update `openapi/owanalytics.yaml` and does not publish a
@@ -22,7 +25,7 @@ The specification is structured across three distinct component layers:
 > `device_availability_ingestion_checkpoint`,
 > `device_availability_ingestion_gaps`), Kafka event ordering/checkpointing
 > rules, and cutover migration rules—constitute a production architecture
-> specification. Approving or merging this test specification PR does NOT bypass
+> specification. Approving or merging this behavior specification PR does NOT bypass
 > separate explicit architecture design sign-off for backend schema additions and
 > production Kafka pipeline changes prior to production deployment.
 
@@ -223,7 +226,7 @@ Handlers must load the monitoring configuration for the resolved router ownershi
 
 ```text
 monitoringDuration = configured monitoring retention duration
-retentionEnd = min(currentServerTime, monitoringConfigurationExpiry)
+retentionEnd = min(currentServerTime + allowedClockSkewSeconds, monitoringConfigurationExpiry)
 retentionStart = retentionEnd - monitoringDuration
 
 If monitoring has been enabled for less time than monitoringDuration:
@@ -231,6 +234,11 @@ If monitoring has been enabled for less time than monitoringDuration:
 ```
 
 Use the configured duration and effective retention timestamps instead of calendar assumptions so leap years, partial-year retention, recently enabled monitoring, and changed retention policies behave consistently.
+Use the same `currentServerTime + allowedClockSkewSeconds` upper bound for both
+future timestamp validation and retention validation. A `timestampTill` value
+inside the allowed skew window must not be rejected as
+`lookback_outside_retention` merely because it is later than
+`currentServerTime`, unless it also exceeds `monitoringConfigurationExpiry`.
 
 The requested half-open range must fit inside the configured retention window:
 
@@ -733,18 +741,23 @@ Do not represent missing memory fields as `0`. A missing `memory_free` value and
 
 ### Ingestion Logic
 
-Ingestion should preserve syntactically valid source telemetry and avoid
-analytics-specific semantic validation. Parse each memory field independently,
-persist fields that can be represented as nonnegative 64-bit integers, and omit
-only the malformed field. Do not apply cross-field checks such as
-`memory_free <= memory_total` during ingestion; those checks belong to the
-aggregation layer so raw telemetry remains available for troubleshooting.
+Ingestion should preserve syntactically and structurally valid source telemetry
+and avoid analytics-specific semantic validation. The typed memory resource
+model stores byte counts as unsigned values; negative memory values are
+structurally invalid for this ingestion contract and are omitted field-by-field,
+not preserved in `DeviceResourceTimePoint`. Parse each memory field
+independently, persist fields that can be represented as nonnegative 64-bit
+integers, and omit only the malformed or structurally invalid field. Do not
+apply cross-field checks such as `memory_free <= memory_total` during ingestion;
+those checks belong to the aggregation layer so source telemetry that is valid
+for the storage contract remains available for troubleshooting.
 
 ```cpp
 AnalyticsObjects::DeviceResourceTimePoint resource;
 
-// Validate numeric type, integral value, non-negative range (>= 0), and 64-bit non-overflow before unsigned conversion.
-// Field-level preservation policy: malformed free, total, cached, or buffered values are omitted independently.
+// Validate numeric type, integral value, non-negative byte-count range (>= 0), and 64-bit non-overflow before unsigned conversion.
+// Field-level preservation policy: malformed or structurally invalid free, total, cached, or buffered values are omitted independently.
+// Negative memory values are structurally invalid for this unsigned byte-count storage contract.
 // Do not apply analytics-specific semantic checks, such as free <= total, at ingestion time.
 auto parseMemoryField = [](const Poco::JSON::Object::Ptr &obj, const std::string &key) -> std::optional<uint64_t> {
     if (!obj->has(key) || obj->isNull(key)) return std::nullopt;
@@ -929,6 +942,26 @@ Do not synthesize a numeric fallback temperature for missing data.
 Do not store a placeholder in wifi_temp for a missing temperature.
 ```
 
+Zero-temperature sentinel source of truth:
+
+```text
+The source of truth for whether wifi_temp = 0 means unavailable is an explicit
+TelemetryTemperatureContract resolved at ingestion time from stable producer
+metadata, such as OWPROV inventory deviceType, gateway capabilities platform,
+firmware family, or an equivalent service-level contract registry.
+
+The resolved contract must expose:
+  wifiTempZeroIsUnavailable: boolean
+
+Persist either the resolved boolean on the radio temperature sample, for example
+radio_data[].wifi_temp_zero_is_unavailable, or persist a stable contract id that
+can be resolved later to the same boolean. Do not infer zero-sentinel behavior
+from the observed temperature value itself.
+
+If no producer/device contract can be resolved for a sample, the default is:
+  wifiTempZeroIsUnavailable = false
+```
+
 Migration boundary configuration & rule:
 
 ```text
@@ -989,7 +1022,7 @@ For each record:
   for each radio in radio_data:
     if radio.band is 2 or 5:
       if radio.wifi_temp is present, non-null, -40 <= radio.wifi_temp <= 125,
-         and (radio.wifi_temp != 0 or the producer/device contract does not define 0 as unavailable):
+         and (radio.wifi_temp != 0 or radio.wifi_temp_zero_is_unavailable is not true):
         add radio.wifi_temp to that band's sample list
 
 For each band:
@@ -1003,7 +1036,7 @@ A valid temperature sample is:
 ```text
 record timestamp is at or after temperatureMigrationCutoverTime
 radio.wifi_temp is present, non-null, and within range [-40, 125]
-radio.wifi_temp = 0 is excluded only when the producer/device contract defines 0 as unavailable
+radio.wifi_temp = 0 is excluded only when the persisted/resolved temperature contract has wifiTempZeroIsUnavailable = true
 ```
 
 If all samples for a band are invalid or missing, return `null` for that band's min, max, and average fields.

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -1971,7 +1971,6 @@ serialNumber          TEXT PRIMARY KEY
 board_id              TEXT NULL
 current_state         TEXT
 last_event_time       BIGINT
-last_idempotency_key  TEXT
 updated_at            BIGINT
 ```
 
@@ -1983,7 +1982,6 @@ Fields:
   board_id             TEXT NULL
   current_state        TEXT
   last_event_time      BIGINT
-  last_idempotency_key TEXT
   updated_at           BIGINT
 
 Indexes:
@@ -1991,7 +1989,7 @@ Indexes:
     board_id ASC
 
 Constraints:
-  current_state must be one of: online, offline, unknown
+  current_state IN ('online', 'offline', 'unknown')
 ```
 
 `device_availability_events` stores only online/offline transition history.
@@ -2003,7 +2001,6 @@ transition rows.
 ```text
 - the latest accepted availability state
 - the latest accepted source event timestamp
-- the latest logical event identity for idempotency
 - optional current board context
 - the state row update timestamp
 ```
@@ -2017,6 +2014,19 @@ consumed in Kafka partition order for the gateway. It must be populated from the
 normalized Kafka source timestamp (`event_time`). `DeviceInfo.lastContact` may
 remain local contact or processing metadata, but it must not be used to order
 source events.
+
+Availability ingestion responsibilities are separated as follows:
+
+```text
+device_availability_state.last_event_time
+  -> replay/non-advancing detection at state level
+
+device_availability_events.idempotency_key UNIQUE
+  -> storage-level duplicate transition protection
+
+Kafka committed offset
+  -> ingestion progress and replay position
+```
 
 Do not add Analytics-owned ingestion progress or durable data-loss tables for availability.
 
@@ -2042,14 +2052,14 @@ Kafka message received
 normalize and validate event
 BEGIN database transaction
 lock/load device_availability_state for serialNumber
-validate idempotency and event_time
+validate event_time
 insert device_availability_events only on a real state transition
 update device_availability_state
 COMMIT database transaction
 commit Kafka offset
 ```
 
-This is an at-least-once processing contract. The Kafka offset must not be committed before the database transaction succeeds. If the service crashes before the database commit, Kafka replays the message after restart. If the service crashes after the database commit but before the Kafka offset commit, Kafka may redeliver the message and storage-level idempotency must make the replay harmless. Kafka auto-commit must not acknowledge messages ahead of successful database commits.
+This is an at-least-once processing contract. The Kafka offset must not be committed before the database transaction succeeds. If the service crashes before the database commit, Kafka replays the message after restart. If the service crashes after the database commit but before the Kafka offset commit, Kafka may redeliver the message; the `event_time` check must make replay non-advancing, and the unique `device_availability_events.idempotency_key` constraint remains a safety net for duplicate transition inserts. Kafka auto-commit must not acknowledge messages ahead of successful database commits.
 
 Availability transition processing must preserve Kafka partition order. The
 default implementation should process messages from one Kafka partition
@@ -2079,7 +2089,7 @@ Restart and rebalance recovery must use the stable Kafka consumer group:
 2. Kafka resumes from the last committed offset for assigned partitions
 3. messages after that offset are replayed
 4. Analytics loads device_availability_state for each serialNumber as messages arrive
-5. idempotency and event_time checks prevent duplicate transition rows
+5. event_time checks prevent duplicate transition rows; event-table idempotency remains a storage safety net
 6. processing continues and offsets are committed only after DB commit
 ```
 
@@ -2095,7 +2105,8 @@ consumer rejoins the same consumer group
 Kafka resumes from the last committed position
 offset 102 may be replayed
 device_availability_state already reflects offset 102
-device_availability_events idempotency prevents a duplicate transition row
+event_time == last_event_time makes the replay a duplicate/non-advancing no-op
+device_availability_events idempotency remains a storage safety net if a duplicate transition insert is attempted
 offset 102 is committed after the replay transaction succeeds or no-ops safely
 consumer continues with offset 103
 ```
@@ -2155,7 +2166,6 @@ Kafka:
 Analytics ingestion:
   restart-safe current availability state
   latest accepted event_time
-  idempotency
   transition detection
   idempotent transition persistence
 
@@ -2240,6 +2250,20 @@ Ingestion-time board source:
 
 The ingestion path must not depend on HTTP request-time `ResolveRouterIdContext`. That resolver can use OWPROV to verify or refresh ownership for API requests, but Kafka connection ingestion should use the maintained `VenueCoordinator` ownership map and tolerate missing current board ownership.
 
+For `device_availability_state`, `board_id` is current ownership/context only.
+For every accepted source-newer event and every bootstrap state row:
+
+```text
+if VenueCoordinator has a current mapping:
+  state.board_id = mapped boardId
+else:
+  state.board_id = NULL
+```
+
+Do not keep a previous state-table `board_id` when the current map has no
+mapping. `device_availability_events.board_id` remains historical event-time
+context.
+
 Rules:
 
 ```text
@@ -2258,22 +2282,26 @@ Bootstrap rule when no `device_availability_state` row exists:
 First observed disconnection:
   insert state row with current_state = offline
   set last_event_time = event_time
-  set last_idempotency_key = idempotency_key
+  set board_id from the current VenueCoordinator mapping, or NULL when absent
+  set updated_at
   do not insert an offline transition event because the prior state is unknown
 
 First observed ping/capabilities:
   insert state row with current_state = online
   set last_event_time = event_time
-  set last_idempotency_key = idempotency_key
+  set board_id from the current VenueCoordinator mapping, or NULL when absent
+  set updated_at
   do not insert an online transition event
 
 First observed unrecognized connection message:
   insert or update state row with current_state = unknown only when useful
   set last_event_time only from a valid source timestamp
+  set board_id from the current VenueCoordinator mapping, or NULL when absent
+  set updated_at
   do not insert a counted event
 ```
 
-In-memory transition checking is only an optimization. It is not sufficient for correctness because Kafka can redeliver messages and the service can restart after losing in-memory state. Transition detection must use `device_availability_state.current_state` and `device_availability_state.last_event_time` under the same transaction before writing `device_availability_events`. Duplicate connection messages must be rejected by `event_time` validation and storage-level idempotency before they can affect `offline_count`.
+In-memory transition checking is only an optimization. It is not sufficient for correctness because Kafka can redeliver messages and the service can restart after losing in-memory state. Transition detection must use `device_availability_state.current_state` and `device_availability_state.last_event_time` under the same transaction before writing `device_availability_events`. Duplicate connection messages must be rejected by `event_time` validation before they can affect `offline_count`; the event-table idempotency constraint remains a storage safety net for duplicate transition inserts.
 
 Normalize connection messages before transition processing:
 
@@ -2425,8 +2453,21 @@ If a message has `event_time == last_event_time`, treat it as duplicate or
 non-advancing, do not create a transition, and do not move state. Equal source
 timestamps are not expected during normal operation.
 
-`last_idempotency_key` is retained for Kafka redelivery/idempotency protection.
-It must not participate in source-event ordering.
+Under the producer contract, the same `serialNumber` and `event_time` identifies
+a duplicate or replay. `device_availability_state` does not store an
+idempotency key. Keep the unique `idempotency_key` on
+`device_availability_events` as a database safety net for persisted
+transitions.
+
+Before a source-newer event updates `device_availability_state`, resolve
+`stateBoardId` from the current VenueCoordinator map:
+
+```text
+if current mapping exists:
+  stateBoardId = mapped boardId
+else:
+  stateBoardId = NULL
+```
 
 If the source topic violates serialNumber keying, per-serial source-event order,
 or strictly increasing per-serial `event_time`, treat that as a producer/topic
@@ -2454,8 +2495,7 @@ For each valid connection message consumed in Kafka partition order:
     if another transaction created the state row first, re-read it and continue
     otherwise initialize current_state from incomingState
     set last_event_time = event_time
-    set last_idempotency_key = idempotency_key
-    set board_id when known
+    set board_id = stateBoardId
     set updated_at
     do not insert an initial transition event
     COMMIT
@@ -2484,16 +2524,15 @@ For each valid connection message consumed in Kafka partition order:
         update device_availability_state:
           current_state = online
           last_event_time = event_time
-          last_idempotency_key = idempotency_key
           updated_at = processing time
-          board_id = boardId when known
+          board_id = stateBoardId
       else:
         treat as duplicate and do not update state
     else if current_state is online:
-      update device_availability_state last_event_time, last_idempotency_key, updated_at, and board_id when known
+      update device_availability_state last_event_time, updated_at, and board_id = stateBoardId
       do not insert a transition event
     else:
-      update device_availability_state to online, last_event_time, last_idempotency_key, updated_at, and board_id when known
+      update device_availability_state to online, last_event_time, updated_at, and board_id = stateBoardId
       do not insert an initial online transition event
 
   if incomingState is offline:
@@ -2503,16 +2542,15 @@ For each valid connection message consumed in Kafka partition order:
         update device_availability_state:
           current_state = offline
           last_event_time = event_time
-          last_idempotency_key = idempotency_key
           updated_at = processing time
-          board_id = boardId when known
+          board_id = stateBoardId
       else:
         treat as duplicate and do not update state
     else if current_state is offline:
-      update device_availability_state last_event_time, last_idempotency_key, updated_at, and board_id when known
+      update device_availability_state last_event_time, updated_at, and board_id = stateBoardId
       do not insert a transition event
     else:
-      update device_availability_state to offline, last_event_time, last_idempotency_key, updated_at, and board_id when known
+      update device_availability_state to offline, last_event_time, updated_at, and board_id = stateBoardId
       do not insert an initial offline transition event because the prior state is unknown
 
   COMMIT
@@ -2541,17 +2579,15 @@ Atomically create or lock the device_availability_state row for :serialNumber.
 Read:
   current_state
   last_event_time
-  last_idempotency_key
 
--- Validate event_time and idempotency, then determine whether state changed.
+-- Validate event_time, then determine whether state changed.
 -- Insert into device_availability_events only if state changed.
 
-Update device_availability_state only when event_time and idempotency checks allow it:
+Update device_availability_state only when event_time checks allow it:
   current_state = :newState
   last_event_time = :eventTime
-  last_idempotency_key = :idempotencyKey
   updated_at = :processingTime
-  board_id = :boardId when known, otherwise keep existing or NULL according to board-context policy
+  board_id = :stateBoardId, where stateBoardId is the current VenueCoordinator mapping or NULL
 
 COMMIT;
 ```
@@ -2564,9 +2600,8 @@ An event is stale when `event_time < last_event_time`.
 An event is duplicate or non-advancing when `event_time == last_event_time`.
 
 Stale, duplicate, and non-advancing events must not insert counted availability
-events and must not update device_availability_state, even if their
-idempotency_key has not been seen before. The equal timestamp case is defensive
-only and is not expected during normal operation.
+events and must not update device_availability_state. The equal timestamp case
+is defensive only and is not expected during normal operation.
 ```
 
 ### Store Only State Transitions
@@ -2584,22 +2619,22 @@ Incorrect:
 every ping → store online event
 ```
 
-Every ping should not be treated as a new online transition. However, every source-newer ping that is accepted after Kafka partition-ordered consumption must still update `device_availability_state.last_event_time`, `last_idempotency_key`, `updated_at`, and `board_id` when known.
+Every ping should not be treated as a new online transition. However, every source-newer ping that is accepted after Kafka partition-ordered consumption must still update `device_availability_state.last_event_time`, `updated_at`, and `board_id` from the current VenueCoordinator mapping or `NULL`.
 
 Ping handling:
 
 ```text
-current_state=online  + ping -> update last_event_time, last_idempotency_key, updated_at, and board_id when known; do not insert a transition event
-current_state=offline + ping after a prior offline state -> insert online event, set current_state=online, update last_event_time, last_idempotency_key, updated_at, and board_id when known
-no state row + ping -> create current_state=online, update last_event_time, last_idempotency_key, updated_at, and board_id when known; do not insert an online event
+current_state=online  + ping -> update last_event_time, updated_at, and board_id from the current map or NULL; do not insert a transition event
+current_state=offline + ping after a prior offline state -> insert online event, set current_state=online, update last_event_time, updated_at, and board_id from the current map or NULL
+no state row + ping -> create current_state=online, update last_event_time, updated_at, and board_id from the current map or NULL; do not insert an online event
 ```
 
 Disconnection handling:
 
 ```text
-current_state=online  + disconnection -> insert offline event, set current_state=offline, update last_event_time, last_idempotency_key, updated_at, and board_id when known
-current_state=offline + disconnection -> update last_event_time, last_idempotency_key, updated_at, and board_id when known; do not insert another offline event
-no state row + disconnection -> create current_state=offline, update last_event_time, last_idempotency_key, updated_at, and board_id when known; do not insert an offline transition event
+current_state=online  + disconnection -> insert offline event, set current_state=offline, update last_event_time, updated_at, and board_id from the current map or NULL
+current_state=offline + disconnection -> update last_event_time, updated_at, and board_id from the current map or NULL; do not insert another offline event
+no state row + disconnection -> create current_state=offline, update last_event_time, updated_at, and board_id from the current map or NULL; do not insert an offline transition event
 ```
 
 Example:
@@ -2627,7 +2662,7 @@ producer-contract issue; do not model it with Analytics ingestion-progress or da
 Review conclusion:
 
 ```text
-The implementation requires `device_availability_state` unless a future design explicitly names an existing persistent table with the same fields and locking guarantees. `last_event_time` must be updated for every source-newer ping, capabilities, or disconnection message accepted after Kafka partition-ordered consumption, even when no availability transition event is inserted. `last_idempotency_key` must be retained for Kafka redelivery/idempotency protection. `DeviceInfo.lastContact` remains contact/processing metadata and is not the source-event ordering field.
+The implementation requires `device_availability_state` unless a future design explicitly names an existing persistent table with the same fields and locking guarantees. `last_event_time` must be updated for every source-newer ping, capabilities, or disconnection message accepted after Kafka partition-ordered consumption, even when no availability transition event is inserted. `board_id` must be set from the current VenueCoordinator mapping or NULL on every accepted source-newer state update. `DeviceInfo.lastContact` remains contact/processing metadata and is not the source-event ordering field.
 ```
 
 ### Calculation
@@ -2726,7 +2761,7 @@ offline_count = 2
 observedWindow = [12:15, 13:20]
 ```
 
-Delayed Kafka message example:
+Kafka consumer lag example:
 
 ```text
 12:00 ping
@@ -2791,8 +2826,9 @@ Use an HTTP error:
 A zero result means no persisted offline transition was observed in the
 requested post-cutover interval based on the data currently available in
 Analytics storage. It does not make claims about outages not yet observed,
-delayed messages, or Kafka consumer position. Kafka consumer lag is operational
-state and is not represented as availability-domain response metadata.
+unconsumed messages, or Kafka consumer position. Kafka consumer lag is
+operational state and is not represented as availability-domain response
+metadata.
 
 `offlineEventCount` is the number of offline transition rows in
 `device_availability_events` that contribute to `offline_count`. Online recovery

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -756,29 +756,38 @@ Do not represent missing memory fields as `0`. A missing `memory_free` value and
 
 Ingestion should preserve syntactically and structurally valid source telemetry
 and avoid analytics-specific semantic validation. The typed memory resource
-model stores byte counts as unsigned values; negative memory values are
-structurally invalid for this ingestion contract and are omitted field-by-field,
-not preserved in `DeviceResourceTimePoint`. Parse each memory field
-independently, persist fields that can be represented as nonnegative 64-bit
-integers, and omit only the malformed or structurally invalid field. Do not
-apply cross-field checks such as `memory_free <= memory_total` during ingestion;
-those checks belong to the aggregation layer so source telemetry that is valid
-for the storage contract remains available for troubleshooting.
+model stores byte counts as unsigned values. The accepted range for each memory
+field is:
+
+```text
+0 <= memory_value <= UINT64_MAX
+```
+
+Negative memory values, fractional values, nonnumeric values, and values that
+overflow `uint64_t` are structurally invalid for this ingestion contract and are
+omitted field-by-field, not preserved in `DeviceResourceTimePoint`. Parse each
+memory field independently, persist fields that can be represented as unsigned
+64-bit integers, and omit only the malformed or structurally invalid field. Do
+not apply cross-field checks such as `memory_free <= memory_total` during
+ingestion; those checks belong to the aggregation layer so source telemetry that
+is valid for the storage contract remains available for troubleshooting.
 
 ```cpp
 AnalyticsObjects::DeviceResourceTimePoint resource;
 
-// Validate numeric type, integral value, non-negative byte-count range (>= 0), and 64-bit non-overflow before unsigned conversion.
+// Validate numeric type, integral value, byte-count range (0..UINT64_MAX), and unsigned 64-bit non-overflow before conversion.
 // Field-level preservation policy: malformed or structurally invalid free, total, cached, or buffered values are omitted independently.
-// Negative memory values are structurally invalid for this unsigned byte-count storage contract.
+// Negative, fractional, nonnumeric, and uint64_t-overflowing values are structurally invalid for this unsigned byte-count storage contract.
 // Do not apply analytics-specific semantic checks, such as free <= total, at ingestion time.
 auto parseMemoryField = [](const Poco::JSON::Object::Ptr &obj, const std::string &key) -> std::optional<uint64_t> {
     if (!obj->has(key) || obj->isNull(key)) return std::nullopt;
     try {
-        if (!obj->isNumeric(key)) return std::nullopt;
-        int64_t val = obj->getElement<int64_t>(key);
-        if (val < 0) return std::nullopt;
-        return static_cast<uint64_t>(val);
+        Poco::Dynamic::Var raw = obj->get(key);
+        if (!raw.isNumeric() || !raw.isInteger()) return std::nullopt;
+
+        uint64_t val = 0;
+        raw.convert(val); // Throws on negative values and overflow.
+        return val;
     } catch (...) {
         return std::nullopt;
     }
@@ -832,12 +841,13 @@ Return:
   observedWindow.endTime = latest timestamp of a memory_free sample contributing to the aggregation
 ```
 
-Memory values are bytes and must be nonnegative. If both `memory_free` and valid
-`memory_total` are present, `memory_free` must not exceed `memory_total`.
-Samples that violate this consistency rule are ignored rather than contributing
-to the summary. Invalid or missing `memory_cached` or `memory_buffered` values
-are ignored field-by-field and must not cause a valid `memory_free` sample to be
-dropped. For successful responses with samples, the invariant is:
+Memory values are bytes and must satisfy `0 <= memory_value <= UINT64_MAX`.
+If both `memory_free` and valid `memory_total` are present, `memory_free` must
+not exceed `memory_total`. Samples that violate this consistency rule are
+ignored rather than contributing to the summary. Invalid or missing
+`memory_cached` or `memory_buffered` values are ignored field-by-field and must
+not cause a valid `memory_free` sample to be dropped. For successful responses
+with samples, the invariant is:
 
 ```text
 min_memfree <= avg_memfree <= max_memfree
@@ -2222,7 +2232,19 @@ src/StorageService.cpp
   include availability retention cleanup if retention should match board timepoint cleanup
 ```
 
-Add a DB upgrade/migration path for the new tables. Existing deployments will start with no historical availability events. Define a fixed `availabilityValidFrom` timestamp as the deployment/migration time when availability-event persistence starts. The API should return `offline_count: 0` for successful empty queries whose requested range starts at or after `availabilityValidFrom`; do not infer old events from `lastDisconnection`.
+Add a DB upgrade/migration path for the new tables. Existing deployments will
+start with no historical availability events. Initialize a fixed
+`availabilityValidFrom` timestamp when availability-event persistence starts and
+persist it as `system_properties.availability_valid_from`. The API should return
+`offline_count: 0` for successful empty queries whose requested range starts at
+or after the persisted `availabilityValidFrom`; do not infer old events from
+`lastDisconnection`.
+
+`availabilityValidFrom` represents the timestamp from which this Analytics
+database can reliably claim that availability transition persistence was active.
+Once initialized, the persisted `system_properties` value is authoritative.
+Changing an environment variable or config file must not silently change the
+historical validity boundary.
 
 Add all availability storage files to `CMakeLists.txt`, including `storage_device_availability_events.*` and `storage_device_availability_state.*`. Register database migration/upgrade logic for these availability tables so fresh databases and upgraded deployments create the event table, state table, indexes, uniqueness constraints, and state constraints consistently.
 
@@ -2685,12 +2707,74 @@ source event for the interval has been ingested.
 Availability migration boundary:
 
 ```text
-availabilityValidFrom is a durable, deployment-wide timestamp loaded on service startup from:
-  1. Configuration file property `availability_valid_from` (in /etc/ucentral/owanalytics.json)
-  2. Environment variable `ANALYTICS_AVAILABILITY_VALID_FROM`
-  3. Persistent database migration metadata table (`system_properties` key `availability_valid_from`) populated during initial table creation.
+availabilityValidFrom is a durable, deployment-wide cutover timestamp for
+availability history. It represents the timestamp from which this Analytics
+database can reliably claim that availability transition persistence was active.
 
-All service replicas and process restarts MUST load the identical `availabilityValidFrom` timestamp from these durable configuration/DB sources to guarantee multi-replica and restart consistency. Dynamic process-start timestamps (e.g. std::chrono::system_clock::now() at startup) are strictly prohibited.
+The authoritative persisted source of truth is:
+  system_properties.availability_valid_from
+
+Configuration and environment values are first-time initialization inputs only.
+They are not equivalent runtime sources once the database property exists.
+Changing an environment variable or config file must not silently change the
+historical validity boundary.
+
+Initialization input precedence, used only when
+system_properties.availability_valid_from does not already exist:
+  ANALYTICS_AVAILABILITY_VALID_FROM
+    overrides
+  availability_valid_from from /etc/ucentral/owanalytics.json
+
+On service startup:
+  rawEnvValue =
+      ANALYTICS_AVAILABILITY_VALID_FROM if present, else unset
+
+  rawConfigValue =
+      availability_valid_from from /etc/ucentral/owanalytics.json if present,
+      else unset
+
+  persistedValue =
+      read system_properties.availability_valid_from
+
+  if persistedValue exists:
+      availabilityValidFrom = persistedValue
+
+      for each supplied rawEnvValue and rawConfigValue:
+          configuredValue = parse supplied value
+          if configuredValue is invalid:
+              fail startup with a clear invalid-configuration error
+
+          if configuredValue != persistedValue:
+              fail startup with a clear configuration-mismatch error:
+                availability_valid_from configuration mismatch:
+                configured value does not match persisted
+                system_properties.availability_valid_from
+
+  else:
+      rawConfiguredValue =
+          rawEnvValue if set
+          else rawConfigValue if set
+          else unset
+
+      if rawConfiguredValue is unset:
+          fail startup with a clear missing-configuration error
+
+      configuredValue = parse rawConfiguredValue
+      if configuredValue is invalid:
+          fail startup with a clear invalid-configuration error
+
+      insert system_properties.availability_valid_from = configuredValue
+      availabilityValidFrom = configuredValue
+
+      if another replica concurrently inserted the property first:
+          re-read system_properties.availability_valid_from
+          apply the persistedValue-exists mismatch checks above
+
+The persisted value must never be silently overwritten during a normal restart
+or deployment. All service replicas and process restarts MUST use the identical
+persisted system_properties.availability_valid_from timestamp to guarantee
+multi-replica and restart consistency. Dynamic process-start timestamps
+(e.g. std::chrono::system_clock::now() at startup) are strictly prohibited.
 
 If startTime < availabilityValidFrom:
   reject the request

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -2135,9 +2135,16 @@ offline transition events contribute, both `observedWindow.startTime` and
 `observedWindow.endTime` are `null`. The response does not report Kafka consumer
 progress or lag as availability-domain data.
 
+The `availability-summary` endpoint is an observed-data API. It reports the
+availability transition rows currently persisted in Analytics storage at request
+time. It does not prove that Kafka has delivered every possible source event,
+that the consumer is caught up, that no delayed message exists, or that the
+requested interval is ingestion-complete.
+
 ## API Logic
 
-This API can use gateway events from the existing `connection` topic.
+Availability ingestion uses gateway events from the existing `connection` topic.
+The REST API query path reads only Analytics storage.
 
 Analytics currently handles gateway-level events:
 
@@ -2274,7 +2281,15 @@ Constraints:
   current_state must be one of: online, offline, unknown
 ```
 
-`device_availability_events` stores only online/offline transition history. `device_availability_state` stores the authoritative current state and the latest accepted source availability ordering key.
+`device_availability_events` stores only online/offline transition history.
+Historical availability queries read this table and count persisted offline
+transition rows.
+
+`device_availability_state` is used during ingestion. It stores the latest
+accepted current state and source availability ordering key, supports
+restart-safe transition detection, and prevents repeated ping or disconnection
+messages from generating duplicate transitions. The REST handler must not derive
+historical availability counts from `device_availability_state`.
 
 `last_event_time` and `last_source_sequence` form the persisted source ordering key after events have been consumed in Kafka partition order for the gateway. `last_event_time` must be populated from the normalized Kafka source timestamp (`event_time`), and `last_source_sequence` must be populated from a reliable source sequence, source offset within the producing system, or another deterministic 64-bit numeric value (`BIGINT`) when one exists. `source_sequence` and `last_source_sequence` are stored as `BIGINT NULL` so SQL and application-layer index and comparator operations preserve numeric order (`10 > 2`). The composite key is used for duplicate detection, stale-event protection, same-timestamp ordering, and defensive validation. `DeviceInfo.lastContact` may remain local contact or processing metadata, but it must not be used to order source events because Kafka delivery can be delayed.
 
@@ -2341,6 +2356,12 @@ Normal Kafka lag is not an Analytics data gap. If the producer is at offset 5000
 
 Exceptional Kafka data-loss conditions are operational incidents, not normal availability-domain state. Examples include Kafka retention expiring before the consumer caught up, a topic being deleted or recreated, or offsets being manually reset past unprocessed data. Log, alert, and metric these conditions. Do not introduce Analytics-owned durable data-loss records unless a separate product requirement explicitly calls for historical completeness auditing.
 
+Kafka operational monitoring may expose consumer lag, offset positions, replay
+activity, retention incidents, and consumer-group health through Kafka metrics,
+Prometheus metrics, service dashboards, logs, alerts, or consumer-group
+monitoring. Those signals are separate from the availability-domain API
+contract.
+
 Final availability ingestion architecture:
 
 ```text
@@ -2368,6 +2389,47 @@ device_availability_state   device_availability_events
                          |
                          v
                 commit Kafka offset
+```
+
+Final responsibility split:
+
+```text
+Kafka:
+  reliable delivery/replay according to Kafka's normal consumer-group semantics
+  restart handling
+  offset management
+  lag monitoring
+
+Analytics ingestion:
+  current availability state
+  idempotent transition persistence
+
+Analytics API:
+  query currently persisted transition history
+  count persisted offline events
+  report observedWindow for those persisted events
+```
+
+The key API principle is:
+
+```text
+The availability API reports what Analytics has observed and persisted.
+It does not prove what Analytics has not yet received.
+```
+
+Explicitly out of scope for `availability-summary`:
+
+```text
+strong read-after-Kafka-ingestion consistency
+zero-lag guarantees
+source-to-API delivery SLA
+Kafka consumer freshness validation
+historical ingestion-completeness proof
+availability coverage proof
+durable gap persistence
+durable checkpoint persistence
+waiting for Kafka catch-up before answering
+high availability across Kafka/DB failure scenarios
 ```
 
 Add a `DeviceAvailabilityEvent` REST/storage object with `to_json` and `from_json` support in:
@@ -2588,15 +2650,19 @@ The producer must publish messages for one serialNumber in source-event order.
 Kafka partition ordering is then the primary ordering guarantee for all
 availability events belonging to one gateway.
 
+Connection messages are expected at intervals of approximately five seconds or
+more, so equal source event timestamps are not expected during normal operation
+when timestamp precision is at least seconds.
+
 Source timestamps and source sequences remain useful for duplicate detection,
 stale-event protection, same-timestamp ordering, and defensive validation. They
 must not be used to build a second durable Analytics ingestion watermark.
 
 If the source topic cannot provide serialNumber keying and producer-side
-per-serial ordering, Kafka alone cannot guarantee exact transition history for
-that gateway. Treat that as a producer/topic contract violation or a separate
-architecture requirement; do not add an Analytics PostgreSQL ingestion-progress or data-loss
-tracking system to compensate.
+per-serial ordering, Kafka alone cannot guarantee correctly ordered transition
+history for that gateway. Treat that as a producer/topic contract violation or a
+separate architecture requirement; do not add an Analytics PostgreSQL
+ingestion-progress or data-loss tracking system to compensate.
 ```
 
 Atomic transition and insert rule:
@@ -2748,13 +2814,14 @@ Stale or non-advancing events must not insert counted availability events and mu
 not update device_availability_state, even if their idempotency_key has not been
 seen before.
 
-Two different logical events with the same `event_time` must be ordered by a
-deterministic 64-bit numeric `source_sequence` (`BIGINT`). Exact Kafka redelivery
-should be identified by the idempotency key. If two different logical events share
-the same `event_time` and lack comparable non-null source sequences, or have identical
-source sequences, Analytics cannot deterministically order them. Log and metric
-the ambiguity, do not insert a counted transition for the ambiguous message, and
-do not create an Analytics ingestion-progress or data-loss table.
+Equal source timestamps are defensive edge cases, not the foundation of the
+availability architecture. Exact Kafka redelivery should be identified by the
+idempotency key. If two different logical events share the same `event_time`, use
+a reliable deterministic 64-bit numeric `source_sequence` (`BIGINT`) when one
+exists. If no reliable source sequence exists, log and metric the producer/source
+anomaly and apply the documented defensive policy for ambiguous duplicate-source
+data. Do not create an Analytics ingestion-progress or data-loss table for this
+edge case.
 ```
 
 ### Store Only State Transitions
@@ -2834,8 +2901,18 @@ The implementation requires `device_availability_state` unless a future design e
 
 ```text
 offline_count =
-    COUNT(event_type = 'offline')
+    count(
+      device_availability_events
+      where serialNumber = routerId
+      and event_type = 'offline'
+      and event_time >= startTime
+      and event_time < endTime
+    )
 ```
+
+`offline_count` is the number of persisted offline transition rows currently
+observed by Analytics for the requested interval. It is not proof that every
+source event for the interval has been ingested.
 
 Availability migration boundary:
 
@@ -2871,6 +2948,74 @@ WHERE serialNumber = :router_id
 ```
 
 Do not require `board_id = :resolvedBoardId` for the availability count. `board_id` is nullable event-time context and can differ from the router's current board after reassignment. The durable query identity for gateway availability history is `serialNumber`.
+
+The availability REST request path must not call Kafka, compare committed
+offsets to partition high watermarks, inspect consumer lag, wait for the
+consumer to catch up, or validate ingestion freshness. Kafka offset state is
+operational state, not API response data.
+
+Final availability query flow:
+
+```text
+Authenticate request
+validate routerId, timestampTill, and lookbackHours
+resolve router ownership
+validate retention and availabilityValidFrom
+query device_availability_events for serialNumber and [startTime, endTime)
+filter event_type = offline
+offline_count = number of persisted matching rows
+derive observedWindow from matching persisted offline rows
+return response
+```
+
+`observedWindow` for availability is derived only from persisted offline
+transition rows contributing to `offline_count`:
+
+```text
+observedWindow.startTime =
+  earliest persisted offline transition event_time contributing to offline_count
+
+observedWindow.endTime =
+  latest persisted offline transition event_time contributing to offline_count
+```
+
+Do not set `observedWindow` to the requested range merely because the query
+covers that range. It reflects observed persisted transition events, not
+ingestion coverage.
+
+Example:
+
+```text
+requestedWindow = [12:00, 14:00)
+persisted offline transition event_time values = [12:15, 13:20]
+
+offline_count = 2
+observedWindow = [12:15, 13:20]
+```
+
+Delayed Kafka message example:
+
+```text
+12:00 ping
+12:05 offline
+12:10 online
+12:20 offline event exists upstream but has not yet been consumed
+
+API request at 12:21:
+  persisted offline rows = [12:05]
+  offline_count = 1
+  observedWindow = [12:05, 12:05]
+
+Later, Kafka consumer processes the 12:20 event.
+
+Same historical API request:
+  persisted offline rows = [12:05, 12:20]
+  offline_count = 2
+  observedWindow = [12:05, 12:20]
+```
+
+Both responses are valid because the API reports the persisted observations
+available at request time.
 
 ### Range Before Availability Cutover
 
@@ -2910,8 +3055,11 @@ Use an HTTP error:
 }
 ```
 
-A zero result means no offline transition rows are currently persisted for the
-requested post-cutover interval. Kafka consumer lag is operational state and is
+A zero result means no persisted offline transition was observed in the
+requested post-cutover interval based on the data currently available in
+Analytics storage. It does not mean no outage definitely occurred, Kafka is
+fully consumed through `endTime`, all producer events have reached Analytics, or
+there are no delayed messages. Kafka consumer lag is operational state and is
 not represented as availability-domain response metadata.
 
 `offlineEventCount` is the number of offline transition rows in

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -8,6 +8,14 @@ This document defines the request format, response format, and implementation lo
 - `get_device_rssi_quality`
 - `get_gateway_offline_count`
 
+The specification is structured across three distinct component layers:
+1. **Public API Contract Specifications**: External OpenAPI schemas (`openapi/owanalytics.yaml`) defining HTTP requests, parameter validation, and response envelopes.
+2. **Persistence & Pipeline Architecture Design**: Internal storage structures (`device_availability_events`, `device_availability_state`, `device_availability_ingestion_checkpoint`, `device_availability_ingestion_gaps`), Kafka event consumption/ordering, and cutover semantics.
+3. **Test Specifications Matrix**: Independent verification matrix documented in `analytics_mcp_api_test_cases.md`.
+
+> [!IMPORTANT]
+> The specified production architecture changes—including four new availability persistence structures (`device_availability_events`, `device_availability_state`, `device_availability_ingestion_checkpoint`, `device_availability_ingestion_gaps`), Kafka event ordering/checkpointing rules, cutover migration rules, and OpenAPI v2.7.0 endpoint schemas—constitute a production architecture specification. Approving or merging this test specification PR does NOT bypass separate explicit architecture design sign-off for backend schema additions and production Kafka pipeline changes prior to production deployment.
+
 The API contracts match the MCP tool names and response fields from the provided CSV.
 
 ---
@@ -32,12 +40,42 @@ Internal storage field: serialNumber
 serialNumber = routerId
 ```
 
-The Analytics API should calculate the requested time range as:
+Public `routerId` validation requires a path-safe string: 1 to 64 alphanumeric characters, hyphens, or underscores (matching `^[a-zA-Z0-9_-]+$`). Syntax validation intentionally rejects path dot-segments such as `.` and `..`, path separators (`/`, `\`), spaces, control characters, and URL-encoded path separators (`%2F`) before OWPROV ownership resolution. Any path-safe serial format (whether hexadecimal or non-hex serial string) passes syntax validation and is sent to OWPROV, letting OWPROV serve as the authoritative entity for verifying serial existence.
+
+The Analytics API calculates the requested time range using checked 64-bit signed epoch arithmetic:
 
 ```text
 end_time = parse(timestamp_till)
 start_time = end_time - (lookback_hours * 3600)
 ```
+
+Validation & Processing Order:
+
+All REST handlers must enforce request validation in four distinct sequential phases:
+
+0. **Phase 0: Request Authentication (Bearer Token)**
+   - Extract and validate HTTP `Authorization` header (`Bearer <token>`).
+   - If missing, malformed, expired, or invalid: return HTTP `401 Unauthorized` (`error: "unauthorized"`) immediately.
+   - Authentication takes precedence over parameter validation; unauthenticated callers receive HTTP `401 Unauthorized` regardless of whether `routerId`, `timestampTill`, or `lookbackHours` are malformed, missing, or invalid.
+
+1. **Phase 1: Pure Request Parsing & Input Validation (No DB or I/O lookups)**
+   - Validate `routerId` syntax (1–64 characters matching `^[a-zA-Z0-9_-]+$`) -> HTTP `400 invalid_router_id` if malformed.
+   - Inspect raw query collection for exact-once presence of `timestampTill` and `lookbackHours` -> HTTP `400 invalid_timestamp` / `invalid_lookback_hours` if missing or repeated.
+   - Parse `timestampTill` shape & UTC semantics -> HTTP `400 invalid_timestamp` if malformed or invalid date/time.
+   - Parse `lookbackHours` strict positive integer -> HTTP `400 invalid_lookback_hours` if zero, negative, or non-numeric.
+   - Checked epoch calculation: Compute `start_time = end_time - (lookback_hours * 3600)` using signed 64-bit integers. Verify `start_time >= 0` (minimum supported Unix epoch `1970-01-01T00:00:00Z`) -> HTTP `400 invalid_timestamp` if underflowing before epoch.
+
+2. **Phase 2: Router Ownership & Serial Resolution**
+   - Resolve `routerId` to `boardId` via local cache / OWPROV -> HTTP `404 not_found` if router serial does not exist in OWPROV.
+   - Load router scope monitoring configuration (`monitoringDuration`) to derive `maxLookbackHours = floor(monitoringDuration / 3600)`.
+
+3. **Phase 3: Duration, Retention & Endpoint Cutover Validation**
+   - Validate duration against scope maximum (all endpoints): `lookbackHours > maxLookbackHours` -> HTTP `400 invalid_lookback_hours`.
+   - Validate requested range against data retention window (all endpoints): requested window outside retention -> HTTP `400 lookback_outside_retention`.
+   - Validate endpoint-specific domain cutover thresholds:
+     - `radio-temperature-summary` endpoint only: `start_time < temperatureMigrationCutoverTime` -> HTTP `400 temperature_range_before_cutover`.
+     - `availability-summary` endpoint only: `start_time < availabilityValidFrom` -> HTTP `400 availability_range_before_cutover`.
+     - `memory-summary`, `rssi-summary`, and `bandwidth-consumption` endpoints: no domain cutover validation unless explicitly defined by that endpoint.
 
 Example:
 
@@ -58,20 +96,77 @@ Recommended query parameters:
 
 These are `GET` APIs, so no request body is required.
 
-### Time Conversion and Validation
+### Internal Retrieval Categories
 
-The public MCP-facing parameters use ISO-8601/RFC3339 time, but the existing Analytics API style uses integer `fromDate` and `endDate` timestamps. Handlers should convert the request as:
+Retrieval behavior is intrinsic to each endpoint. Do not expose a public
+`metricMode` query parameter unless the endpoint also defines separate
+mode-specific response schemas.
+
+Endpoint retrieval mapping:
 
 ```text
-timestampTill: RFC3339 UTC string, for example 2026-07-27T12:00:00Z
+memory-summary:
+  dataset retrieval = all
+  response = fixed gauge aggregation schema
+
+radio-temperature-summary:
+  dataset retrieval = all
+  response = fixed gauge aggregation schema
+
+wifi-clients/usage-summary:
+  dataset retrieval = differential
+  response = calculated cumulative-counter deltas
+
+wifi-clients/rssi-summary:
+  dataset retrieval = all
+  response = fixed RSSI quality percentage aggregation schema
+
+availability-summary:
+  dataset retrieval = all_with_baseline
+  response = offline transition count
+```
+
+For `all`, retrieve every record in the requested range. For state-transition
+calculations, also retrieve the latest valid state at or before the requested
+start; this is `all_with_baseline`.
+
+For `differential`, return the change in cumulative counter values over the
+requested time range:
+
+```text
+delta = ending metric value - starting metric value
+```
+
+Use exact effective-boundary samples when available. Effective boundaries are
+the requested boundaries clipped to any proven session lifetime. Otherwise, use
+the latest available starting sample at or before the effective start and the
+earliest available ending sample at or after the effective end. Each fallback
+boundary sample must be within two times the configured telemetry sampling
+interval from the effective boundary. When fallback samples are used, the
+default response exposes the requested time range, aggregate result time window,
+usage accuracy, segment count, and fallback status. Effective boundaries and
+per-segment actual sample timestamps are included only when
+`includeCalculationDetails=true`.
+
+### Time Conversion and Validation
+
+The public MCP-facing parameters use ISO-8601/RFC3339 UTC time, but the existing Analytics API style uses integer `fromDate` and `endDate` timestamps. Handlers should convert the request as:
+
+```text
+timestampTill: RFC3339 UTC string ending with 'Z', for example 2026-07-27T12:00:00Z
 endTime:       Unix epoch seconds parsed from timestampTill
 startTime:     endTime - (lookbackHours * 3600)
 ```
 
+Timezone Requirement:
+`timestampTill` MUST use the UTC `Z` suffix format (e.g., `2026-07-27T12:00:00Z`). Explicit numeric timezone offsets (such as `+05:30` or `-08:00`) and timestamps without a timezone designator are unsupported and MUST be rejected with `400 Bad Request` and `error: "invalid_timestamp"`.
+
 Validation rules:
 
 ```text
-timestampTill must parse as a valid timestamp.
+timestampTill must parse as a valid UTC timestamp ending with 'Z'.
+lookbackHours must be present exactly once.
+lookbackHours must parse as a strict whole decimal integer with no trailing characters.
 lookbackHours must be greater than 0.
 maxLookbackHours = floor(configured monitoringDuration / 3600).
 lookbackHours must be less than or equal to maxLookbackHours.
@@ -82,7 +177,21 @@ All APIs in this document derive `maxLookbackHours` from the configured `monitor
 
 For a one-year monitoring configuration, `maxLookbackHours` is `365 * 24` only when the configured monitoring duration is exactly 365 days. Do not assume every calendar year is 8760 hours; use the configured duration and effective retention timestamps when validating the request.
 
-Return `400 Bad Request` for invalid timestamps, unsupported timezones, non-positive `lookbackHours`, or values above the applicable maximum. Internally, query `timepoints.timestamp` and `wificlienthistory.timestamp` using epoch seconds.
+Return validation errors with field-specific error codes:
+
+```text
+invalid_timestamp:
+  timestampTill is missing, malformed, not UTC `Z` format, or otherwise unsupported.
+
+invalid_lookback_hours:
+  lookbackHours is missing, repeated, empty, non-numeric, fractional, partially numeric, overflowing,
+  zero, negative, or greater than maxLookbackHours.
+
+lookback_outside_retention:
+  the calculated [startTime, endTime) window is outside the configured retention window.
+```
+
+A valid timestamp with an invalid `lookbackHours` value must not return `invalid_timestamp`. Internally, query `timepoints.timestamp` and `wificlienthistory.timestamp` using epoch seconds.
 
 ### Monitoring Configuration
 
@@ -150,6 +259,35 @@ timestamp < endTime
 ```
 
 `timestampTill` is the exclusive upper bound. This prevents adjacent requests from double-counting samples or events at the shared boundary.
+
+For cumulative-counter differential summaries, exact effective-boundary samples
+are preferred. For endpoints with proven session lifetimes, effective boundaries
+are the requested boundaries clipped to the proven session start and end. For
+endpoints without session lifetimes, effective boundaries equal the requested
+boundaries. Otherwise, the handler must use the latest available sample at or
+before `effective_start` and the earliest available sample at or after
+`effective_end`, provided each fallback sample is within two times the configured
+telemetry sampling interval from the effective boundary. These fallback samples
+can fall outside `[startTime, endTime)`, so the response must expose:
+
+```text
+requestedTimeWindow.startTime = startTime
+requestedTimeWindow.endTime = endTime
+resultTimeWindow.earliestActualStartTime =
+  earliest actual starting sample used by any calculable segment contributing
+  to returned clients
+resultTimeWindow.latestActualEndTime =
+  latest actual ending sample used by any calculable segment contributing
+  to returned clients
+resultTimeWindow.boundaryFallbackUsed =
+  true when any calculable segment contributing to returned clients used a
+  fallback boundary sample
+```
+
+When no calculable usage segment exists for an observed client, the client
+response uses `segment_count: 0` instead of inventing effective or actual
+boundary timestamps. If `includeCalculationDetails=true`, that client has
+`calculation_segments: []`.
 
 Example:
 
@@ -563,19 +701,35 @@ Do not represent missing memory fields as `0`. A missing `memory_free` value and
 
 ```cpp
 AnalyticsObjects::DeviceResourceTimePoint resource;
-if (memory.has("free")) {
-    resource.memory_free = memory["free"].as<uint64_t>();
+
+// Validate numeric type, integral value, non-negative range (>= 0), and 64-bit non-overflow before unsigned conversion.
+// Sample-level rejection policy for negative telemetry: If ANY present memory field (free, total, cached, buffered) is negative (< 0), non-numeric, or invalid, mark the entire memory sample invalid and omit resource_data so the entire corrupted memory timepoint is excluded during aggregation.
+bool sampleValid = true;
+auto parseMemoryField = [&sampleValid](const Poco::JSON::Object::Ptr &obj, const std::string &key) -> std::optional<uint64_t> {
+    if (!obj->has(key) || obj->isNull(key)) return std::nullopt;
+    try {
+        if (!obj->isNumeric(key)) { sampleValid = false; return std::nullopt; }
+        int64_t val = obj->getElement<int64_t>(key);
+        if (val < 0) { sampleValid = false; return std::nullopt; }
+        return static_cast<uint64_t>(val);
+    } catch (...) {
+        sampleValid = false;
+        return std::nullopt;
+    }
+};
+
+auto freeVal = parseMemoryField(memory, "free");
+auto totalVal = parseMemoryField(memory, "total");
+auto cachedVal = parseMemoryField(memory, "cached");
+auto bufferedVal = parseMemoryField(memory, "buffered");
+
+if (sampleValid) {
+    if (freeVal)     resource.memory_free = *freeVal;
+    if (totalVal)    resource.memory_total = *totalVal;
+    if (cachedVal)   resource.memory_cached = *cachedVal;
+    if (bufferedVal) resource.memory_buffered = *bufferedVal;
+    DTP.resource_data = resource;
 }
-if (memory.has("total")) {
-    resource.memory_total = memory["total"].as<uint64_t>();
-}
-if (memory.has("cached")) {
-    resource.memory_cached = memory["cached"].as<uint64_t>();
-}
-if (memory.has("buffered")) {
-    resource.memory_buffered = memory["buffered"].as<uint64_t>();
-}
-DTP.resource_data = resource;
 ```
 
 ### Aggregation Logic
@@ -593,11 +747,19 @@ For each record:
   read record.resource_data.memory_free
   ignore missing resource_data
   include the sample only when memory_free is present
+  exclude the sample if any present memory value is negative
+  exclude the sample if memory_total is present and memory_free > memory_total
 
 Return:
   min_memfree = min(memory_free samples)
   max_memfree = max(memory_free samples)
   avg_memfree = sum(memory_free samples) / sample_count
+```
+
+Memory values are bytes and must be nonnegative. If `memory_total` is present, `memory_free` must not exceed `memory_total`; corrupted samples that violate this consistency rule are ignored rather than contributing to the summary. For successful responses with samples, the invariant is:
+
+```text
+min_memfree <= avg_memfree <= max_memfree
 ```
 
 Do not query `device_timepoints.memory_free` unless a separate normalized table and migration are introduced.
@@ -693,6 +855,8 @@ radios[].band
 radios[].wifi_temp
 ```
 
+`radios[].wifi_temp` and all `*_wifi_temp_*` response fields use degrees Celsius.
+
 Required ingestion rule:
 
 ```text
@@ -706,24 +870,29 @@ Do not synthesize a numeric fallback temperature for missing data.
 Do not store a placeholder in wifi_temp for a missing temperature.
 ```
 
-Migration boundary rule:
+Migration boundary configuration & rule:
 
 ```text
-Define a fixed temperature_migration_cutover_time as the deployment/migration
-timestamp where radios[].wifi_temp starts being written consistently.
+temperatureMigrationCutoverTime:
+  source: Analytics service configuration (file key 'temperature.migration_cutover_time' or ENV 'TEMPERATURE_MIGRATION_CUTOVER_TIME')
+  scope: global per deployment
+  format: ISO 8601 / RFC 3339 UTC string (e.g. "2026-07-01T00:00:00Z")
+  required: true (Analytics service fails startup with a FATAL log if missing or unparseable)
 
-Only use temperature records created at or after temperature_migration_cutover_time.
+Only use temperature records created at or after temperatureMigrationCutoverTime.
 Ignore all earlier records because historical temperature values cannot reliably
 distinguish measured values from synthetic fallback values.
 
-If the requested range starts before temperature_migration_cutover_time:
-  effective_start_time = temperature_migration_cutover_time
-else:
-  effective_start_time = startTime
+If the requested range starts before temperatureMigrationCutoverTime (startTime < temperatureMigrationCutoverTime):
+  return 400 Bad Request with JSON error envelope:
+  {
+    "error": "temperature_range_before_cutover",
+    "message": "The requested summary interval starts before the temperature migration cutover timestamp."
+  }
 
 Do not filter out post-cutover samples only because the measured value is 20°C.
-After the cutover, a present wifi_temp value is treated as a legitimate
-measurement.
+After the cutover, a present wifi_temp value is treated as a legitimate measurement.
+However, wifi_temp = 0 is defined as an uninitialized or missing-sensor sentinel across all OpenWiFi telemetry. A sample with wifi_temp = 0, null, 255, or outside the valid range [-40, 125] is treated as a missing sensor reading and MUST be excluded from aggregation for all samples regardless of timestamp.
 ```
 
 The current radio-band mapping is:
@@ -743,20 +912,20 @@ band = 5 → fields ending in _5G
 
 ### Aggregation Logic
 
-Use the current `timepoints.radio_data` JSON array:
+After validating `startTime >= temperatureMigrationCutoverTime`, query the `timepoints.radio_data` JSON array:
 
 ```text
 Load TimePointDB records where:
   boardId == resolvedBoardId
   stored serialNumber == request routerId
-  timestamp >= effective_start_time
+  timestamp >= startTime
   timestamp < endTime
 
 For each record:
   parse radio_data
   for each radio in radio_data:
     if radio.band is 2 or 5:
-      if radio.wifi_temp is present and non-null:
+      if radio.wifi_temp is present, non-null, != 0, and -40 <= radio.wifi_temp <= 125:
         add radio.wifi_temp to that band's sample list
 
 For each band:
@@ -768,8 +937,8 @@ For each band:
 A valid temperature sample is:
 
 ```text
-record timestamp is at or after temperature_migration_cutover_time
-radio.wifi_temp is present and non-null
+record timestamp is at or after temperatureMigrationCutoverTime
+radio.wifi_temp is present, non-null, != 0, and within range [-40, 125]
 ```
 
 If all samples for a band are invalid or missing, return `null` for that band's min, max, and average fields.
@@ -825,7 +994,11 @@ get_device_bandwidth_consumption(
 GET /api/v1/devices/{routerId}/wifi-clients/usage-summary
     ?timestampTill=2026-07-27T12:00:00Z
     &lookbackHours=24
+    &includeCalculationDetails=false
 ```
+
+`includeCalculationDetails` is optional and defaults to `false`. Set it to
+`true` only for diagnostic calculation provenance.
 
 ## Example Request
 
@@ -842,31 +1015,330 @@ None
 
 ## Response
 
+By default, usage-summary returns concise calculation quality metadata for MCP
+consumers. Segment-level provenance is verbose and is omitted unless
+`includeCalculationDetails=true` is requested.
+
 ```json
-[
-  {
-    "mac": "e2:51:95:ed:0f:28",
-    "rx_bytes": 106487500,
-    "tx_bytes": 3851250,
-    "total_bytes": 110338750,
-    "data_consume_rx": "851.9 Mb",
-    "data_consume_tx": "30.81 Mb",
-    "total_data_usage": "882.71 Mb",
-    "usage_accuracy": "exact",
-    "incomplete": false
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
   },
-  {
-    "mac": "28:39:26:a1:7c:a5",
-    "rx_bytes": 30071250,
-    "tx_bytes": 16486250,
-    "total_bytes": 46557500,
-    "data_consume_rx": "240.57 Mb",
-    "data_consume_tx": "131.89 Mb",
-    "total_data_usage": "372.46 Mb",
-    "usage_accuracy": "lower_bound",
-    "incomplete": true
-  }
-]
+  "resultTimeWindow": {
+    "earliestActualStartTime": "2026-07-26T11:55:00Z",
+    "latestActualEndTime": "2026-07-27T12:05:00Z",
+    "boundaryFallbackUsed": true
+  },
+  "items": [
+    {
+      "mac": "e2:51:95:ed:0f:28",
+      "rx_bytes": 106487500,
+      "tx_bytes": 3851250,
+      "total_bytes": 110338750,
+      "data_consume_rx": "106.49 MB",
+      "data_consume_tx": "3.85 MB",
+      "total_data_usage": "110.34 MB",
+      "usage_accuracy": "exact",
+      "incomplete": false,
+      "segment_count": 1,
+      "boundary_fallback_used": false
+    },
+    {
+      "mac": "28:39:26:a1:7c:a5",
+      "rx_bytes": 30071250,
+      "tx_bytes": 16486250,
+      "total_bytes": 46557500,
+      "data_consume_rx": "30.07 MB",
+      "data_consume_tx": "16.49 MB",
+      "total_data_usage": "46.56 MB",
+      "usage_accuracy": "bounded_interval",
+      "incomplete": false,
+      "segment_count": 1,
+      "boundary_fallback_used": true
+    },
+    {
+      "mac": "54:6c:0e:44:11:09",
+      "rx_bytes": 4200000,
+      "tx_bytes": 600000,
+      "total_bytes": 4800000,
+      "data_consume_rx": "4.20 MB",
+      "data_consume_tx": "0.60 MB",
+      "total_data_usage": "4.80 MB",
+      "usage_accuracy": "exact",
+      "incomplete": false,
+      "segment_count": 2,
+      "boundary_fallback_used": false
+    }
+  ],
+  "totalClients": 3,
+  "truncated": false
+}
+```
+
+`resultTimeWindow` is aggregate response metadata:
+
+```text
+earliestActualStartTime =
+  minimum actual_start_time among the server's internal calculable segments
+  contributing to returned clients
+
+latestActualEndTime =
+  maximum actual_end_time among the server's internal calculable segments
+  contributing to returned clients
+
+boundaryFallbackUsed =
+  true when any internal calculable segment contributing to returned clients
+  used a fallback boundary sample
+```
+
+It describes only the overall result envelope. It does not mean every client or
+segment used the entire envelope, and it is identical whether or not
+`includeCalculationDetails` is enabled.
+
+When no clients are returned:
+
+```json
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
+  },
+  "resultTimeWindow": {
+    "earliestActualStartTime": null,
+    "latestActualEndTime": null,
+    "boundaryFallbackUsed": false
+  },
+  "items": [],
+  "totalClients": 0,
+  "truncated": false
+}
+```
+
+When a client is observed but no usage interval can be calculated, such as when
+only one cumulative-counter sample exists in or bounding the requested range,
+return the safely provable minimum with `segment_count: 0`:
+
+```json
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-08-05T12:00:00Z",
+    "endTime": "2026-08-05T13:00:00Z"
+  },
+  "resultTimeWindow": {
+    "earliestActualStartTime": null,
+    "latestActualEndTime": null,
+    "boundaryFallbackUsed": false
+  },
+  "items": [
+    {
+      "mac": "e2:51:95:ed:0f:28",
+      "rx_bytes": 0,
+      "tx_bytes": 0,
+      "total_bytes": 0,
+      "data_consume_rx": "0.00 MB",
+      "data_consume_tx": "0.00 MB",
+      "total_data_usage": "0.00 MB",
+      "usage_accuracy": "lower_bound",
+      "incomplete": true,
+      "segment_count": 0,
+      "boundary_fallback_used": false
+    }
+  ],
+  "totalClients": 1,
+  "truncated": false
+}
+```
+
+## Calculation Details
+
+Use `includeCalculationDetails=true` only for diagnostics, troubleshooting, or
+calculation provenance. Ordinary MCP decisions should use `usage_accuracy`,
+`segment_count`, `boundary_fallback_used`, and the aggregate `resultTimeWindow`.
+
+```http
+GET /api/v1/devices/60cf84f22290/wifi-clients/usage-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24&includeCalculationDetails=true
+Authorization: Bearer <token>
+```
+
+When details are enabled, every returned calculation segment has non-null
+`actual_start_time` and `actual_end_time`. `stream_id` and `segment_id` are
+opaque identifiers scoped to the response. Clients must not persist them,
+compare them across requests, parse them, or depend on their format; the
+examples below are illustrative only. If no differential can be calculated, the
+client still has `segment_count: 0` and
+`calculation_segments: []`.
+
+Detailed response invariants:
+
+```text
+client.rx_bytes == SUM(calculation_segments[].rx_bytes)
+client.tx_bytes == SUM(calculation_segments[].tx_bytes)
+client.total_bytes == SUM(calculation_segments[].total_bytes)
+client.segment_count == calculation_segments.length
+client.boundary_fallback_used ==
+  true when any calculation segment has boundary_fallback_used = true
+```
+
+Example detailed response for the same calculated result:
+
+```json
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
+  },
+  "resultTimeWindow": {
+    "earliestActualStartTime": "2026-07-26T11:55:00Z",
+    "latestActualEndTime": "2026-07-27T12:05:00Z",
+    "boundaryFallbackUsed": true
+  },
+  "items": [
+    {
+      "mac": "e2:51:95:ed:0f:28",
+      "rx_bytes": 106487500,
+      "tx_bytes": 3851250,
+      "total_bytes": 110338750,
+      "data_consume_rx": "106.49 MB",
+      "data_consume_tx": "3.85 MB",
+      "total_data_usage": "110.34 MB",
+      "usage_accuracy": "exact",
+      "incomplete": false,
+      "segment_count": 1,
+      "boundary_fallback_used": false,
+      "calculation_segments": [
+        {
+          "stream_id": "e2:51:95:ed:0f:28|bssid=18:34:af:01:02:03|ssid=Corp|band=5G",
+          "segment_id": "e2:51:95:ed:0f:28|session=42|segment=0",
+          "segment_start_reason": "window_start",
+          "segment_end_reason": "window_end",
+          "effective_start_time": "2026-07-26T12:00:00Z",
+          "effective_end_time": "2026-07-27T12:00:00Z",
+          "actual_start_time": "2026-07-26T12:00:00Z",
+          "actual_end_time": "2026-07-27T12:00:00Z",
+          "boundary_fallback_used": false,
+          "accuracy": "exact",
+          "rx_bytes": 106487500,
+          "tx_bytes": 3851250,
+          "total_bytes": 110338750
+        }
+      ]
+    },
+    {
+      "mac": "28:39:26:a1:7c:a5",
+      "rx_bytes": 30071250,
+      "tx_bytes": 16486250,
+      "total_bytes": 46557500,
+      "data_consume_rx": "30.07 MB",
+      "data_consume_tx": "16.49 MB",
+      "total_data_usage": "46.56 MB",
+      "usage_accuracy": "bounded_interval",
+      "incomplete": false,
+      "segment_count": 1,
+      "boundary_fallback_used": true,
+      "calculation_segments": [
+        {
+          "stream_id": "28:39:26:a1:7c:a5|bssid=18:34:af:04:05:06|ssid=Corp|band=5G",
+          "segment_id": "28:39:26:a1:7c:a5|session=99|segment=0",
+          "segment_start_reason": "window_start",
+          "segment_end_reason": "window_end",
+          "effective_start_time": "2026-07-26T12:00:00Z",
+          "effective_end_time": "2026-07-27T12:00:00Z",
+          "actual_start_time": "2026-07-26T11:55:00Z",
+          "actual_end_time": "2026-07-27T12:05:00Z",
+          "boundary_fallback_used": true,
+          "accuracy": "bounded_interval",
+          "rx_bytes": 30071250,
+          "tx_bytes": 16486250,
+          "total_bytes": 46557500
+        }
+      ]
+    },
+    {
+      "mac": "54:6c:0e:44:11:09",
+      "rx_bytes": 4200000,
+      "tx_bytes": 600000,
+      "total_bytes": 4800000,
+      "data_consume_rx": "4.20 MB",
+      "data_consume_tx": "0.60 MB",
+      "total_data_usage": "4.80 MB",
+      "usage_accuracy": "exact",
+      "incomplete": false,
+      "segment_count": 2,
+      "boundary_fallback_used": false,
+      "calculation_segments": [
+        {
+          "stream_id": "54:6c:0e:44:11:09|bssid=18:34:af:07:08:09|ssid=Corp|band=5G",
+          "segment_id": "54:6c:0e:44:11:09|session=10|segment=0",
+          "segment_start_reason": "window_start",
+          "segment_end_reason": "session_end",
+          "effective_start_time": "2026-07-26T12:00:00Z",
+          "effective_end_time": "2026-07-26T18:30:00Z",
+          "actual_start_time": "2026-07-26T12:00:00Z",
+          "actual_end_time": "2026-07-26T18:30:00Z",
+          "boundary_fallback_used": false,
+          "accuracy": "exact",
+          "rx_bytes": 1800000,
+          "tx_bytes": 250000,
+          "total_bytes": 2050000
+        },
+        {
+          "stream_id": "54:6c:0e:44:11:09|bssid=18:34:af:07:08:09|ssid=Corp|band=5G",
+          "segment_id": "54:6c:0e:44:11:09|session=11|segment=0",
+          "segment_start_reason": "session_start",
+          "segment_end_reason": "window_end",
+          "effective_start_time": "2026-07-26T19:00:00Z",
+          "effective_end_time": "2026-07-27T12:00:00Z",
+          "actual_start_time": "2026-07-26T19:00:00Z",
+          "actual_end_time": "2026-07-27T12:00:00Z",
+          "boundary_fallback_used": false,
+          "accuracy": "exact",
+          "rx_bytes": 2400000,
+          "tx_bytes": 350000,
+          "total_bytes": 2750000
+        }
+      ]
+    }
+  ],
+  "totalClients": 3,
+  "truncated": false
+}
+```
+
+When a client is observed in-window (`[startTime, endTime)`) but no usage interval can be calculated, such as when
+only one cumulative-counter sample exists in or bounding the requested range,
+return the safely provable minimum with no calculation segments:
+
+```json
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-08-05T12:00:00Z",
+    "endTime": "2026-08-05T13:00:00Z"
+  },
+  "resultTimeWindow": {
+    "earliestActualStartTime": null,
+    "latestActualEndTime": null,
+    "boundaryFallbackUsed": false
+  },
+  "items": [
+    {
+      "mac": "e2:51:95:ed:0f:28",
+      "rx_bytes": 0,
+      "tx_bytes": 0,
+      "total_bytes": 0,
+      "data_consume_rx": "0.00 MB",
+      "data_consume_tx": "0.00 MB",
+      "total_data_usage": "0.00 MB",
+      "usage_accuracy": "lower_bound",
+      "incomplete": true,
+      "segment_count": 0,
+      "boundary_fallback_used": false,
+      "calculation_segments": []
+    }
+  ],
+  "totalClients": 1,
+  "truncated": false
+}
 ```
 
 ## API Logic
@@ -902,62 +1374,168 @@ The values are cumulative counters, so they must not be summed directly.
 ### Correct Calculation
 
 ```text
+For an uninterrupted stream:
+  delta = ending metric value - starting metric value
+
+For confirmed rollover:
+  apply known-width rollover arithmetic
+
+For confirmed independent session split/reset:
+  calculate each proven session segment separately
+  sum segment differentials
+
+For ambiguous reset/session split:
+  calculate only safely observed nonnegative segment deltas
+  mark the stream lower_bound
+
 stream_key = association/session id when available, otherwise:
   station MAC
   BSSID
   SSID
   band/radio when present
 
-baseline = last sample before start_time for the same stream_key, if available
+requested_start = startTime
+requested_end = endTime
 
-first in-window delta:
-  if baseline exists:
-    counterDelta(first.rx_bytes, baseline.rx_bytes)
-    counterDelta(first.tx_bytes, baseline.tx_bytes)
-  else if this is a confirmed new association/session that began within the window:
-    first.rx_bytes
-    first.tx_bytes
-  else:
-    0
+effective boundaries:
+  effective_start = max(requested_start, proven_session_start)
+  effective_end = min(requested_end, proven_session_end)
 
-subsequent deltas:
-  counterDelta(current.rx_bytes, previous.rx_bytes)
-  counterDelta(current.tx_bytes, previous.tx_bytes)
+start_sample:
+  exact sample at effective_start, if available
+  otherwise latest available sample at or before effective_start
 
-data_consume_rx = SUM(reset-safe rx_bytes deltas)
-data_consume_tx = SUM(reset-safe tx_bytes deltas)
-total_data_usage = data_consume_rx + data_consume_tx
+end_sample:
+  exact sample at effective_end, if available
+  otherwise earliest available sample at or after effective_end
 
-usage_accuracy = exact when no contributing stream is incomplete, otherwise lower_bound
+boundary tolerance:
+  abs(effective_start - actual_start_time) <= 2 * expected_collection_interval
+  abs(actual_end_time - effective_end) <= 2 * expected_collection_interval
+
+actual_start_time = start_sample.timestamp
+actual_end_time = end_sample.timestamp
+boundary_fallback_used =
+  actual_start_time != effective_start ||
+  actual_end_time != effective_end
+
+uninterrupted segment differential:
+  counterDelta(end_sample.rx_bytes, start_sample.rx_bytes)
+  counterDelta(end_sample.tx_bytes, start_sample.tx_bytes)
+
+samples between start_sample and end_sample:
+  use to detect counter resets, confirmed rollovers, duplicate or
+  out-of-order telemetry, missing-sample gaps, and session boundaries
+  do not sum raw cumulative values as usage
+  do sum proven segment deltas when resets or session splits are confirmed
+
+rx_bytes    = SUM(stream rx_bytes segment differentials or lower-bound deltas)
+tx_bytes    = SUM(stream tx_bytes segment differentials or lower-bound deltas)
+total_bytes = rx_bytes + tx_bytes
+
+data_consume_rx  = format_bytes(rx_bytes)
+data_consume_tx  = format_bytes(tx_bytes)
+total_data_usage = format_bytes(total_bytes)
+
+stream accuracy =
+  exact when the segment has authoritative counter evidence at effective_start
+    and effective_end, and every internal sub-segment is fully proven
+  bounded_interval when the segment uses immediate fallback samples within
+    tolerance and every internal sub-segment is fully proven
+  lower_bound when the stream lacks a usable boundary pair, exceeds boundary
+    tolerance, has an ambiguous reset/session change, or only has partially
+    observed segments
+
+client usage_accuracy precedence =
+  lower_bound if any contributing stream is lower_bound
+  otherwise bounded_interval if any contributing stream is bounded_interval
+  otherwise exact
+
 incomplete = true when usage_accuracy is lower_bound
 ```
 
-Calculate counter deltas independently for RX and TX per `stream_key`. After stream-level deltas are calculated, aggregate the resulting RX/TX deltas by station MAC for the response. If any stream contributing to a station MAC is incomplete/estimated, that station's usage is incomplete/estimated.
+Calculate counter deltas independently for RX and TX per `stream_key` and
+internal calculable segment. After segment deltas are calculated, aggregate the
+resulting RX/TX deltas by station MAC for the response. Client `rx_bytes` and
+`tx_bytes` must equal the sum of internal segment RX/TX deltas; each internal
+segment's `total_bytes` must equal its `rx_bytes + tx_bytes`. The default
+response exposes `segment_count` and `boundary_fallback_used` instead of the
+segment objects. When `includeCalculationDetails=true`, the detailed
+`calculation_segments[]` array must satisfy the same byte-sum invariants. If
+any segment contributing to a station MAC is lower_bound, that station's usage
+is lower_bound.
+
+Client MAC values in API responses must be normalized canonical lowercase colon-separated MAC addresses matching `^[0-9a-f]{2}(:[0-9a-f]{2}){5}$`.
 
 Usage accuracy contract:
 
 ```text
-Returned usage is exact only when every stream has enough information to account
-for the requested window:
-  a pre-window baseline exists for an ongoing stream, or
-  the stream is confirmed to have begun within the requested window, or
-  any counter rollover is confirmed and handled with rollover arithmetic.
+Returned usage is exact only when every contributing calculation segment has
+authoritative boundary evidence matching effective boundaries exactly:
+  effective_start = max(requested_start, proven_session_start), and
+  effective_end = min(requested_end, proven_session_end), and
+  actual_start_time == effective_start and actual_end_time == effective_end,
+  and every counter reset, rollover, or session transition is unambiguously proven
+  and accounted for using independent segment differentials or verified rollover arithmetic.
 
-When a stream lacks a pre-window baseline, has no reliable session/association
-start, or has an ambiguous counter decrease, the returned usage is a lower-bound
-estimate. The algorithm must avoid overcounting unknown traffic, so it adds zero
-for ambiguous intervals and treats the result as incomplete/estimated.
+Returned usage is bounded_interval when exact boundary samples are unavailable but
+the latest available starting sample at or before `effective_start` and the
+earliest available ending sample at or after `effective_end` are available
+within two times the configured telemetry sampling interval, and no reset or gap
+prevents the segment differential from being calculated. The response must
+include requested timestamps and aggregate actual sample timestamps. When
+`includeCalculationDetails=true`, it must also include the effective and actual
+timestamps for each returned segment. This is usage over an interval containing
+the segment's overlap with the requested interval; when counters are monotonic
+and uninterrupted, the returned value is greater than or equal to usage in that
+overlap.
 
-The response must expose `usage_accuracy` per client:
+When a stream lacks a usable bounding sample pair or has an ambiguous counter
+decrease/session change, or when either fallback boundary exceeds tolerance, the
+returned usage is a lower-bound estimate. The algorithm must avoid overcounting
+unknown traffic, so it adds only safely provable nonnegative consecutive segment
+deltas inside the requested range and treats the result as incomplete/estimated.
+If no positive interval can be safely proven, return 0 bytes for that stream with
+`lower_bound`. Include a client in `items[]` and count it in `totalClients` only when it has at least one in-window observation (`[startTime, endTime)`) or proven session overlap during the requested interval, even if the safely provable lower-bound delta is 0. Outside-window bounding samples (e.g. pre-window baseline or post-window fallback samples) are used exclusively as boundary calculation aids for clients that have proven in-window presence or session overlap. A station MAC with only outside-window samples and no in-window observation or session overlap during `[startTime, endTime)` must be excluded from `items[]` and `totalClients`. If no differential segment can be calculated
+for that client, return `segment_count: 0` and `boundary_fallback_used: false`;
+do not create a segment with fabricated effective or actual boundary timestamps.
+If details are enabled, return `calculation_segments: []` for that client.
+
+The response must expose `usage_accuracy`, `segment_count`, and
+`boundary_fallback_used` per client:
   exact: all contributing streams are fully accounted for
+  bounded_interval: at least one contributing segment used fallback samples
+    within tolerance that bound the requested range
   lower_bound: at least one contributing stream used a conservative zero delta
-    for an ambiguous interval or missing baseline
+    for an ambiguous interval, missing usable boundary pair, or out-of-tolerance
+    boundary
 
 When `usage_accuracy` is `lower_bound`, the reported byte and formatted usage
 values are the safely observed minimum. Actual usage may be higher.
 ```
 
-A fixed-width rollover is confirmed only when the counter width is known for that source and the observed decrease is consistent with a rollover for that counter. If the counter width is unknown, or the decrease could also be a reset/reconnect/stale sample, treat it as ambiguous.
+Differential response decision table:
+
+| Condition | Result |
+|---|---|
+| Exact effective start and effective end counter evidence exists, no reset/session ambiguity | `exact` differential |
+| Fallback start and end samples bound the effective segment range and both are within `2 * expected_collection_interval`, no reset/session ambiguity | `bounded_interval` differential |
+| Session starts inside the requested window with proven zero/session baseline and authoritative end evidence | `exact` if effective boundaries are fully proven |
+| Session ends inside the requested window with authoritative start and proven session-end evidence | `exact` if effective boundaries are fully proven |
+| Start sample missing and session start inside the requested window is confirmed but complete effective-boundary evidence is unavailable | sum safely provable nonnegative segment deltas; `lower_bound` |
+| Start sample missing and session origin is unknown | `lower_bound` |
+| End sample missing | sum safely provable nonnegative consecutive segment deltas through the latest usable sample; `lower_bound` |
+| Both boundary samples missing | sum safely provable nonnegative consecutive segment deltas inside the requested range; `lower_bound` |
+| Only one in-window sample exists | return 0 bytes, `lower_bound`, `segment_count: 0`, and `boundary_fallback_used: false`; if details are enabled, return `calculation_segments: []` |
+| Client appears during the window without reliable session-start proof | sum safely provable post-appearance segment deltas only; `lower_bound` |
+| Client disappears before the end boundary | sum safely provable segment deltas through the last usable sample; `lower_bound` |
+| Client reconnects and counters reset | split only when session identity proves independent streams; otherwise `lower_bound` |
+| Multiple sessions for the same MAC | calculate per proven session stream, then aggregate by MAC; mark client `lower_bound` if any contributing stream is incomplete |
+| Ambiguous counter reset, stale sample, duplicate conflict, or out-of-order telemetry | `lower_bound` |
+
+A fixed-width rollover is confirmed only when the counter width is known for that source, the observed decrease is consistent with a rollover for that counter, and the maximum possible counter increase during the observation gap cannot exceed one full counter range. If the counter width is unknown, if multiple wraps may have occurred, or if the decrease could also be a reset/reconnect/stale sample, treat it as ambiguous and return `lower_bound`.
+
+If the expected collection interval is missing, zero, invalid, or cannot be resolved reliably for the requested retention period, fallback boundary samples cannot qualify as `bounded_interval`; exact boundary samples are required to avoid `lower_bound`.
 
 ### Reset-Safe Delta Logic
 
@@ -969,28 +1547,27 @@ struct CounterDeltaResult {
 
 CounterDeltaResult counterDelta(uint64_t current,
                                 uint64_t previous,
-                                bool confirmedNewSession,
-                                bool newSessionStartedInWindow,
                                 bool confirmedFixedWidthRollover,
+                                bool singleRolloverBoundProven,
                                 uint64_t counterMax) {
     if (current >= previous) {
         return {current - previous, false};
     }
 
-    if (confirmedNewSession) {
-        if (newSessionStartedInWindow) {
-            return {current, false};
-        }
-        return {0, true};
-    }
-
-    if (confirmedFixedWidthRollover) {
+    if (confirmedFixedWidthRollover && singleRolloverBoundProven) {
         return {(counterMax - previous) + current + 1, false};
     }
 
     return {0, true};
 }
 ```
+
+Session starts are handled by segment construction, not by blindly adding the
+current counter on every decrease. When reliable session evidence proves a new
+session started inside the requested window, use that session's first valid
+counter sample as the segment baseline and sum only subsequent proven segment
+deltas. If there is no subsequent usable sample, that segment contributes 0 with
+`lower_bound`.
 
 Do not treat every lower counter as a reset where `current` should be added. A lower value can mean a new association session, movement between radios/BSSIDs, stale or out-of-order telemetry, duplicate station records inside one timepoint, or counter-width rollover. Adding `current` on every decrease can overcount traffic by attributing unknown pre-window traffic to the requested window.
 
@@ -1005,11 +1582,20 @@ Build a deterministic sample key from the stable fields available in the associa
 Sort samples by:
   station MAC
   timestamp ASC
-  BSSID/SSID/band/radio tie-breakers
+  stream identity fields for grouping only
 
 Deduplicate exact duplicate samples before calculating deltas.
 
-Discard out-of-order samples for the same calculated stream.
+For the same calculated stream and same timestamp:
+  identical counters are duplicates and collapse to one sample
+  different counters are ambiguous and must be excluded from delta calculation
+  unless a reliable source sequence number proves their temporal order
+
+Different stream keys are calculated independently. BSSID, SSID, band, and radio
+identify counter streams; they must not be used to invent temporal order between
+different counter values at the same timestamp.
+
+Deterministically sort all stream samples by timestamp ASC before calculating deltas. Valid out-of-order historical telemetry must be sorted and included in differential calculation; valid samples must not be discarded or treated as stale merely because they arrived out of temporal sequence. Discarding is strictly reserved for exact duplicate samples or ambiguous conflicting counter samples at the same timestamp without sequence proof.
 
 When an association/session identifier is available:
   calculate deltas only within the same session.
@@ -1018,21 +1604,50 @@ When no session identifier is available:
   use station MAC as the result grouping key,
   but use BSSID/SSID/band/radio changes as stream boundaries when possible.
 
+Independent Directional Counter Rules (RX vs TX):
+1. RX and TX counters are calculated independently per stream.
+2. If RX is present and valid but TX is missing, non-numeric, negative (< 0), or uncalculable:
+   - RX bytes are calculated normally and included in data_consume_rx.
+   - TX bytes return 0 as a required non-null integer in calculation_segments (and formatted "0.00 MB" in summary strings).
+   - Total segment bytes total_bytes = rx_bytes + 0 = rx_bytes.
+   - The stream accuracy is classified as lower_bound.
+3. If TX is present and valid but RX is missing/invalid:
+   - TX bytes are calculated normally and included in data_consume_tx.
+   - RX bytes return 0 as a required non-null integer in calculation_segments (and formatted "0.00 MB" in summary strings).
+   - Total segment bytes total_bytes = 0 + tx_bytes = tx_bytes.
+   - The stream accuracy is classified as lower_bound.
+4. If a boundary sample has RX but not TX (or vice versa), the missing direction cannot form a calculable boundary delta; that direction returns 0 bytes and is marked uncalculable (lower_bound).
+5. segment_count is incremented if at least one direction (RX or TX) produces a valid calculable segment delta.
+6. A client MAC is included in totalClients and items[] if it has proven in-window presence or session overlap, regardless of whether one counter direction was missing or uncalculable.
+
 If current < previous:
   if a new association/session is confirmed:
     if the new session start time is within [startTime, endTime):
-      add current as post-session-start traffic
+      close the previous segment at the last pre-reset sample
+      start a new segment with current as its baseline
+      add only subsequent proven nonnegative deltas for the new segment
+      mark the stream lower_bound unless both session segments can be fully proven
     else:
       treat current as the new baseline, add delta 0, and mark the result
       incomplete/estimated
-  else if fixed-width rollover is known and can be confirmed:
+  else if fixed-width rollover is known, one-wrap bound is proven, and can be confirmed:
     apply rollover math
   else:
     treat current as the new baseline, add delta 0, and mark the result
     incomplete/estimated
 ```
 
-Without the pre-window baseline for the same calculated stream, the first sample inside the requested window can include traffic that occurred before `start_time`. Do not add the first in-window cumulative counter directly unless it is known to be a fresh association/session that started inside the requested window. If the stream may have started before `start_time`, add zero for the first sample and mark the result incomplete/estimated.
+For usage differential calculation, choose the start and end samples first, then
+calculate the boundary differential for each segment. Exact usage requires
+authoritative counter evidence exactly at each segment's `effective_start` and
+`effective_end`, where effective boundaries are clipped to proven session
+lifetime and the requested window. If fallback samples within tolerance are used,
+classify the result as `bounded_interval`. The default response exposes the
+requested time window, aggregate result time window, and fallback summary
+fields. When `includeCalculationDetails=true`, each returned segment
+additionally exposes its effective and actual boundary timestamps. Do not add a
+cumulative counter directly unless it is known to represent traffic that started inside the
+segment's effective interval.
 
 A new association/session is confirmed only when the source provides reliable session identity or timing evidence. For example, a session id change, association id change, or connected-duration reset may prove a new session if it also proves the session start time is within the requested window. BSSID, SSID, band, or radio changes define separate calculation streams, but they do not by themselves prove that the new cumulative counter started inside the requested window.
 
@@ -1045,13 +1660,18 @@ Example:
 
 Delta 10:00 -> 10:05 = 500
 
-If 10:10 is a confirmed new session that started inside the request window:
-  add 200
+If 10:10 is a confirmed new session that started inside the request window WITH authoritative proof of starting at counter zero (e.g. session_start event with baseline 0 at session origin):
+  add 200 (delta from zero baseline)
   total rx_bytes = 700
   usage_accuracy = exact, unless another stream is incomplete
 
+If 10:10 is a confirmed new session that started inside the request window WITHOUT authoritative proof of starting at zero:
+  treat 200 as the new segment baseline (delta = 0 for 10:10 sample alone)
+  total rx_bytes = 500
+  usage_accuracy = lower_bound (until a subsequent sample in Session B establishes a proven delta)
+
 If 10:10 is an ambiguous decrease:
-  add 0
+  add 0 (treat 200 as baseline)
   total rx_bytes = 500
   usage_accuracy = lower_bound
 
@@ -1079,27 +1699,29 @@ A client moving between BSSIDs should remain one client in the final response un
 
 ### Unit Conversion
 
-The MCP output expects strings such as:
+The API returns raw byte counters plus display-only strings such as:
 
 ```text
-851.9 Mb
-30.81 Mb
+106.49 MB
+3.85 MB
 ```
 
 Recommended conversion:
 
 ```cpp
-double rxMb = static_cast<double>(rxBytes) * 8.0 / 1000000.0;
-double txMb = static_cast<double>(txBytes) * 8.0 / 1000000.0;
+double rxMB = static_cast<double>(rxBytes) / 1000000.0;
+double txMB = static_cast<double>(txBytes) / 1000000.0;
 ```
 
-`Mb` means megabits. If the implementation divides bytes by `1024 * 1024`, label the result as `MiB` or `MB` instead.
+`MB` means decimal megabytes. If the implementation divides bytes by `1024 * 1024`, label the result as `MiB` instead.
 
 Formatting:
 
 ```cpp
-fmt::format("{:.2f} Mb", value);
+fmt::format("{:.2f} MB", value);
 ```
+
+This uses standard floating point formatting semantics (formatting two decimal places with the `" MB"` suffix) rather than tying calculations to a custom round-half-up implementation.
 
 ### Query Flow
 
@@ -1108,21 +1730,24 @@ Resolve boardId from routerId
     ↓
 Load TimePointDB records for resolvedBoardId and stored serialNumber == request routerId
     ↓
-Include records from startTime up to but not including endTime
-    ↓
-Also load the latest pre-window association sample for each calculated stream_key
+Query both boundary candidates for each calculated stream:
+  - In-window samples: timestamp >= startTime and timestamp < endTime
+  - Start boundary: latest sample at or before effective_start (timestamp <= effective_start)
+  - End boundary: earliest sample at or after effective_end (timestamp >= effective_end)
+(Outside-window samples serve strictly as boundary calculation aids for streams with in-window observations or proven session overlap; they do NOT make a client eligible for response items)
     ↓
 Parse ssid_data associations
     ↓
-Build stream_key values and sort samples by stream_key and timestamp
+Build stream_key values and sort samples by stream_key and timestamp ASC
     ↓
-Calculate reset-safe RX/TX deltas
+Calculate reset-safe RX/TX deltas using effective start and end boundary samples
     ↓
-Aggregate stream-level deltas by station MAC
+Aggregate stream-level deltas by station MAC (including only clients with in-window observations or proven session overlap), sort clients deterministically by raw total_bytes DESC then normalized mac ASC, and apply the 500-client limit (truncated = totalClients > 500)
     ↓
-Convert bytes to megabits
+Convert bytes to decimal megabytes
     ↓
-Return array
+Return wrapped response with requestedTimeWindow, resultTimeWindow, items,
+totalClients, and truncated
 ```
 
 ---
@@ -1163,24 +1788,70 @@ None
 ## Response
 
 ```json
-[
-  {
-    "mac": "e2:51:95:ed:0f:28",
-    "rssi_excellent_pct": 41.67,
-    "rssi_good_pct": 50.0,
-    "rssi_fair_pct": 1.67,
-    "rssi_poor_pct": 6.67,
-    "rssi_total_samples": 60
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
   },
-  {
-    "mac": "28:39:26:a1:7c:a5",
-    "rssi_excellent_pct": 92.73,
-    "rssi_good_pct": 7.27,
-    "rssi_fair_pct": 0.0,
-    "rssi_poor_pct": 0.0,
-    "rssi_total_samples": 110
-  }
-]
+  "resultTimeWindow": {
+    "firstSampleTime": "2026-07-26T12:01:00Z",
+    "lastSampleTime": "2026-07-27T11:58:00Z",
+    "totalSamples": 170
+  },
+  "items": [
+    {
+      "mac": "e2:51:95:ed:0f:28",
+      "rssi_excellent_pct": 41.67,
+      "rssi_good_pct": 50.0,
+      "rssi_fair_pct": 1.67,
+      "rssi_poor_pct": 6.67,
+      "rssi_total_samples": 60
+    },
+    {
+      "mac": "28:39:26:a1:7c:a5",
+      "rssi_excellent_pct": 92.73,
+      "rssi_good_pct": 7.27,
+      "rssi_fair_pct": 0.0,
+      "rssi_poor_pct": 0.0,
+      "rssi_total_samples": 110
+    }
+  ],
+  "totalClients": 2,
+  "truncated": false
+}
+```
+
+`resultTimeWindow` for RSSI is scoped to returned `items[]` after applying the
+500-client response limit:
+
+```text
+firstSampleTime =
+  earliest valid RSSI sample contributing to items[]
+
+lastSampleTime =
+  latest valid RSSI sample contributing to items[]
+
+totalSamples =
+  SUM(items[].rssi_total_samples)
+```
+
+For empty RSSI results:
+
+```json
+{
+  "requestedTimeWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
+  },
+  "resultTimeWindow": {
+    "firstSampleTime": null,
+    "lastSampleTime": null,
+    "totalSamples": 0
+  },
+  "items": [],
+  "totalClients": 0,
+  "truncated": false
+}
 ```
 
 ## API Logic
@@ -1238,6 +1909,8 @@ poor_pct      = poor_count × 100 / total_samples
 ```
 
 Round percentages to two decimal places.
+
+The four percentage fields are constrained to `0 <= value <= 100`. Because each percentage is independently rounded to two decimal places, the four values may sum to slightly below or above exactly `100`.
 
 ### Current Storage Aggregation Logic
 
@@ -1304,9 +1977,50 @@ None
 
 ```json
 {
-  "gw_uuid": "60cf84f22290",
-  "fetch_status": "success",
-  "offline_count": 6
+  "meta": {
+    "requestedWindow": {
+      "startTime": "2026-07-26T12:00:00Z",
+      "endTime": "2026-07-27T12:00:00Z"
+    },
+    "observedWindow": {
+      "firstSampleAt": "2026-07-26T13:15:00Z",
+      "lastSampleAt": "2026-07-27T09:45:00Z"
+    },
+    "sourceWindow": {
+      "firstSampleAt": "2026-07-26T11:55:00Z",
+      "lastSampleAt": "2026-07-27T12:00:00Z"
+    },
+    "contributingWindow": {
+      "firstSampleAt": "2026-07-26T13:15:00Z",
+      "lastSampleAt": "2026-07-27T09:45:00Z"
+    },
+    "selection": "boundary_assisted",
+    "coverage": "full",
+    "accuracy": "exact",
+    "sampleCount": 6,
+    "offlineEventCount": 6,
+    "effectiveSamplingIntervalSeconds": 0,
+    "allowedGapSeconds": 0,
+    "boundarySamplesUsed": {
+      "beforeStart": true,
+      "atStart": false,
+      "atEnd": false,
+      "afterEnd": false
+    },
+    "availabilityCoverage": {
+      "coverageStart": "2026-07-26T11:55:00Z",
+      "stateKnownFrom": "2026-07-26T11:55:00Z",
+      "processedThrough": "2026-07-27T12:00:00Z",
+      "allowedIngestionDelaySeconds": 0,
+      "ingestionGapKnown": false,
+      "proofSource": "serial_partition_checkpoint"
+    }
+  },
+  "data": {
+    "gw_uuid": "60cf84f22290",
+    "fetch_status": "success",
+    "offline_count": 6
+  }
 }
 ```
 
@@ -1354,7 +2068,7 @@ metadata
 
 ### Required Storage Implementation
 
-Add a dedicated storage class for availability events:
+Add dedicated storage classes for availability events and restart-safe availability state:
 
 ```text
 src/storage/storage_device_availability_events.h
@@ -1372,6 +2086,7 @@ Fields:
   serialNumber    TEXT
   event_type      TEXT
   event_time      BIGINT
+  source_sequence BIGINT NULL
   reason          TEXT
   connection_ip   TEXT
   session_id      TEXT
@@ -1383,11 +2098,13 @@ Indexes:
   availability_serial_time_index:
     serialNumber ASC
     event_time ASC
+    source_sequence ASC NULLS FIRST
 
   availability_board_serial_time_index:
     board_id ASC
     serialNumber ASC
     event_time ASC
+    source_sequence ASC NULLS FIRST
 
 Unique constraints:
   availability_idempotency_key_unique:
@@ -1396,6 +2113,14 @@ Unique constraints:
 Optional indexes:
   availability_event_id_index:
     event_id ASC
+```
+
+SQL composite ordering semantics:
+
+```text
+When querying device_availability_events by (event_time, source_sequence):
+- Ascending queries use ORDER BY event_time ASC, source_sequence ASC NULLS FIRST so unsequenced events (source_sequence = NULL) at a timestamp sort before sequenced events at the same timestamp.
+- Descending queries use ORDER BY event_time DESC, source_sequence DESC NULLS LAST so the event with the highest sequence number at a timestamp sorts first, and unsequenced events sort last.
 ```
 
 `event_id` stores the normalized source event id when the payload provides one, using `payload.ping.uuid`, `payload.uuid`, or `payload.disconnection.uuid` only when that `uuid` is stable for the same logical source event.
@@ -1411,6 +2136,7 @@ serialNumber
 board_id
 current_state
 last_event_time
+last_source_sequence
 last_idempotency_key
 updated_at
 metadata
@@ -1424,6 +2150,7 @@ Fields:
   board_id             TEXT NULL
   current_state        TEXT
   last_event_time      BIGINT
+  last_source_sequence BIGINT NULL
   last_idempotency_key TEXT
   updated_at           BIGINT
   metadata             TEXT
@@ -1435,6 +2162,53 @@ Indexes:
 Constraints:
   current_state must be one of: online, offline, unknown
 ```
+
+`device_availability_events` stores only online/offline transition history. `device_availability_state` stores the authoritative current state and the latest accepted source availability ordering key.
+
+`last_event_time` and `last_source_sequence` form the persisted source ordering key after events have passed the required per-serial ordering mechanism. `last_event_time` must be populated from the normalized Kafka source timestamp (`event_time`), and `last_source_sequence` must be populated from a reliable source sequence, source offset within the producing system, or another deterministic 64-bit numeric value (`BIGINT`) when one exists. `source_sequence` and `last_source_sequence` are stored as `BIGINT NULL` so SQL and application-layer index and comparator operations preserve numeric order (`10 > 2`). The composite key is used for stale detection only after Analytics has established that no older transition for the same serialNumber can still be accepted. `DeviceInfo.lastContact` may remain local contact or processing metadata, but it must not be used to order source events because Kafka delivery can be delayed.
+
+Add persisted ingestion coverage tables for availability exactness:
+
+```text
+device_availability_ingestion_checkpoint
+----------------------------------------
+serialNumber
+coverage_start
+state_known_from
+processed_through_event_time
+partition
+offset
+ordering_strategy
+reorder_window_ms
+ingestion_gap_known
+updated_at
+metadata
+
+device_availability_ingestion_gaps
+----------------------------------
+serialNumber
+gap_start_event_time
+gap_end_event_time
+reason
+detected_at
+metadata
+```
+
+`processed_through_event_time` is a source-event-time watermark, not a Kafka processing-time or `DeviceInfo.lastContact` value. `state_known_from` stores the earliest source event timestamp from which gateway state is authoritatively established. When initial state is unproven (such as a first observed disconnection initializing state without prior state history), `state_known_from` is set to the timestamp of the first observed transition or explicit state proof (or an unproven gap is persisted in `device_availability_ingestion_gaps` for `[coverage_start, initial_observation_time)`). Kafka topic, partition, and offset are stored only as proof metadata.
+
+For availability coverage decisions over a requested interval `[startTime, endTime)`:
+
+```text
+coverageTargetEnd = endTime - allowedIngestionDelaySeconds
+```
+
+An exact result (`meta.coverage = "full"`, `meta.accuracy = "exact"`) is allowed only when the serialNumber checkpoint proves `coverage_start <= startTime`, `state_known_from <= startTime` (or no unproven initial gap), `processed_through_event_time >= endTime`, and no persisted gap overlaps `[startTime, endTime)`.
+
+Evaluating coverage against `coverageTargetEnd = endTime - allowedIngestionDelaySeconds` does not prove that there were no offline transitions in `[coverageTargetEnd, endTime)`. Therefore, if `processed_through_event_time < endTime` (even when `processed_through_event_time >= coverageTargetEnd`), the requested interval `[startTime, endTime)` is not fully covered up to `endTime` and must be reported as partial coverage (`meta.coverage = "partial"`, `meta.accuracy = "lower_bound"`) with the effective/observed window covered so far ending at `processed_through_event_time` (or `coverageTargetEnd`). Set `allowedIngestionDelaySeconds` to the configured maximum tolerated ingestion/source-message delay for availability queries, and return it in `meta.availabilityCoverage`.
+
+The checkpoint must be advanced durably with event processing. For a message that changes availability state or updates same-state metadata, the state update, optional transition insert, and checkpoint update must commit in one database transaction before the corresponding Kafka offset is committed. Rebalances and restarts must reload the checkpoint and any persisted reorder-buffer state needed by the selected ordering strategy. If the implementation cannot prove continuity after a restart, rebalance, topic retention truncation, skipped unparseable connection message, reorder-window overflow, or offset discontinuity, it must persist an ingestion gap and stop returning exact coverage for overlapping ranges.
+
+When one serialNumber has no recent messages, do not infer coverage from an empty event table. The API may return an exact zero only if that serialNumber has a durable checkpoint whose `processed_through_event_time` reaches `endTime`; otherwise the result is partial/lower-bound or unavailable according to the coverage rules. A partition-level or source-level watermark may be used instead of per-message checkpoint advancement only if it is durable, serialNumber-scoped for the queried gateway, and can prove that no earlier source event for that gateway remains unprocessed.
 
 Add a `DeviceAvailabilityEvent` REST/storage object with `to_json` and `from_json` support in:
 
@@ -1449,22 +2223,32 @@ Update `StorageService`:
 src/StorageService.h
   include storage/storage_device_availability_events.h
   include storage/storage_device_availability_state.h
+  include storage/storage_device_availability_ingestion_checkpoint.h
+  include storage/storage_device_availability_ingestion_gaps.h
   add DeviceAvailabilityEventsDB accessor
   add DeviceAvailabilityStateDB accessor
+  add DeviceAvailabilityIngestionCheckpointDB accessor
+  add DeviceAvailabilityIngestionGapsDB accessor
   add std::unique_ptr<DeviceAvailabilityEventsDB>
   add std::unique_ptr<DeviceAvailabilityStateDB>
+  add std::unique_ptr<DeviceAvailabilityIngestionCheckpointDB>
+  add std::unique_ptr<DeviceAvailabilityIngestionGapsDB>
 
 src/StorageService.cpp
   construct DeviceAvailabilityEventsDB
   construct DeviceAvailabilityStateDB
+  construct DeviceAvailabilityIngestionCheckpointDB
+  construct DeviceAvailabilityIngestionGapsDB
   call DeviceAvailabilityEventsDB->Create()
   call DeviceAvailabilityStateDB->Create()
+  call DeviceAvailabilityIngestionCheckpointDB->Create()
+  call DeviceAvailabilityIngestionGapsDB->Create()
   include availability retention cleanup if retention should match board timepoint cleanup
 ```
 
-Add a DB upgrade/migration path for the new table. Existing deployments will start with no historical availability events. Define a fixed `availabilityValidFrom` timestamp as the deployment/migration time when availability-event persistence starts. The API should return `offline_count: 0` only for successful empty queries whose requested range starts at or after `availabilityValidFrom`; do not infer old events from `lastDisconnection`.
+Add a DB upgrade/migration path for the new tables. Existing deployments will start with no historical availability events. Define a fixed `availabilityValidFrom` timestamp as the deployment/migration time when availability-event persistence starts. The API should return `offline_count: 0` as an exact result only for successful empty queries whose requested range starts at or after `availabilityValidFrom` and is covered by the per-serial ingestion checkpoint; do not infer old events from `lastDisconnection`.
 
-Add the files to `CMakeLists.txt`.
+Add all availability storage files to `CMakeLists.txt`, including `storage_device_availability_events.*`, `storage_device_availability_state.*`, `storage_device_availability_ingestion_checkpoint.*`, and `storage_device_availability_ingestion_gaps.*`. Register database migration/upgrade logic for all availability tables so fresh databases and upgraded deployments create the event table, state table, checkpoint table, gap table, indexes, uniqueness constraints, and state constraints consistently.
 
 ### Ingestion Hook
 
@@ -1502,23 +2286,28 @@ On ping/capabilities:
 Do not store online events for every ping.
 ```
 
-Bootstrap rule when no persisted state exists:
+Bootstrap rule when no `device_availability_state` row exists:
 
 ```text
 First observed disconnection:
-  insert one offline event
-  set current_state = offline
+  insert state row with current_state = offline
+  set last_event_time = event_time
+  set last_idempotency_key = idempotency_key
+  do not insert an offline transition event because the prior state is unknown
 
 First observed ping/capabilities:
-  set current_state = online
-  do not insert an online event
+  insert state row with current_state = online
+  set last_event_time = event_time
+  set last_idempotency_key = idempotency_key
+  do not insert an online transition event
 
 First observed unrecognized connection message:
-  set current_state = unknown
+  insert or update state row with current_state = unknown only when useful
+  set last_event_time only from a valid source timestamp
   do not insert a counted event
 ```
 
-In-memory transition checking is only an optimization. It is not sufficient for correctness because Kafka can redeliver messages and the service can restart after losing in-memory state. Transition detection must use `device_availability_state` or derive the latest known state from `device_availability_events` under the same transaction before writing. Duplicate connection messages must be rejected by storage-level idempotency before they can affect `offline_count`.
+In-memory transition checking is only an optimization. It is not sufficient for correctness because Kafka can redeliver messages and the service can restart after losing in-memory state. Transition detection must use `device_availability_state.current_state` and `device_availability_state.last_event_time` under the same transaction before writing `device_availability_events`. Duplicate connection messages must be rejected by source timestamp validation and storage-level idempotency before they can affect `offline_count`.
 
 Normalize connection messages before transition processing:
 
@@ -1591,6 +2380,20 @@ Else:
 
 Treat `uuid` as a source event id only if it is stable for the same logical connection message across Kafka redelivery and unique within the source namespace identified by `system.host` and `system.id`. If `uuid` is only a random per-delivery value, do not use it as `source_event_id`.
 
+Example for exact Kafka redelivery protection, after verifying that `payload.ping.uuid` remains stable for the same logical redelivered message:
+
+```text
+hash(
+  system.host +
+  system.id +
+  serialNumber +
+  message_type +
+  payload.ping.uuid
+)
+```
+
+Do not use `system.id` alone as the logical event id; it identifies the producing system, not one individual ping.
+
 Minimum fields for derived idempotency keys:
 
 ```text
@@ -1627,74 +2430,181 @@ Do not include Kafka topic, partition, or offset in the derived logical `idempot
 
 The same delivered logical connection event must always produce the same `idempotency_key`. If the implementation cannot build a stable or deterministic key for an event, it must not write that event as a counted availability transition; log it as an ingestion error instead.
 
+Ordering rule:
+
+```text
+Availability transition detection must process connection events in source-event
+order for each serialNumber.
+
+The preferred implementation is to produce Kafka connection messages in
+source-event order with serialNumber as the Kafka message key, so all events for
+one gateway are in one partition and retain gateway event order. If the source
+topic cannot provide that guarantee, Analytics must add a bounded event-time
+reorder window or an equivalent serialNumber-scoped ordering mechanism before
+applying the transition state machine.
+
+A newer same-state online event must not advance last_event_time in a way that
+causes an older offline transition for the same serialNumber to be discarded
+silently. If a deployment intentionally chooses best-effort counting instead of
+per-serial ordering, that lower-accuracy behavior must be documented separately
+and surfaced to callers; it must not be reported as exact availability counting.
+```
+
 Atomic transition and insert rule:
 
 ```text
-For each valid connection message:
-  begin transaction
-  load the persisted state row for serialNumber with write/transaction isolation
+For each valid connection message emitted by the per-serial ordering stage:
+  BEGIN
+
+  acquire a serialNumber-scoped transaction lock before reading state
+  load device_availability_state row for serialNumber with write isolation
   if no state row exists:
+    atomically create or lock the serialNumber state slot using one of:
+      INSERT ... ON CONFLICT ... DO UPDATE/NOTHING followed by SELECT ... FOR UPDATE
+      PostgreSQL advisory transaction lock
+      serializable transaction with retry
     treat previous state as unknown
-  determine the new state from the message
-  if state row exists and event_time is older than last_event_time:
+
+  -- Explicit scalar ordering comparison logic:
+  if event_time < last_event_time:
     treat the message as stale
     do not insert an availability event
     do not update device_availability_state
-    commit transaction
+    COMMIT
     stop processing this message
-  if state row exists and event_time equals last_event_time and no reliable tie-breaker proves this event is later:
-    treat the message as duplicate or non-advancing
-    do not insert a counted availability event
-    do not update device_availability_state
-    commit transaction
-    stop processing this message
-  if previous state is unknown:
-    if new state is offline:
-      insert one offline event with conflict-safe semantics
-      if the insert created a row:
-        update device_availability_state to offline and last_event_time
-      else:
+
+  if event_time == last_event_time:
+    if both source_sequence and last_source_sequence are present (non-null BIGINT):
+      if source_sequence < last_source_sequence:
+        treat the message as stale
+        do not insert an availability event
         do not update device_availability_state
-    else if new state is online:
-      update device_availability_state to online and last_event_time
-      do not insert an online event
+        COMMIT
+        stop processing this message
+
+      if source_sequence == last_source_sequence:
+        if idempotency_key equals last_idempotency_key:
+          treat the message as an exact duplicate
+        else:
+          persist an ingestion ambiguity gap for this serialNumber, event_time, and source_sequence
+          treat the message as ambiguous, not exact
+        do not insert an availability event
+        do not update device_availability_state
+        COMMIT
+        stop processing this message
     else:
-      update device_availability_state to unknown and last_event_time
-      do not insert a counted event
-  else if previous state differs from new state:
-    insert availability event with conflict-safe semantics:
-      INSERT ... ON CONFLICT(idempotency_key) DO NOTHING
-    if the insert created a row:
-      update device_availability_state to the new state and last_event_time
-    else:
-      treat it as a duplicate
+      -- Equal timestamp without comparable non-null BIGINT sequences
+      if idempotency_key equals last_idempotency_key:
+        treat the message as an exact duplicate
+      else:
+        persist an ingestion ambiguity gap for this serialNumber and event_time
+        treat the message as unordered / ambiguous, not exact
+      do not insert an availability event
       do not update device_availability_state
-  else if previous state equals new state:
-    update last contact metadata only when event_time is newer than last_event_time
-    do not insert a counted transition event
-  commit transaction
+      COMMIT
+      stop processing this message
+
+  -- event_time > last_event_time, or event_time == last_event_time with source_sequence > last_source_sequence:
+  determine incomingState from message_type:
+    ping or capabilities -> online
+    disconnection -> offline
+
+  if incomingState is online:
+    if current_state is offline:
+      INSERT online transition event with conflict-safe semantics
+      if the insert created a row:
+        update device_availability_state:
+          current_state = online
+          last_event_time = event_time
+          last_source_sequence = source_sequence
+          last_idempotency_key = idempotency_key
+          updated_at = processing time
+      else:
+        treat as duplicate and do not update state
+    else if current_state is online:
+      update device_availability_state metadata, last_event_time, last_source_sequence, last_idempotency_key, and updated_at
+      do not insert a transition event
+    else:
+      update device_availability_state to online, last_event_time, and last_source_sequence
+      do not insert an initial online transition event
+
+  if incomingState is offline:
+    if current_state is online:
+      INSERT offline transition event with conflict-safe semantics
+      if the insert created a row:
+        update device_availability_state:
+          current_state = offline
+          last_event_time = event_time
+          last_source_sequence = source_sequence
+          last_idempotency_key = idempotency_key
+          updated_at = processing time
+      else:
+        treat as duplicate and do not update state
+    else if current_state is offline:
+      update device_availability_state metadata, last_event_time, last_source_sequence, last_idempotency_key, and updated_at
+      do not insert a transition event
+    else:
+      update device_availability_state to offline, last_event_time, and last_source_sequence
+      do not insert an initial offline transition event because the prior state is unknown
+
+  COMMIT
 
 or the equivalent database-specific "insert if absent" operation.
 
 The storage method must return whether a row was inserted. Duplicate events that hit
 the unique idempotency constraint must not be treated as new offline transitions and
 must not move `device_availability_state` backward or forward.
+
+This transaction shape assumes the selected ordering strategy has already made
+the message eligible for state-machine processing. Do not apply this scalar
+`last_event_time` staleness check directly to raw Kafka arrival order unless the
+connection topic is keyed by serialNumber and source-event ordered.
 ```
 
-Staleness rule:
+Equivalent transaction shape:
 
 ```text
-An event is stale when its event_time is older than the persisted state's
-last_event_time for the same serialNumber. An event with the same event_time is
-non-advancing unless a deterministic source tie-breaker proves it happened later.
+BEGIN;
+
+Acquire a serialNumber-scoped transaction lock.
+Atomically create or lock the device_availability_state row for :serialNumber.
+Read:
+  current_state
+  last_event_time
+  last_source_sequence
+  last_idempotency_key
+
+-- Validate scalar timestamp and sequence ordering key and determine whether state changed.
+-- Insert into device_availability_events only if state changed.
+
+Update device_availability_state only when timestamp, sequence, and idempotency checks allow it:
+  current_state = :newState
+  last_event_time = :eventTime
+  last_source_sequence = :sourceSequence
+  last_idempotency_key = :idempotencyKey
+  updated_at = :processingTime
+  board_id = :boardId when known, otherwise keep existing or NULL according to metadata policy
+  metadata = source and processing metadata
+
+COMMIT;
+```
+
+Staleness rule after ordering:
+
+```text
+An event is stale when `event_time < last_event_time`, or when `event_time == last_event_time` and both `source_sequence` and `last_source_sequence` are present (non-null BIGINT) with `source_sequence < last_source_sequence`.
 
 Stale or non-advancing events must not insert counted availability events and must
 not update device_availability_state, even if their idempotency_key has not been
 seen before.
 
-For equal timestamps, use deterministic tie-breakers if the source provides them.
-If no reliable tie-breaker exists, process at most one state-changing event for that
-serialNumber and timestamp.
+Two different logical events with the same `event_time` must be ordered by a
+deterministic 64-bit numeric `source_sequence` (`BIGINT`). Exact Kafka redelivery
+should be identified by the idempotency key. If two different logical events share
+the same `event_time` and lack comparable non-null source sequences, or have identical
+source sequences, Analytics must persist an ingestion ambiguity gap for that source time
+and downgrade overlapping availability queries to partial/lower-bound coverage instead
+of silently discarding one transition as non-advancing or guessing order arbitrarily.
 ```
 
 ### Store Only State Transitions
@@ -1712,7 +2622,64 @@ Incorrect:
 every ping → store online event
 ```
 
-Every ping should not be treated as a new online transition.
+Every ping should not be treated as a new online transition. However, every source-newer ping that is accepted by the per-serial ordering stage must still update `device_availability_state.last_event_time` and metadata.
+
+Ping handling:
+
+```text
+current_state=online  + ping -> update last_event_time and metadata only
+current_state=offline + ping after a prior offline state -> insert online event, set current_state=online, update last_event_time
+no state row + ping -> create current_state=online, update last_event_time, do not insert an online event
+```
+
+Disconnection handling:
+
+```text
+current_state=online  + disconnection -> insert offline event, set current_state=offline, update last_event_time
+current_state=offline + disconnection -> update last_event_time and metadata only when the source message is newer; do not insert another offline event
+no state row + disconnection -> create current_state=offline, update last_event_time, do not insert an offline transition event
+```
+
+Example:
+
+```text
+12:00 first ping initializes current_state=online with no transition event
+12:05 disconnection source event
+12:10 ping source event
+```
+
+If Kafka delivers the `12:10` ping before the `12:05` disconnection and the
+topic does not guarantee serialNumber ordering, Analytics must not immediately
+advance `last_event_time` to `12:10` and then reject the delayed `12:05`
+disconnection. With a bounded reorder window, both messages are ordered by
+source time before transition processing:
+
+```text
+12:05 disconnection -> insert offline event, current_state=offline, last_event_time=12:05
+12:10 ping          -> insert online event, current_state=online,  last_event_time=12:10
+```
+
+The final current state is online, and the outage from `12:05` to `12:10` remains
+present in transition history. If the implementation lacks serial-keyed
+source-event ordering or a bounded reorder window, this case is only best-effort
+and must not be surfaced as exact availability counting.
+
+Kafka delay example:
+
+```text
+Ping source time:          12:00
+Ping processed:            12:05
+Disconnection source time: 12:03
+Disconnection processed:   12:06
+```
+
+The `12:03` disconnection is not stale because it is newer than `device_availability_state.last_event_time = 12:00`. It must not be rejected by comparing against processing-time `DeviceInfo.lastContact = 12:05`.
+
+Review conclusion:
+
+```text
+The implementation requires `device_availability_state` unless a future design explicitly names an existing persistent table with the same fields and locking guarantees. `last_event_time` must be updated for every source-newer ping, capabilities, or disconnection message accepted by the per-serial ordering stage, even when no availability transition event is inserted. `DeviceInfo.lastContact` remains contact/processing metadata and is not the source-event ordering field.
+```
 
 ### Calculation
 
@@ -1724,8 +2691,12 @@ offline_count =
 Availability migration boundary:
 
 ```text
-availabilityValidFrom = deployment timestamp when device_availability_events
-persistence became active
+availabilityValidFrom is a durable, deployment-wide timestamp loaded on service startup from:
+  1. Configuration file property `availability_valid_from` (in /etc/ucentral/owanalytics.json)
+  2. Environment variable `ANALYTICS_AVAILABILITY_VALID_FROM`
+  3. Persistent database migration metadata table (`system_properties` key `availability_valid_from`) populated during initial table creation.
+
+All service replicas and process restarts MUST load the identical `availabilityValidFrom` timestamp from these durable configuration/DB sources to guarantee multi-replica and restart consistency. Dynamic process-start timestamps (e.g. std::chrono::system_clock::now() at startup) are strictly prohibited.
 
 If startTime < availabilityValidFrom:
   reject the request
@@ -1735,6 +2706,10 @@ If startTime < availabilityValidFrom:
 If startTime >= availabilityValidFrom:
   query device_availability_events normally
 ```
+
+For `meta.coverage = "none"` and `meta.accuracy = "not_applicable"`, return
+`data.offline_count = null`. Do not return a numeric `0` when the API has no
+coverage proof for the requested interval.
 
 Rejecting pre-cutover ranges prevents a successful zero response from meaning either
 "no outages occurred" or "Analytics was not collecting availability events yet."
@@ -1771,11 +2746,74 @@ Use an HTTP error:
 
 ```json
 {
-  "gw_uuid": "60cf84f22290",
-  "fetch_status": "success",
-  "offline_count": 0
+  "meta": {
+    "requestedWindow": {
+      "startTime": "2026-07-26T12:00:00Z",
+      "endTime": "2026-07-27T12:00:00Z"
+    },
+    "observedWindow": {
+      "firstSampleAt": null,
+      "lastSampleAt": null
+    },
+    "sourceWindow": {
+      "firstSampleAt": "2026-07-26T11:55:00Z",
+      "lastSampleAt": "2026-07-26T11:55:00Z"
+    },
+    "contributingWindow": {
+      "firstSampleAt": null,
+      "lastSampleAt": null
+    },
+    "selection": "boundary_assisted",
+    "coverage": "full",
+    "accuracy": "exact",
+    "sampleCount": 0,
+    "offlineEventCount": 0,
+    "effectiveSamplingIntervalSeconds": 0,
+    "allowedGapSeconds": 0,
+    "boundarySamplesUsed": {
+      "beforeStart": true,
+      "atStart": false,
+      "atEnd": false,
+      "afterEnd": false
+    },
+    "availabilityCoverage": {
+      "coverageStart": "2026-07-20T00:00:00Z",
+      "stateKnownFrom": "2026-07-20T00:00:00Z",
+      "processedThrough": "2026-07-27T12:01:00Z",
+      "allowedIngestionDelaySeconds": 60,
+      "ingestionGapKnown": false,
+      "proofSource": "serial_partition_checkpoint"
+    }
+  },
+  "data": {
+    "gw_uuid": "60cf84f22290",
+    "fetch_status": "success",
+    "offline_count": 0
+  }
 }
 ```
+
+An exact zero is valid only when availability coverage proves the complete requested interval up to `endTime`: `coverageStart <= startTime`, `stateKnownFrom <= startTime`, `processedThrough >= endTime`, `ingestionGapKnown = false`, and `proofSource != "unavailable"`. When `processedThrough < endTime` (even if `processedThrough >= endTime - allowedIngestionDelaySeconds`), the requested interval is not fully covered up to `endTime` and a zero matching event count must be reported as partial/lower-bound (`meta.coverage = "partial"`), or as unavailable with `offline_count: null` when no coverage proof exists.
+
+For the availability endpoint, `sampleCount` is retained for response-shape
+consistency with the other summary APIs. When `meta.coverage` is `"full"` or `"partial"`, `sampleCount` is defined as:
+
+```text
+sampleCount = offlineEventCount = offline_count
+```
+
+`sampleCount` is the number of offline transition rows in `device_availability_events`
+contributing to `offline_count`. Online recovery transition rows (`event_type = 'online'`)
+are stored in transition history for state tracking and `observedWindow` / `sourceWindow`
+bounds, but they do not contribute to `sampleCount`, `offlineEventCount`, or `offline_count`.
+For `"full"` or `"partial"` coverage, `sampleCount` always equals `offlineEventCount`.
+
+When `meta.coverage = "none"` and `meta.accuracy = "not_applicable"`, `sampleCount`, `offlineEventCount`,
+and `offline_count` are all `null`.
+
+`boundarySamplesUsed.beforeStart` is `true` only when a pre-start boundary event
+was actually selected. Event counting does not require a pre-start boundary
+event when durable availability coverage proves the requested interval.
 
 ### Internal Error
 
@@ -1792,7 +2830,7 @@ Use an HTTP error:
 }
 ```
 
-Do not return `fetch_status: failed` with HTTP 200 for internal failures.
+HTTP 200 represents a successful retrieval. Do not return a success-shaped HTTP 200 response for internal failures; return the appropriate HTTP error instead.
 
 ---
 
@@ -1839,11 +2877,15 @@ Add objects:
 struct GatewayMemorySummary;
 struct GatewayWifiTemperatureSummary;
 struct ClientBandwidthConsumption;
+struct ClientBandwidthConsumptionResponse;
 struct ClientRssiQuality;
+struct ClientRssiQualityResponse;
 struct GatewayOfflineSummary;
 ```
 
 JSON field names should match the MCP CSV where the API is directly returning MCP fields. `usage-summary` additionally returns raw byte totals and usage accuracy fields so callers can distinguish exact usage from lower-bound estimates.
+
+Client MAC addresses (`mac`) must be normalized to canonical lowercase colon-separated format matching pattern `^[0-9a-f]{2}(:[0-9a-f]{2}){5}$` across all client metrics endpoints.
 
 ---
 
@@ -1873,6 +2915,9 @@ Wi-Fi client metrics handler:
 usage-summary
 rssi-summary
 ```
+
+Handler query parsing implementation note:
+REST handlers must inspect and parse the raw HTTP query string parameter collection directly rather than relying solely on generated framework parameter binding. Handlers must verify that `lookbackHours` and `timestampTill` appear exactly once in the raw query string, reject repeated parameters, reject fractional numeric values, and reject 32-bit integer overflow.
 
 Timepoint-backed handlers must call a shared serial-resolution helper before storage access:
 
@@ -1972,9 +3017,9 @@ bool GetGatewayAvailabilitySummary(...);
 |---|---|---|---|
 | `get_gateway_free_memory` | `GET /devices/{routerId}/memory-summary` | `timepoints.resource_data.memory_free` | Resolve routerId to venueId and boardId, then aggregate `timepoints` |
 | `get_gateway_wifi_temp` | `GET /devices/{routerId}/radio-temperature-summary` | `timepoints.radio_data[].wifi_temp` | Resolve routerId to venueId and boardId, then aggregate present Wi-Fi temperature samples from `timepoints` |
-| `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then reset-safe delta aggregation with pre-window baseline |
+| `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then calculate reset-safe cumulative-counter differentials with concise quality metadata by default; include segment provenance only when `includeCalculationDetails=true` |
 | `get_device_rssi_quality` | `GET /devices/{routerId}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve routerId to venueId and boardId, then classify RSSI samples |
-| `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic plus `device_availability_events` | Use routerId as durable serialNumber, persist restart-safe state transitions, then count offline events by serialNumber |
+| `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic plus `device_availability_events` and `device_availability_state` | Use routerId as durable serialNumber, use `device_availability_state.current_state` and `last_event_time` for restart-safe transition detection, then count offline events by serialNumber |
 
 ---
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -2122,27 +2122,9 @@ None
       "startTime": "2026-07-26T13:15:00Z",
       "endTime": "2026-07-27T09:45:00Z"
     },
-    "sourceWindow": {
-      "startTime": "2026-07-26T11:55:00Z",
-      "endTime": "2026-07-27T12:00:00Z"
-    },
-    "contributingWindow": {
-      "startTime": "2026-07-26T13:15:00Z",
-      "endTime": "2026-07-27T09:45:00Z"
-    },
-    "selection": "boundary_assisted",
     "coverage": "full",
     "accuracy": "exact",
-    "sampleCount": 6,
     "offlineEventCount": 6,
-    "effectiveSamplingIntervalSeconds": 0,
-    "allowedGapSeconds": 0,
-    "boundarySamplesUsed": {
-      "beforeStart": true,
-      "atStart": false,
-      "atEnd": false,
-      "afterEnd": false
-    },
     "availabilityCoverage": {
       "coverageStart": "2026-07-26T11:55:00Z",
       "stateKnownFrom": "2026-07-26T11:55:00Z",
@@ -2159,6 +2141,13 @@ None
   }
 }
 ```
+
+For availability responses, `observedWindow` is the actual event-time range
+represented by the availability data used to produce the response. It is derived
+from offline transition events that contributed to `offline_count`; when no
+offline transition events contribute, both `observedWindow.startTime` and
+`observedWindow.endTime` are `null`. Completeness and ingestion progress are
+reported separately in `availabilityCoverage`.
 
 ## API Logic
 
@@ -2891,27 +2880,9 @@ Use an HTTP error:
       "startTime": null,
       "endTime": null
     },
-    "sourceWindow": {
-      "startTime": "2026-07-26T11:55:00Z",
-      "endTime": "2026-07-26T11:55:00Z"
-    },
-    "contributingWindow": {
-      "startTime": null,
-      "endTime": null
-    },
-    "selection": "boundary_assisted",
     "coverage": "full",
     "accuracy": "exact",
-    "sampleCount": 0,
     "offlineEventCount": 0,
-    "effectiveSamplingIntervalSeconds": 0,
-    "allowedGapSeconds": 0,
-    "boundarySamplesUsed": {
-      "beforeStart": true,
-      "atStart": false,
-      "atEnd": false,
-      "afterEnd": false
-    },
     "availabilityCoverage": {
       "coverageStart": "2026-07-20T00:00:00Z",
       "stateKnownFrom": "2026-07-20T00:00:00Z",
@@ -2931,25 +2902,14 @@ Use an HTTP error:
 
 An exact zero is valid only when availability coverage proves the complete requested interval up to `endTime`: `coverageStart <= startTime`, `stateKnownFrom <= startTime`, `processedThrough >= endTime`, `ingestionGapKnown = false`, and `proofSource != "unavailable"`. When `processedThrough < endTime` (even if `processedThrough >= endTime - allowedIngestionDelaySeconds`), the requested interval is not fully covered up to `endTime` and a zero matching event count must be reported as partial/lower-bound (`meta.coverage = "partial"`), or as unavailable with `offline_count: null` when no coverage proof exists.
 
-For the availability endpoint, `sampleCount` is retained for response-shape
-consistency with the other summary APIs. When `meta.coverage` is `"full"` or `"partial"`, `sampleCount` is defined as:
+`offlineEventCount` is the number of offline transition rows in
+`device_availability_events` that contribute to `offline_count`. Online recovery
+transition rows (`event_type = 'online'`) are stored in transition history for
+state tracking, but they do not contribute to `observedWindow`,
+`offlineEventCount`, or `offline_count`.
 
-```text
-sampleCount = offlineEventCount = offline_count
-```
-
-`sampleCount` is the number of offline transition rows in `device_availability_events`
-contributing to `offline_count`. Online recovery transition rows (`event_type = 'online'`)
-are stored in transition history for state tracking and `observedWindow` / `sourceWindow`
-bounds, but they do not contribute to `sampleCount`, `offlineEventCount`, or `offline_count`.
-For `"full"` or `"partial"` coverage, `sampleCount` always equals `offlineEventCount`.
-
-When `meta.coverage = "none"` and `meta.accuracy = "not_applicable"`, `sampleCount`, `offlineEventCount`,
-and `offline_count` are all `null`.
-
-`boundarySamplesUsed.beforeStart` is `true` only when a pre-start boundary event
-was actually selected. Event counting does not require a pre-start boundary
-event when durable availability coverage proves the requested interval.
+When `meta.coverage = "none"` and `meta.accuracy = "not_applicable"`,
+`offlineEventCount` and `offline_count` are both `null`.
 
 ### Internal Error
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -62,11 +62,15 @@ All REST handlers must enforce request validation in four distinct sequential ph
    - Validate `routerId` syntax (1–64 characters matching `^[a-zA-Z0-9_-]+$`) -> HTTP `400 invalid_router_id` if malformed.
    - Inspect raw query collection for exact-once presence of `timestampTill` and `lookbackHours` -> HTTP `400 invalid_timestamp` / `invalid_lookback_hours` if missing or repeated.
    - Parse `timestampTill` shape & UTC semantics -> HTTP `400 invalid_timestamp` if malformed or invalid date/time.
+   - Capture `currentServerTime` once for the request and verify `end_time <= currentServerTime + allowedClockSkewSeconds` -> HTTP `400 invalid_timestamp` if `timestampTill` is too far in the future.
    - Parse `lookbackHours` strict positive integer -> HTTP `400 invalid_lookback_hours` if zero, negative, or non-numeric.
    - Checked epoch calculation: Compute `start_time = end_time - (lookback_hours * 3600)` using signed 64-bit integers. Verify `start_time >= 0` (minimum supported Unix epoch `1970-01-01T00:00:00Z`) -> HTTP `400 invalid_timestamp` if underflowing before epoch.
 
 2. **Phase 2: Router Ownership & Serial Resolution**
-   - Resolve `routerId` to `boardId` via local cache / OWPROV -> HTTP `404 not_found` if router serial does not exist in OWPROV.
+   - Resolve `routerId` to `boardId` via local cache / OWPROV.
+   - Return HTTP `404 not_found` if the router serial does not exist in OWPROV.
+   - Return HTTP `404 not_found` if the router serial exists in OWPROV but is outside the authenticated caller's accessible entity, venue, or board scope.
+   - Do not return HTTP `403 Forbidden` for the "existing router outside caller scope" case because it would disclose that the router serial exists.
    - Load router scope monitoring configuration (`monitoringDuration`) to derive `maxLookbackHours = floor(monitoringDuration / 3600)`.
 
 3. **Phase 3: Duration, Retention & Endpoint Cutover Validation**
@@ -165,6 +169,10 @@ Validation rules:
 
 ```text
 timestampTill must parse as a valid UTC timestamp ending with 'Z'.
+currentServerTime must be captured once per request after timestampTill parses.
+allowedClockSkewSeconds must be the same non-negative service-level value for all MCP analytics handlers.
+Unless a deployment explicitly configures another value, allowedClockSkewSeconds defaults to 300 seconds.
+endTime must be less than or equal to currentServerTime + allowedClockSkewSeconds.
 lookbackHours must be present exactly once.
 lookbackHours must parse as a strict whole decimal integer with no trailing characters.
 lookbackHours must be greater than 0.
@@ -172,6 +180,11 @@ maxLookbackHours = floor(configured monitoringDuration / 3600).
 lookbackHours must be less than or equal to maxLookbackHours.
 startTime must be less than endTime.
 ```
+
+If `timestampTill` is beyond `currentServerTime + allowedClockSkewSeconds`, return
+`400 Bad Request` with `error: "invalid_timestamp"`. Do not clamp `endTime` to
+server time. The returned aggregate must represent the requested half-open
+window exactly, not a silently shortened window.
 
 All APIs in this document derive `maxLookbackHours` from the configured `monitoringDuration` for the resolved router ownership scope. All APIs share this limit unless an endpoint section explicitly names a stricter limit. No endpoint currently defines a separate limit.
 
@@ -181,7 +194,8 @@ Return validation errors with field-specific error codes:
 
 ```text
 invalid_timestamp:
-  timestampTill is missing, malformed, not UTC `Z` format, or otherwise unsupported.
+  timestampTill is missing, malformed, not UTC `Z` format, beyond
+  currentServerTime + allowedClockSkewSeconds, or otherwise unsupported.
 
 invalid_lookback_hours:
   lookbackHours is missing, repeated, empty, non-numeric, fractional, partially numeric, overflowing,
@@ -199,7 +213,7 @@ Handlers must load the monitoring configuration for the resolved router ownershi
 
 ```text
 monitoringDuration = configured monitoring retention duration
-retentionEnd = min(currentTime, monitoringConfigurationExpiry)
+retentionEnd = min(currentServerTime, monitoringConfigurationExpiry)
 retentionStart = retentionEnd - monitoringDuration
 
 If monitoring has been enabled for less time than monitoringDuration:
@@ -325,6 +339,11 @@ analytics.gateway_metrics.read
 The permission is evaluated against the resolved board first, then the resolved venue, then the parent entity. Child-venue access is allowed only when the caller's venue permission explicitly includes descendant venues according to the same venue hierarchy rules used by OWPROV and `VenueCoordinator`; otherwise access is limited to the exact resolved venue or board.
 
 Authorization must not rely on the caller-supplied `routerId` alone. A caller must not be able to request an arbitrary gateway serial number and retrieve metrics without proving access to the router's current ownership scope. The external API intentionally returns `404 Not Found` for both nonexistent routers and routers outside the caller's authorized scope to avoid exposing router existence. Internal logs and metrics should preserve the exact reason.
+
+Reserve `403 Forbidden` for cases where the authenticated caller has visibility
+of the router's ownership scope, but lacks permission to perform the requested
+operation. Do not use `403 Forbidden` merely because OWPROV confirms the
+router exists outside the caller's accessible scope.
 
 For historical availability, authorize by current router ownership before querying `device_availability_events` by `serialNumber`. The event-time `board_id` field is historical context only and must not be the sole authorization source. If current ownership cannot be resolved for a non-operator caller, do not serve serial-number-only availability history. A privileged operator-level permission may bypass current ownership resolution only if explicitly implemented and audited.
 
@@ -460,6 +479,7 @@ Failure handling:
 
 ```text
 OWPROV inventory not found              -> 404 Not Found
+OWPROV inventory outside caller scope   -> 404 Not Found
 Inventory exists but venue is empty     -> 404 Not Found
 No Analytics board configured for venue -> 404 Not Found
 Multiple matching boards                -> 409 Conflict
@@ -503,7 +523,7 @@ InventoryNotFound     -> 404 Not Found
 EmptyVenue            -> 404 Not Found
 BoardNotConfigured    -> 404 Not Found
 MultipleBoards        -> 409 Conflict
-AccessDenied          -> 404 Not Found
+AccessDenied          -> 404 Not Found when the router exists in OWPROV but is outside the caller's accessible scope
 MonitoringNotConfigured -> 404 Not Found
 MonitoringDisabled    -> 409 Conflict
 OwprovUnavailable     -> 502 Bad Gateway

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -74,6 +74,7 @@ All REST handlers must enforce request validation in four distinct sequential ph
 1. **Phase 1: Pure Request Parsing & Input Validation (No DB or I/O lookups)**
    - Validate `routerId` syntax (1–64 characters matching `^[a-zA-Z0-9_-]+$`) -> HTTP `400 invalid_router_id` if malformed.
    - Inspect raw query collection for exact-once presence of `timestampTill` and `lookbackHours` -> HTTP `400 invalid_timestamp` / `invalid_lookback_hours` if missing or repeated.
+   - For `wifi-clients/usage-summary` only, inspect raw query collection for optional `includeCalculationDetails`. It may appear at most once. If present, it must be exactly `true` or `false` -> HTTP `400 invalid_include_calculation_details` if repeated, empty, or any other value.
    - Parse `timestampTill` shape & UTC semantics -> HTTP `400 invalid_timestamp` if malformed or invalid date/time.
    - Capture `currentServerTime` once for the request and verify `end_time <= currentServerTime + allowedClockSkewSeconds` -> HTTP `400 invalid_timestamp` if `timestampTill` is too far in the future.
    - Parse `lookbackHours` strict positive integer -> HTTP `400 invalid_lookback_hours` if zero, negative, or non-numeric.
@@ -213,6 +214,10 @@ invalid_timestamp:
 invalid_lookback_hours:
   lookbackHours is missing, repeated, empty, non-numeric, fractional, partially numeric, overflowing,
   zero, negative, or greater than maxLookbackHours.
+
+invalid_include_calculation_details:
+  includeCalculationDetails is repeated, empty, or present with any value other
+  than the exact lowercase strings `true` or `false`.
 
 lookback_outside_retention:
   the calculated [startTime, endTime) window starts before the retained data window
@@ -1118,6 +1123,21 @@ GET /api/v1/devices/{routerId}/wifi-clients/usage-summary
 
 `includeCalculationDetails` is optional and defaults to `false`. Set it to
 `true` only for diagnostic calculation provenance.
+
+Validation:
+
+```text
+missing includeCalculationDetails -> false
+includeCalculationDetails=true    -> true
+includeCalculationDetails=false   -> false
+includeCalculationDetails=foo     -> 400 invalid_include_calculation_details
+includeCalculationDetails=1       -> 400 invalid_include_calculation_details
+includeCalculationDetails=        -> 400 invalid_include_calculation_details
+repeated includeCalculationDetails -> 400 invalid_include_calculation_details
+```
+
+Values are case-sensitive and must be the exact lowercase strings `true` or
+`false`; do not accept numeric, empty, mixed-case, or partially parsed values.
 
 ## Example Request
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -1905,7 +1905,6 @@ connection_ip
 session_id
 event_id
 idempotency_key
-metadata
 ```
 
 ### Required Storage Implementation
@@ -1928,25 +1927,21 @@ Fields:
   serialNumber    TEXT
   event_type      TEXT
   event_time      BIGINT
-  source_sequence BIGINT NULL
   reason          TEXT
   connection_ip   TEXT
   session_id      TEXT
   event_id        TEXT
   idempotency_key TEXT NOT NULL
-  metadata        TEXT
 
 Indexes:
   availability_serial_time_index:
     serialNumber ASC
     event_time ASC
-    source_sequence ASC NULLS FIRST
 
   availability_board_serial_time_index:
     board_id ASC
     serialNumber ASC
     event_time ASC
-    source_sequence ASC NULLS FIRST
 
 Unique constraints:
   availability_idempotency_key_unique:
@@ -1957,12 +1952,10 @@ Optional indexes:
     event_id ASC
 ```
 
-SQL composite ordering semantics:
+SQL ordering semantics:
 
 ```text
-When querying device_availability_events by (event_time, source_sequence):
-- Ascending queries use ORDER BY event_time ASC, source_sequence ASC NULLS FIRST so unsequenced events (source_sequence = NULL) at a timestamp sort before sequenced events at the same timestamp.
-- Descending queries use ORDER BY event_time DESC, source_sequence DESC NULLS LAST so the event with the highest sequence number at a timestamp sorts first, and unsequenced events sort last.
+When querying device_availability_events, order by event_time only.
 ```
 
 `event_id` stores the normalized source event id when the payload provides one, using `payload.ping.uuid`, `payload.uuid`, or `payload.disconnection.uuid` only when that `uuid` is stable for the same logical source event.
@@ -1974,14 +1967,12 @@ Add a persisted current-state table for restart-safe transition detection:
 ```text
 device_availability_state
 -------------------------
-serialNumber
-board_id
-current_state
-last_event_time
-last_source_sequence
-last_idempotency_key
-updated_at
-metadata
+serialNumber          TEXT PRIMARY KEY
+board_id              TEXT NULL
+current_state         TEXT
+last_event_time       BIGINT
+last_idempotency_key  TEXT
+updated_at            BIGINT
 ```
 
 Required fields and constraints:
@@ -1992,10 +1983,8 @@ Fields:
   board_id             TEXT NULL
   current_state        TEXT
   last_event_time      BIGINT
-  last_source_sequence BIGINT NULL
   last_idempotency_key TEXT
   updated_at           BIGINT
-  metadata             TEXT
 
 Indexes:
   availability_state_board_index:
@@ -2009,13 +1998,25 @@ Constraints:
 Historical availability queries read this table and count persisted offline
 transition rows.
 
-`device_availability_state` is used during ingestion. It stores the latest
-accepted current state and source availability ordering key, supports
-restart-safe transition detection, and prevents repeated ping or disconnection
-messages from generating duplicate transitions. The REST handler must not derive
-historical availability counts from `device_availability_state`.
+`device_availability_state` exists only to persist:
 
-`last_event_time` and `last_source_sequence` form the persisted source ordering key after events have been consumed in Kafka partition order for the gateway. `last_event_time` must be populated from the normalized Kafka source timestamp (`event_time`), and `last_source_sequence` must be populated from a reliable source sequence, source offset within the producing system, or another deterministic 64-bit numeric value (`BIGINT`) when one exists. `source_sequence` and `last_source_sequence` are stored as `BIGINT NULL` so SQL and application-layer index and comparator operations preserve numeric order (`10 > 2`). The composite key is used for duplicate detection, stale-event protection, same-timestamp ordering, and defensive validation. `DeviceInfo.lastContact` may remain local contact or processing metadata, but it must not be used to order source events because Kafka delivery can be delayed.
+```text
+- the latest accepted availability state
+- the latest accepted source event timestamp
+- the latest logical event identity for idempotency
+- optional current board context
+- the state row update timestamp
+```
+
+It prevents repeated ping or disconnection messages from generating duplicate
+transitions. The REST handler must not derive historical availability counts from
+`device_availability_state`.
+
+`last_event_time` is the persisted source ordering key after events have been
+consumed in Kafka partition order for the gateway. It must be populated from the
+normalized Kafka source timestamp (`event_time`). `DeviceInfo.lastContact` may
+remain local contact or processing metadata, but it must not be used to order
+source events.
 
 Do not add Analytics-owned ingestion progress or durable data-loss tables for availability.
 
@@ -2026,7 +2027,13 @@ device_availability_events
 device_availability_state
 ```
 
-Kafka topic, partition, offset, message key, and consumer timestamp may be stored in event or state `metadata` for diagnostics only. They must not form the logical availability event identity and must not be persisted as an Analytics ingestion-progress record.
+Kafka topic, partition, offset, message key, consumer timestamp, message type,
+connection IP, disconnect reason, producer information, and other diagnostic
+details must not be stored in `device_availability_state`. Keep operational and
+debugging information in logs, metrics, traces, or other existing observability
+mechanisms. If diagnostic fields are required for a historical transition, model
+them explicitly in `device_availability_events` where already defined; do not
+add a generic metadata column solely for diagnostics.
 
 Expected Kafka and database processing contract:
 
@@ -2035,8 +2042,8 @@ Kafka message received
 normalize and validate event
 BEGIN database transaction
 lock/load device_availability_state for serialNumber
-apply idempotency and source ordering checks
-insert device_availability_events transition when required
+validate idempotency and event_time
+insert device_availability_events only on a real state transition
 update device_availability_state
 COMMIT database transaction
 commit Kafka offset
@@ -2072,7 +2079,7 @@ Restart and rebalance recovery must use the stable Kafka consumer group:
 2. Kafka resumes from the last committed offset for assigned partitions
 3. messages after that offset are replayed
 4. Analytics loads device_availability_state for each serialNumber as messages arrive
-5. idempotency and ordering checks prevent duplicate transition rows
+5. idempotency and event_time checks prevent duplicate transition rows
 6. processing continues and offsets are committed only after DB commit
 ```
 
@@ -2146,7 +2153,10 @@ Kafka:
   lag monitoring
 
 Analytics ingestion:
-  current availability state
+  restart-safe current availability state
+  latest accepted event_time
+  idempotency
+  transition detection
   idempotent transition persistence
 
 Analytics API:
@@ -2263,7 +2273,7 @@ First observed unrecognized connection message:
   do not insert a counted event
 ```
 
-In-memory transition checking is only an optimization. It is not sufficient for correctness because Kafka can redeliver messages and the service can restart after losing in-memory state. Transition detection must use `device_availability_state.current_state` and `device_availability_state.last_event_time` under the same transaction before writing `device_availability_events`. Duplicate connection messages must be rejected by source timestamp validation and storage-level idempotency before they can affect `offline_count`.
+In-memory transition checking is only an optimization. It is not sufficient for correctness because Kafka can redeliver messages and the service can restart after losing in-memory state. Transition detection must use `device_availability_state.current_state` and `device_availability_state.last_event_time` under the same transaction before writing `device_availability_events`. Duplicate connection messages must be rejected by `event_time` validation and storage-level idempotency before they can affect `offline_count`.
 
 Normalize connection messages before transition processing:
 
@@ -2356,57 +2366,72 @@ Minimum fields for derived idempotency keys:
 All counted availability events:
   serialNumber is required
   event_type is required
-  event_time is required and must have the highest precision available from the source
+  event_time is required and must satisfy the producer contract of strictly increasing source timestamps per serialNumber
 
 Offline events derived from disconnection:
   reason or source disconnect cause is required when available
   if reason/cause and connection_ip are missing:
     prefer stable source_event_id from payload.disconnection.uuid
     otherwise derive the key from serialNumber, message_type, event_type, and event_time
-  if reason/cause and connection_ip are missing and event_time precision is coarser than seconds:
-    do not write a counted offline event unless a stable source_event_id or session_id exists
 
 Online events derived from ping/capabilities:
   session_id is required when available
   if session_id is unavailable:
-    event_time plus message type must be precise enough to distinguish separate logical reconnects
-  if event_time is missing or too coarse to distinguish separate reconnects:
-    update current-state metadata only; do not write a counted online transition event
+    derive the key from serialNumber, message_type, event_type, and event_time
+  if event_time is missing or violates the strictly increasing per-serial producer contract:
+    do not move current state; do not write a counted online transition event
 
 Unrecognized connection messages:
   do not write counted availability events
-  store only current-state metadata when useful
+  do not use device_availability_state as a payload or diagnostics store
 ```
 
-If the minimum fields for the event type are not present, the implementation must not create a counted `device_availability_events` row. It may update non-counted metadata only when doing so cannot move `device_availability_state` backward or create a false transition.
+If the minimum fields for the event type are not present, the implementation must
+not create a counted `device_availability_events` row and must not use
+`device_availability_state` to store diagnostic details from that message.
 
 Do not include `board_id` in the idempotency key unless it is part of a stable source event id. Board ownership can change between delivery and redelivery, and including current ownership in a derived key can turn one logical event into multiple stored events.
 
-Do not include Kafka topic, partition, or offset in the derived logical `idempotency_key`. Kafka coordinates identify a broker record, not the logical connection event. They dedupe redelivery of the same Kafka record, but they do not dedupe the same logical connection event produced as a second Kafka record with a different offset. Store topic, partition, offset, message key, and consumer timestamp in `metadata` for tracing only.
+Do not include Kafka topic, partition, or offset in the derived logical
+`idempotency_key`. Kafka coordinates identify a broker record, not the logical
+connection event. They dedupe redelivery of the same Kafka record, but they do
+not dedupe the same logical connection event produced as a second Kafka record
+with a different offset. Keep Kafka coordinates and consumer timestamps in logs,
+metrics, or traces rather than `device_availability_state`.
 
 The same delivered logical connection event must always produce the same `idempotency_key`. If the implementation cannot build a stable or deterministic key for an event, it must not write that event as a counted availability transition; log it as an ingestion error instead.
 
 Ordering rule:
 
 ```text
-Connection events must be produced to Kafka with Kafka key = serialNumber.
-The producer must publish messages for one serialNumber in source-event order.
-Kafka partition ordering is then the primary ordering guarantee for all
-availability events belonging to one gateway.
+For each serialNumber:
+- Kafka key = serialNumber
+- events are produced in source-event order
+- source event_time is strictly increasing
 
-Connection messages are expected at intervals of approximately five seconds or
-more, so equal source event timestamps are not expected during normal operation
-when timestamp precision is at least seconds.
+Kafka partition ordering is therefore the ordering guarantee for all
+availability events belonging to one gateway. Analytics orders source events
+using only `event_time`.
 
-Source timestamps and source sequences remain useful for duplicate detection,
-stale-event protection, same-timestamp ordering, and defensive validation. They
-must not be used to build a second durable Analytics ingestion watermark.
+Because the producer guarantees strictly increasing source timestamps per
+serialNumber and writes those events to Kafka in that same order, normal
+processing sees:
 
-If the source topic cannot provide serialNumber keying and producer-side
-per-serial ordering, Kafka alone cannot guarantee correctly ordered transition
-history for that gateway. Treat that as a producer/topic contract violation or a
-separate architecture requirement; do not add an Analytics PostgreSQL
-ingestion-progress or data-loss tracking system to compensate.
+incoming event_time > last_event_time
+
+Analytics keeps only defensive checks for stale or duplicate/non-advancing
+messages. If a message has `event_time < last_event_time`, ignore it as stale.
+If a message has `event_time == last_event_time`, treat it as duplicate or
+non-advancing, do not create a transition, and do not move state. Equal source
+timestamps are not expected during normal operation.
+
+`last_idempotency_key` is retained for Kafka redelivery/idempotency protection.
+It must not participate in source-event ordering.
+
+If the source topic violates serialNumber keying, per-serial source-event order,
+or strictly increasing per-serial `event_time`, treat that as a producer/topic
+contract violation. Do not add Analytics PostgreSQL ingestion-progress,
+data-loss, or additional durable ordering state to compensate.
 ```
 
 Atomic transition and insert rule:
@@ -2416,15 +2441,27 @@ For each valid connection message consumed in Kafka partition order:
   BEGIN
 
   acquire a serialNumber-scoped transaction lock before reading state
+  determine incomingState from message_type:
+    ping or capabilities -> online
+    disconnection -> offline
+
   load device_availability_state row for serialNumber with write isolation
   if no state row exists:
     atomically create or lock the serialNumber state slot using one of:
       INSERT ... ON CONFLICT ... DO UPDATE/NOTHING followed by SELECT ... FOR UPDATE
       PostgreSQL advisory transaction lock
       serializable transaction with retry
-    treat previous state as unknown
+    if another transaction created the state row first, re-read it and continue
+    otherwise initialize current_state from incomingState
+    set last_event_time = event_time
+    set last_idempotency_key = idempotency_key
+    set board_id when known
+    set updated_at
+    do not insert an initial transition event
+    COMMIT
+    stop processing this message
 
-  -- Explicit scalar ordering comparison logic:
+  -- Event-time-only ordering check:
   if event_time < last_event_time:
     treat the message as stale
     do not insert an availability event
@@ -2433,41 +2470,13 @@ For each valid connection message consumed in Kafka partition order:
     stop processing this message
 
   if event_time == last_event_time:
-    if both source_sequence and last_source_sequence are present (non-null BIGINT):
-      if source_sequence < last_source_sequence:
-        treat the message as stale
-        do not insert an availability event
-        do not update device_availability_state
-        COMMIT
-        stop processing this message
+    treat the message as duplicate or non-advancing
+    do not insert an availability event
+    do not update device_availability_state
+    COMMIT
+    stop processing this message
 
-      if source_sequence == last_source_sequence:
-        if idempotency_key equals last_idempotency_key:
-          treat the message as an exact duplicate
-        else:
-          treat the message as ambiguous duplicate-source data
-          log and metric the ambiguity
-        do not insert an availability event
-        do not update device_availability_state
-        COMMIT
-        stop processing this message
-    else:
-      -- Equal timestamp without comparable non-null BIGINT sequences
-      if idempotency_key equals last_idempotency_key:
-        treat the message as an exact duplicate
-      else:
-        treat the message as ambiguous duplicate-source data
-        log and metric the ambiguity
-      do not insert an availability event
-      do not update device_availability_state
-      COMMIT
-      stop processing this message
-
-  -- event_time > last_event_time, or event_time == last_event_time with source_sequence > last_source_sequence:
-  determine incomingState from message_type:
-    ping or capabilities -> online
-    disconnection -> offline
-
+  -- event_time > last_event_time:
   if incomingState is online:
     if current_state is offline:
       INSERT online transition event with conflict-safe semantics
@@ -2475,16 +2484,16 @@ For each valid connection message consumed in Kafka partition order:
         update device_availability_state:
           current_state = online
           last_event_time = event_time
-          last_source_sequence = source_sequence
           last_idempotency_key = idempotency_key
           updated_at = processing time
+          board_id = boardId when known
       else:
         treat as duplicate and do not update state
     else if current_state is online:
-      update device_availability_state metadata, last_event_time, last_source_sequence, last_idempotency_key, and updated_at
+      update device_availability_state last_event_time, last_idempotency_key, updated_at, and board_id when known
       do not insert a transition event
     else:
-      update device_availability_state to online, last_event_time, and last_source_sequence
+      update device_availability_state to online, last_event_time, last_idempotency_key, updated_at, and board_id when known
       do not insert an initial online transition event
 
   if incomingState is offline:
@@ -2494,16 +2503,16 @@ For each valid connection message consumed in Kafka partition order:
         update device_availability_state:
           current_state = offline
           last_event_time = event_time
-          last_source_sequence = source_sequence
           last_idempotency_key = idempotency_key
           updated_at = processing time
+          board_id = boardId when known
       else:
         treat as duplicate and do not update state
     else if current_state is offline:
-      update device_availability_state metadata, last_event_time, last_source_sequence, last_idempotency_key, and updated_at
+      update device_availability_state last_event_time, last_idempotency_key, updated_at, and board_id when known
       do not insert a transition event
     else:
-      update device_availability_state to offline, last_event_time, and last_source_sequence
+      update device_availability_state to offline, last_event_time, last_idempotency_key, updated_at, and board_id when known
       do not insert an initial offline transition event because the prior state is unknown
 
   COMMIT
@@ -2515,10 +2524,11 @@ the unique idempotency constraint must not be treated as new offline transitions
 must not move `device_availability_state` backward or forward.
 
 This transaction shape assumes the connection topic is keyed by serialNumber and
-the producer publishes per-serial events in source-event order. Do not apply this
-state machine to a topic that can deliver out-of-order messages for one
-serialNumber unless a separate architecture explicitly defines that ordering
-guarantee outside Analytics PostgreSQL ingestion-progress or data-loss tables.
+the producer publishes per-serial events in source-event order with strictly
+increasing source `event_time`. Do not apply this state machine to a topic that
+violates that contract unless a separate architecture explicitly defines the
+ordering guarantee outside Analytics PostgreSQL ingestion-progress or data-loss
+tables.
 ```
 
 Equivalent transaction shape:
@@ -2531,20 +2541,17 @@ Atomically create or lock the device_availability_state row for :serialNumber.
 Read:
   current_state
   last_event_time
-  last_source_sequence
   last_idempotency_key
 
--- Validate scalar timestamp and sequence ordering key and determine whether state changed.
+-- Validate event_time and idempotency, then determine whether state changed.
 -- Insert into device_availability_events only if state changed.
 
-Update device_availability_state only when timestamp, sequence, and idempotency checks allow it:
+Update device_availability_state only when event_time and idempotency checks allow it:
   current_state = :newState
   last_event_time = :eventTime
-  last_source_sequence = :sourceSequence
   last_idempotency_key = :idempotencyKey
   updated_at = :processingTime
-  board_id = :boardId when known, otherwise keep existing or NULL according to metadata policy
-  metadata = source and processing metadata
+  board_id = :boardId when known, otherwise keep existing or NULL according to board-context policy
 
 COMMIT;
 ```
@@ -2552,20 +2559,14 @@ COMMIT;
 Staleness rule after ordering:
 
 ```text
-An event is stale when `event_time < last_event_time`, or when `event_time == last_event_time` and both `source_sequence` and `last_source_sequence` are present (non-null BIGINT) with `source_sequence < last_source_sequence`.
+An event is stale when `event_time < last_event_time`.
 
-Stale or non-advancing events must not insert counted availability events and must
-not update device_availability_state, even if their idempotency_key has not been
-seen before.
+An event is duplicate or non-advancing when `event_time == last_event_time`.
 
-Equal source timestamps are defensive edge cases, not the foundation of the
-availability architecture. Exact Kafka redelivery should be identified by the
-idempotency key. If two different logical events share the same `event_time`, use
-a reliable deterministic 64-bit numeric `source_sequence` (`BIGINT`) when one
-exists. If no reliable source sequence exists, log and metric the producer/source
-anomaly and apply the documented defensive policy for ambiguous duplicate-source
-data. Do not create an Analytics ingestion-progress or data-loss table for this
-edge case.
+Stale, duplicate, and non-advancing events must not insert counted availability
+events and must not update device_availability_state, even if their
+idempotency_key has not been seen before. The equal timestamp case is defensive
+only and is not expected during normal operation.
 ```
 
 ### Store Only State Transitions
@@ -2583,22 +2584,22 @@ Incorrect:
 every ping → store online event
 ```
 
-Every ping should not be treated as a new online transition. However, every source-newer ping that is accepted after Kafka partition-ordered consumption must still update `device_availability_state.last_event_time` and metadata.
+Every ping should not be treated as a new online transition. However, every source-newer ping that is accepted after Kafka partition-ordered consumption must still update `device_availability_state.last_event_time`, `last_idempotency_key`, `updated_at`, and `board_id` when known.
 
 Ping handling:
 
 ```text
-current_state=online  + ping -> update last_event_time and metadata only
-current_state=offline + ping after a prior offline state -> insert online event, set current_state=online, update last_event_time
-no state row + ping -> create current_state=online, update last_event_time, do not insert an online event
+current_state=online  + ping -> update last_event_time, last_idempotency_key, updated_at, and board_id when known; do not insert a transition event
+current_state=offline + ping after a prior offline state -> insert online event, set current_state=online, update last_event_time, last_idempotency_key, updated_at, and board_id when known
+no state row + ping -> create current_state=online, update last_event_time, last_idempotency_key, updated_at, and board_id when known; do not insert an online event
 ```
 
 Disconnection handling:
 
 ```text
-current_state=online  + disconnection -> insert offline event, set current_state=offline, update last_event_time
-current_state=offline + disconnection -> update last_event_time and metadata only when the source message is newer; do not insert another offline event
-no state row + disconnection -> create current_state=offline, update last_event_time, do not insert an offline transition event
+current_state=online  + disconnection -> insert offline event, set current_state=offline, update last_event_time, last_idempotency_key, updated_at, and board_id when known
+current_state=offline + disconnection -> update last_event_time, last_idempotency_key, updated_at, and board_id when known; do not insert another offline event
+no state row + disconnection -> create current_state=offline, update last_event_time, last_idempotency_key, updated_at, and board_id when known; do not insert an offline transition event
 ```
 
 Example:
@@ -2610,8 +2611,7 @@ Example:
 ```
 
 With Kafka key = serialNumber and producer-side per-serial ordering, Kafka
-preserves the gateway event order even when the consumer processes the messages
-later:
+preserves the gateway event order:
 
 ```text
 12:05 disconnection -> insert offline event, current_state=offline, last_event_time=12:05
@@ -2624,21 +2624,10 @@ producer publishes events for one serialNumber out of order, Kafka cannot provid
 the required per-gateway transition ordering. Treat that as an operational or
 producer-contract issue; do not model it with Analytics ingestion-progress or data-loss tables.
 
-Kafka delay example:
-
-```text
-Ping source time:          12:00
-Ping processed:            12:05
-Disconnection source time: 12:03
-Disconnection processed:   12:06
-```
-
-The `12:03` disconnection is not stale because it is newer than `device_availability_state.last_event_time = 12:00`. It must not be rejected by comparing against processing-time `DeviceInfo.lastContact = 12:05`.
-
 Review conclusion:
 
 ```text
-The implementation requires `device_availability_state` unless a future design explicitly names an existing persistent table with the same fields and locking guarantees. `last_event_time` must be updated for every source-newer ping, capabilities, or disconnection message accepted after Kafka partition-ordered consumption, even when no availability transition event is inserted. `DeviceInfo.lastContact` remains contact/processing metadata and is not the source-event ordering field.
+The implementation requires `device_availability_state` unless a future design explicitly names an existing persistent table with the same fields and locking guarantees. `last_event_time` must be updated for every source-newer ping, capabilities, or disconnection message accepted after Kafka partition-ordered consumption, even when no availability transition event is inserted. `last_idempotency_key` must be retained for Kafka redelivery/idempotency protection. `DeviceInfo.lastContact` remains contact/processing metadata and is not the source-event ordering field.
 ```
 
 ### Calculation

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -138,13 +138,13 @@ wifi-clients/rssi-summary:
   response = fixed RSSI quality percentage aggregation schema
 
 availability-summary:
-  dataset retrieval = all_with_baseline
-  response = offline transition count
+  dataset retrieval = all
+  response = persisted offline transition count
 ```
 
-For `all`, retrieve every record in the requested range. For state-transition
-calculations, also retrieve the latest valid state at or before the requested
-start; this is `all_with_baseline`.
+For `all`, retrieve every record in the requested range. `availability-summary`
+uses `all` because it counts persisted offline transition rows in
+`[startTime, endTime)` and does not need a pre-window baseline.
 
 For `differential`, return the change in cumulative counter values over the
 requested time range:
@@ -2319,6 +2319,27 @@ commit Kafka offset
 ```
 
 This is an at-least-once processing contract. The Kafka offset must not be committed before the database transaction succeeds. If the service crashes before the database commit, Kafka replays the message after restart. If the service crashes after the database commit but before the Kafka offset commit, Kafka may redeliver the message and storage-level idempotency must make the replay harmless. Kafka auto-commit must not acknowledge messages ahead of successful database commits.
+
+Availability transition processing must preserve Kafka partition order. The
+default implementation should process messages from one Kafka partition
+sequentially for availability state transitions. If batching or concurrent
+processing is introduced later, offset commits must remain contiguous per
+partition: commit only the highest offset for which that record and every earlier
+uncommitted record in the same partition have successfully completed the
+database transaction. Never commit past an earlier failed, skipped, or
+unprocessed record in the same partition.
+
+Unsafe concurrent commit example:
+
+```text
+partition P:
+offset 100 -> DB success
+offset 101 -> DB fails
+offset 102 -> DB success
+
+Do not commit offset 102, because that would skip offset 101 after restart.
+The highest committable contiguous offset is 100.
+```
 
 Restart and rebalance recovery must use the stable Kafka consumer group:
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -72,7 +72,6 @@ All REST handlers must enforce request validation in four distinct sequential ph
 1. **Phase 1: Pure Request Parsing & Input Validation (No DB or I/O lookups)**
    - Validate `routerId` syntax (1–64 characters matching `^[a-zA-Z0-9_-]+$`) -> HTTP `400 invalid_router_id` if malformed.
    - Inspect raw query collection for exact-once presence of `timestampTill` and `lookbackHours` -> HTTP `400 invalid_timestamp` / `invalid_lookback_hours` if missing or repeated.
-   - For `wifi-clients/usage-summary` only, inspect raw query collection for optional `includeCalculationDetails`. It may appear at most once. If present, it must be exactly `true` or `false` -> HTTP `400 invalid_include_calculation_details` if repeated, empty, or any other value.
    - Parse `timestampTill` shape & UTC semantics -> HTTP `400 invalid_timestamp` if malformed or invalid date/time.
    - Capture `currentServerTime` once for the request and verify `end_time <= currentServerTime + allowedClockSkewSeconds` -> HTTP `400 invalid_timestamp` if `timestampTill` is too far in the future.
    - Parse `lookbackHours` strict positive integer -> HTTP `400 invalid_lookback_hours` if zero, negative, or non-numeric.
@@ -208,10 +207,6 @@ invalid_timestamp:
 invalid_lookback_hours:
   lookbackHours is missing, repeated, empty, non-numeric, fractional, partially numeric, overflowing,
   zero, negative, or greater than maxLookbackHours.
-
-invalid_include_calculation_details:
-  includeCalculationDetails is repeated, empty, or present with any value other
-  than the exact lowercase strings `true` or `false`.
 
 lookback_outside_retention:
   the calculated [startTime, endTime) window starts before the retained data window
@@ -1142,26 +1137,7 @@ get_device_bandwidth_consumption(
 GET /api/v1/devices/{routerId}/wifi-clients/usage-summary
     ?timestampTill=2026-07-27T12:00:00Z
     &lookbackHours=24
-    &includeCalculationDetails=false
 ```
-
-`includeCalculationDetails` is optional and defaults to `false`. Set it to
-`true` only for diagnostic calculation provenance.
-
-Validation:
-
-```text
-missing includeCalculationDetails -> false
-includeCalculationDetails=true    -> true
-includeCalculationDetails=false   -> false
-includeCalculationDetails=foo     -> 400 invalid_include_calculation_details
-includeCalculationDetails=1       -> 400 invalid_include_calculation_details
-includeCalculationDetails=        -> 400 invalid_include_calculation_details
-repeated includeCalculationDetails -> 400 invalid_include_calculation_details
-```
-
-Values are case-sensitive and must be the exact lowercase strings `true` or
-`false`; do not accept numeric, empty, mixed-case, or partially parsed values.
 
 ## Example Request
 
@@ -1235,8 +1211,7 @@ endTime =
 ```
 
 It describes only the overall result envelope. It does not mean every client or
-segment used the entire envelope, and it is identical whether or not
-`includeCalculationDetails` is enabled.
+internal calculation stream used the entire envelope.
 
 When no clients are returned:
 
@@ -1279,167 +1254,6 @@ return zero usage for that client without a quality classification:
       "data_consume_rx": "0.00 MB",
       "data_consume_tx": "0.00 MB",
       "total_data_usage": "0.00 MB"
-    }
-  ],
-  "totalClients": 1,
-  "truncated": false
-}
-```
-
-## Calculation Details
-
-Use `includeCalculationDetails=true` only for diagnostics, troubleshooting, or
-calculation provenance. Ordinary MCP decisions should use the returned byte
-values and `observedWindow`.
-
-```http
-GET /api/v1/devices/60cf84f22290/wifi-clients/usage-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24&includeCalculationDetails=true
-Authorization: Bearer <token>
-```
-
-When details are enabled, every returned calculation segment has non-null
-`actual_start_time` and `actual_end_time`. `stream_id` and `segment_id` are
-opaque identifiers scoped to the response. Clients must not persist them,
-compare them across requests, parse them, or depend on their format; the
-examples below are illustrative only. If no differential can be calculated, the
-client has `calculation_segments: []`.
-
-Detailed response invariants:
-
-```text
-client.rx_bytes == SUM(calculation_segments[].rx_bytes)
-client.tx_bytes == SUM(calculation_segments[].tx_bytes)
-client.total_bytes == SUM(calculation_segments[].total_bytes)
-```
-
-Example detailed response for the same calculated result:
-
-```json
-{
-  "requestedWindow": {
-    "startTime": "2026-07-26T12:00:00Z",
-    "endTime": "2026-07-27T12:00:00Z"
-  },
-  "observedWindow": {
-    "startTime": "2026-07-26T11:55:00Z",
-    "endTime": "2026-07-27T12:05:00Z"
-  },
-  "items": [
-    {
-      "mac": "e2:51:95:ed:0f:28",
-      "rx_bytes": 106487500,
-      "tx_bytes": 3851250,
-      "total_bytes": 110338750,
-      "data_consume_rx": "106.49 MB",
-      "data_consume_tx": "3.85 MB",
-      "total_data_usage": "110.34 MB",
-      "calculation_segments": [
-        {
-          "stream_id": "e2:51:95:ed:0f:28|bssid=18:34:af:01:02:03|ssid=Corp|band=5G",
-          "segment_id": "e2:51:95:ed:0f:28|session=42|segment=0",
-          "segment_start_reason": "window_start",
-          "segment_end_reason": "window_end",
-          "effective_start_time": "2026-07-26T12:00:00Z",
-          "effective_end_time": "2026-07-27T12:00:00Z",
-          "actual_start_time": "2026-07-26T12:00:00Z",
-          "actual_end_time": "2026-07-27T12:00:00Z",
-          "rx_bytes": 106487500,
-          "tx_bytes": 3851250,
-          "total_bytes": 110338750
-        }
-      ]
-    },
-    {
-      "mac": "28:39:26:a1:7c:a5",
-      "rx_bytes": 30071250,
-      "tx_bytes": 16486250,
-      "total_bytes": 46557500,
-      "data_consume_rx": "30.07 MB",
-      "data_consume_tx": "16.49 MB",
-      "total_data_usage": "46.56 MB",
-      "calculation_segments": [
-        {
-          "stream_id": "28:39:26:a1:7c:a5|bssid=18:34:af:04:05:06|ssid=Corp|band=5G",
-          "segment_id": "28:39:26:a1:7c:a5|session=99|segment=0",
-          "segment_start_reason": "window_start",
-          "segment_end_reason": "window_end",
-          "effective_start_time": "2026-07-26T12:00:00Z",
-          "effective_end_time": "2026-07-27T12:00:00Z",
-          "actual_start_time": "2026-07-26T11:55:00Z",
-          "actual_end_time": "2026-07-27T12:05:00Z",
-          "rx_bytes": 30071250,
-          "tx_bytes": 16486250,
-          "total_bytes": 46557500
-        }
-      ]
-    },
-    {
-      "mac": "54:6c:0e:44:11:09",
-      "rx_bytes": 4200000,
-      "tx_bytes": 600000,
-      "total_bytes": 4800000,
-      "data_consume_rx": "4.20 MB",
-      "data_consume_tx": "0.60 MB",
-      "total_data_usage": "4.80 MB",
-      "calculation_segments": [
-        {
-          "stream_id": "54:6c:0e:44:11:09|bssid=18:34:af:07:08:09|ssid=Corp|band=5G",
-          "segment_id": "54:6c:0e:44:11:09|session=10|segment=0",
-          "segment_start_reason": "window_start",
-          "segment_end_reason": "session_end",
-          "effective_start_time": "2026-07-26T12:00:00Z",
-          "effective_end_time": "2026-07-26T18:30:00Z",
-          "actual_start_time": "2026-07-26T12:00:00Z",
-          "actual_end_time": "2026-07-26T18:30:00Z",
-          "rx_bytes": 1800000,
-          "tx_bytes": 250000,
-          "total_bytes": 2050000
-        },
-        {
-          "stream_id": "54:6c:0e:44:11:09|bssid=18:34:af:07:08:09|ssid=Corp|band=5G",
-          "segment_id": "54:6c:0e:44:11:09|session=11|segment=0",
-          "segment_start_reason": "session_start",
-          "segment_end_reason": "window_end",
-          "effective_start_time": "2026-07-26T19:00:00Z",
-          "effective_end_time": "2026-07-27T12:00:00Z",
-          "actual_start_time": "2026-07-26T19:00:00Z",
-          "actual_end_time": "2026-07-27T12:00:00Z",
-          "rx_bytes": 2400000,
-          "tx_bytes": 350000,
-          "total_bytes": 2750000
-        }
-      ]
-    }
-  ],
-  "totalClients": 3,
-  "truncated": false
-}
-```
-
-When a client is observed in-window (`[startTime, endTime)`) but no usage interval can be calculated, such as when
-only one cumulative-counter sample exists in or bounding the requested range,
-return zero usage with no calculation segments:
-
-```json
-{
-  "requestedWindow": {
-    "startTime": "2026-08-05T12:00:00Z",
-    "endTime": "2026-08-05T13:00:00Z"
-  },
-  "observedWindow": {
-    "startTime": null,
-    "endTime": null
-  },
-  "items": [
-    {
-      "mac": "e2:51:95:ed:0f:28",
-      "rx_bytes": 0,
-      "tx_bytes": 0,
-      "total_bytes": 0,
-      "data_consume_rx": "0.00 MB",
-      "data_consume_tx": "0.00 MB",
-      "total_data_usage": "0.00 MB",
-      "calculation_segments": []
     }
   ],
   "totalClients": 1,
@@ -1514,8 +1328,8 @@ end_sample:
   sample at effective_end, if available
   otherwise earliest available sample at or after effective_end
 
-actual_start_time = start_sample.timestamp
-actual_end_time = end_sample.timestamp
+start_sample_time = start_sample.timestamp
+end_sample_time = end_sample.timestamp
 
 uninterrupted segment differential:
   counterDelta(end_sample.rx_bytes, start_sample.rx_bytes)
@@ -1537,12 +1351,12 @@ total_data_usage = format_bytes(total_bytes)
 ```
 
 Calculate counter deltas independently for RX and TX per `stream_key` and
-internal calculable segment. After segment deltas are calculated, aggregate the
-resulting RX/TX deltas by station MAC for the response. Client `rx_bytes` and
-`tx_bytes` must equal the sum of internal segment RX/TX deltas; each internal
-segment's `total_bytes` must equal its `rx_bytes + tx_bytes`. When
-`includeCalculationDetails=true`, the detailed `calculation_segments[]` array
-must satisfy the same byte-sum invariants.
+internal calculable segment. Streams, sessions, counter reset detection,
+boundary samples, and segments are internal implementation mechanics only. After
+internal segment deltas are calculated, aggregate the resulting RX/TX deltas by
+station MAC for the public response. Client `rx_bytes` and `tx_bytes` must equal
+the sum of internal segment RX/TX deltas; each internal segment's `total_bytes`
+must equal its `rx_bytes + tx_bytes`.
 
 Client MAC values in API responses must be normalized canonical lowercase colon-separated MAC addresses matching `^[0-9a-f]{2}(:[0-9a-f]{2}){5}$`.
 
@@ -1553,15 +1367,13 @@ Use only valid persisted samples to calculate cumulative-counter deltas.
 Outside-window samples may be used as boundary samples when needed to calculate
 the first or last differential segment for a client observed in the requested
 range. The response must include requested timestamps and aggregate actual
-sample timestamps through `observedWindow`. When `includeCalculationDetails=true`,
-it must also include effective and actual timestamps for each returned segment.
+sample timestamps through `observedWindow`.
 
 If a stream lacks a usable bounding sample pair or has an ambiguous counter
 decrease/session change, skip the ambiguous interval rather than inventing
 traffic. Sum only safely calculable nonnegative consecutive segment deltas. If
 no differential segment can be calculated for an observed client, return that
-client with zero byte totals and, when details are enabled,
-`calculation_segments: []`.
+client with zero byte totals.
 
 Include a client in `items[]` and count it in `totalClients` only when it has at
 least one in-window observation (`[startTime, endTime)`) or proven session
@@ -1583,7 +1395,7 @@ Differential data-handling rules:
 | Start sample missing | sum safely calculable nonnegative consecutive segment deltas from available samples |
 | End sample missing | sum safely calculable nonnegative consecutive segment deltas through the latest usable sample |
 | Both boundary samples missing | sum safely calculable consecutive segment deltas inside the requested range |
-| Only one in-window sample exists | return zero bytes for that client; if details are enabled, return `calculation_segments: []` |
+| Only one in-window sample exists | return zero bytes for that client |
 | Client appears during the window without reliable session-start proof | sum safely calculable post-appearance segment deltas only |
 | Client disappears before the end boundary | sum safely calculable segment deltas through the last usable sample |
 | Client reconnects and counters reset | split only when session identity proves independent streams; otherwise skip the ambiguous interval |
@@ -1673,11 +1485,11 @@ Independent Directional Counter Rules (RX vs TX):
 1. RX and TX counters are calculated independently per stream.
 2. If RX is present and valid but TX is missing, non-numeric, negative (< 0), or uncalculable:
    - RX bytes are calculated normally and included in data_consume_rx.
-   - TX bytes return 0 as a required non-null integer in calculation_segments (and formatted "0.00 MB" in summary strings).
+   - TX bytes return 0 as a required non-null integer and formatted "0.00 MB" in summary strings.
    - Total segment bytes total_bytes = rx_bytes + 0 = rx_bytes.
 3. If TX is present and valid but RX is missing/invalid:
    - TX bytes are calculated normally and included in data_consume_tx.
-   - RX bytes return 0 as a required non-null integer in calculation_segments (and formatted "0.00 MB" in summary strings).
+   - RX bytes return 0 as a required non-null integer and formatted "0.00 MB" in summary strings.
    - Total segment bytes total_bytes = 0 + tx_bytes = tx_bytes.
 4. If a boundary sample has RX but not TX (or vice versa), the missing direction cannot form a calculable boundary delta; that direction returns 0 bytes.
 5. A client MAC is included in totalClients and items[] if it has proven in-window presence or session overlap, regardless of whether one counter direction was missing or uncalculable.
@@ -1700,10 +1512,8 @@ For usage differential calculation, choose the start and end samples first, then
 calculate the boundary differential for each segment. Effective boundaries are
 clipped to proven session lifetime and the requested window. The default
 response exposes the requested window, observed window, and calculated values.
-When `includeCalculationDetails=true`, each returned segment additionally
-exposes its effective and actual boundary timestamps. Do not add a cumulative
-counter directly unless it is known to represent traffic that started inside the
-segment's effective interval.
+Do not add a cumulative counter directly unless it is known to represent traffic
+that started inside the segment's effective interval.
 
 A new association/session is confirmed only when the source provides reliable session identity or timing evidence. For example, a session id change, association id change, or connected-duration reset may prove a new session if it also proves the session start time is within the requested window. BSSID, SSID, band, or radio changes define separate calculation streams, but they do not by themselves prove that the new cumulative counter started inside the requested window.
 
@@ -3213,7 +3023,7 @@ bool GetGatewayAvailabilitySummary(...);
 |---|---|---|---|
 | `get_gateway_free_memory` | `GET /devices/{routerId}/memory-summary` | `timepoints.resource_data.memory_free` | Resolve routerId to venueId and boardId, then aggregate `timepoints` |
 | `get_gateway_wifi_temp` | `GET /devices/{routerId}/radio-temperature-summary` | `timepoints.radio_data[].wifi_temp` | Resolve routerId to venueId and boardId, then aggregate present Wi-Fi temperature samples from `timepoints` |
-| `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then calculate reset-safe cumulative-counter differentials from available persisted samples; include segment provenance only when `includeCalculationDetails=true` |
+| `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then calculate reset-safe cumulative-counter differentials from available persisted samples |
 | `get_device_rssi_quality` | `GET /devices/{routerId}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve routerId to venueId and boardId, then classify RSSI samples |
 | `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic plus `device_availability_events` and `device_availability_state` | Use routerId as durable serialNumber, use `device_availability_state.current_state` and `last_event_time` for restart-safe transition detection, then count offline events by serialNumber |
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -941,7 +941,11 @@ If the requested range starts before temperatureMigrationCutoverTime (startTime 
 
 Do not filter out post-cutover samples only because the measured value is 20°C.
 After the cutover, a present wifi_temp value is treated as a legitimate measurement.
-However, wifi_temp = 0 is defined as an uninitialized or missing-sensor sentinel across all OpenWiFi telemetry. A sample with wifi_temp = 0, null, 255, or outside the valid range [-40, 125] is treated as a missing sensor reading and MUST be excluded from aggregation for all samples regardless of timestamp.
+Reject `wifi_temp = 0` only when the corresponding telemetry producer or device
+contract defines `0` as an unavailable or uninitialized sensor sentinel.
+Otherwise, treat `0°C` as a valid in-range measurement. A sample with
+`wifi_temp = null`, `255`, or a value outside the valid range `[-40, 125]` is
+treated as a missing sensor reading and MUST be excluded from aggregation.
 ```
 
 The current radio-band mapping is:
@@ -974,7 +978,8 @@ For each record:
   parse radio_data
   for each radio in radio_data:
     if radio.band is 2 or 5:
-      if radio.wifi_temp is present, non-null, != 0, and -40 <= radio.wifi_temp <= 125:
+      if radio.wifi_temp is present, non-null, -40 <= radio.wifi_temp <= 125,
+         and (radio.wifi_temp != 0 or the producer/device contract does not define 0 as unavailable):
         add radio.wifi_temp to that band's sample list
 
 For each band:
@@ -987,7 +992,8 @@ A valid temperature sample is:
 
 ```text
 record timestamp is at or after temperatureMigrationCutoverTime
-radio.wifi_temp is present, non-null, != 0, and within range [-40, 125]
+radio.wifi_temp is present, non-null, and within range [-40, 125]
+radio.wifi_temp = 0 is excluded only when the producer/device contract defines 0 as unavailable
 ```
 
 If all samples for a band are invalid or missing, return `null` for that band's min, max, and average fields.

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -153,16 +153,12 @@ requested time range:
 delta = ending metric value - starting metric value
 ```
 
-Use exact effective-boundary samples when available. Effective boundaries are
-the requested boundaries clipped to any proven session lifetime. Otherwise, use
-the latest available starting sample at or before the effective start and the
-earliest available ending sample at or after the effective end. Each fallback
-boundary sample must be within two times the configured telemetry sampling
-interval from the effective boundary. When fallback samples are used, the
-default response exposes `requestedWindow`, `observedWindow`,
-usage accuracy, segment count, and fallback status. Effective boundaries and
-per-segment actual sample timestamps are included only when
-`includeCalculationDetails=true`.
+Use the valid persisted samples available for the requested range. Effective
+boundaries are the requested boundaries clipped to any proven session lifetime.
+When samples immediately before or after the requested range are needed to
+calculate cumulative-counter deltas, the handler may use them. The response uses
+`observedWindow` to show the actual sample timestamps that contributed to the
+result; it must not add a result-quality classification.
 
 ### Time Conversion and Validation
 
@@ -317,31 +313,23 @@ observedWindow.endTime
 `endTime`. Endpoint-specific metadata must not be added inside
 `observedWindow`.
 
-For cumulative-counter differential summaries, exact effective-boundary samples
-are preferred. For endpoints with proven session lifetimes, effective boundaries
-are the requested boundaries clipped to the proven session start and end. For
-endpoints without session lifetimes, effective boundaries equal the requested
-boundaries. Otherwise, the handler must use the latest available sample at or
-before `effective_start` and the earliest available sample at or after
-`effective_end`, provided each fallback sample is within two times the configured
-telemetry sampling interval from the effective boundary. These fallback samples
-can fall outside `[startTime, endTime)`, so the response must expose:
+For all endpoints, `observedWindow` describes the persisted samples or events
+that contributed to the result:
 
 ```text
 requestedWindow.startTime = startTime
 requestedWindow.endTime = endTime
+
 observedWindow.startTime =
-  earliest actual starting sample used by any calculable segment contributing
-  to returned clients
+  earliest actual persisted sample/event timestamp used in the result
 observedWindow.endTime =
-  latest actual ending sample used by any calculable segment contributing
-  to returned clients
+  latest actual persisted sample/event timestamp used in the result
 ```
 
-When no calculable usage segment exists for an observed client, the client
-response uses `segment_count: 0` instead of inventing effective or actual
-boundary timestamps. If `includeCalculationDetails=true`, that client has
-`calculation_segments: []`.
+If no valid persisted data contributes to a result, both
+`observedWindow.startTime` and `observedWindow.endTime` are `null`. Analytics
+does not attach a result-quality classification to the relationship between
+`requestedWindow` and `observedWindow`.
 
 Example:
 
@@ -696,6 +684,14 @@ None
 
 ```json
 {
+  "requestedWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
+  },
+  "observedWindow": {
+    "startTime": "2026-07-26T12:03:00Z",
+    "endTime": "2026-07-27T11:57:00Z"
+  },
   "min_memfree": 211374,
   "max_memfree": 215050,
   "avg_memfree": 212074.36
@@ -837,6 +833,8 @@ Return:
   min_memfree = min(memory_free samples)
   max_memfree = max(memory_free samples)
   avg_memfree = sum(memory_free samples) / sample_count
+  observedWindow.startTime = earliest timestamp of a memory_free sample contributing to the aggregation
+  observedWindow.endTime = latest timestamp of a memory_free sample contributing to the aggregation
 ```
 
 Memory values are bytes and must be nonnegative. If both `memory_free` and valid
@@ -884,6 +882,14 @@ Return MCP response shape
 
 ```json
 {
+  "requestedWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
+  },
+  "observedWindow": {
+    "startTime": null,
+    "endTime": null
+  },
   "min_memfree": null,
   "max_memfree": null,
   "avg_memfree": null
@@ -931,6 +937,14 @@ None
 
 ```json
 {
+  "requestedWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
+  },
+  "observedWindow": {
+    "startTime": "2026-07-26T12:04:00Z",
+    "endTime": "2026-07-27T11:55:00Z"
+  },
   "min_wifi_temp_2.4G": 62,
   "max_wifi_temp_2.4G": 70,
   "avg_wifi_temp_2.4G": 66.64,
@@ -1051,6 +1065,12 @@ For each band:
   min_temperature = min(samples)
   max_temperature = max(samples)
   avg_temperature = sum(samples) / sample_count
+
+observedWindow.startTime =
+  earliest timestamp of a valid temperature sample contributing to any returned band aggregation
+
+observedWindow.endTime =
+  latest timestamp of a valid temperature sample contributing to any returned band aggregation
 ```
 
 A valid temperature sample is:
@@ -1085,6 +1105,14 @@ if (radio.band == 5) {
 
 ```json
 {
+  "requestedWindow": {
+    "startTime": "2026-07-26T12:00:00Z",
+    "endTime": "2026-07-27T12:00:00Z"
+  },
+  "observedWindow": {
+    "startTime": "2026-07-26T12:04:00Z",
+    "endTime": "2026-07-27T11:55:00Z"
+  },
   "min_wifi_temp_2.4G": 62,
   "max_wifi_temp_2.4G": 70,
   "avg_wifi_temp_2.4G": 66.64,
@@ -1150,10 +1178,6 @@ None
 
 ## Response
 
-By default, usage-summary returns concise calculation quality metadata for MCP
-consumers. Segment-level provenance is verbose and is omitted unless
-`includeCalculationDetails=true` is requested.
-
 ```json
 {
   "requestedWindow": {
@@ -1172,11 +1196,7 @@ consumers. Segment-level provenance is verbose and is omitted unless
       "total_bytes": 110338750,
       "data_consume_rx": "106.49 MB",
       "data_consume_tx": "3.85 MB",
-      "total_data_usage": "110.34 MB",
-      "usage_accuracy": "exact",
-      "incomplete": false,
-      "segment_count": 1,
-      "boundary_fallback_used": false
+      "total_data_usage": "110.34 MB"
     },
     {
       "mac": "28:39:26:a1:7c:a5",
@@ -1185,11 +1205,7 @@ consumers. Segment-level provenance is verbose and is omitted unless
       "total_bytes": 46557500,
       "data_consume_rx": "30.07 MB",
       "data_consume_tx": "16.49 MB",
-      "total_data_usage": "46.56 MB",
-      "usage_accuracy": "bounded_interval",
-      "incomplete": false,
-      "segment_count": 1,
-      "boundary_fallback_used": true
+      "total_data_usage": "46.56 MB"
     },
     {
       "mac": "54:6c:0e:44:11:09",
@@ -1198,11 +1214,7 @@ consumers. Segment-level provenance is verbose and is omitted unless
       "total_bytes": 4800000,
       "data_consume_rx": "4.20 MB",
       "data_consume_tx": "0.60 MB",
-      "total_data_usage": "4.80 MB",
-      "usage_accuracy": "exact",
-      "incomplete": false,
-      "segment_count": 2,
-      "boundary_fallback_used": false
+      "total_data_usage": "4.80 MB"
     }
   ],
   "totalClients": 3,
@@ -1214,12 +1226,12 @@ consumers. Segment-level provenance is verbose and is omitted unless
 
 ```text
 startTime =
-  minimum actual_start_time among the server's internal calculable segments
-  contributing to returned clients
+  earliest actual persisted sample timestamp used by any returned client
+  calculation
 
 endTime =
-  maximum actual_end_time among the server's internal calculable segments
-  contributing to returned clients
+  latest actual persisted sample timestamp used by any returned client
+  calculation
 ```
 
 It describes only the overall result envelope. It does not mean every client or
@@ -1246,7 +1258,7 @@ When no clients are returned:
 
 When a client is observed but no usage interval can be calculated, such as when
 only one cumulative-counter sample exists in or bounding the requested range,
-return the safely provable minimum with `segment_count: 0`:
+return zero usage for that client without a quality classification:
 
 ```json
 {
@@ -1266,11 +1278,7 @@ return the safely provable minimum with `segment_count: 0`:
       "total_bytes": 0,
       "data_consume_rx": "0.00 MB",
       "data_consume_tx": "0.00 MB",
-      "total_data_usage": "0.00 MB",
-      "usage_accuracy": "lower_bound",
-      "incomplete": true,
-      "segment_count": 0,
-      "boundary_fallback_used": false
+      "total_data_usage": "0.00 MB"
     }
   ],
   "totalClients": 1,
@@ -1281,8 +1289,8 @@ return the safely provable minimum with `segment_count: 0`:
 ## Calculation Details
 
 Use `includeCalculationDetails=true` only for diagnostics, troubleshooting, or
-calculation provenance. Ordinary MCP decisions should use `usage_accuracy`,
-`segment_count`, `boundary_fallback_used`, and `observedWindow`.
+calculation provenance. Ordinary MCP decisions should use the returned byte
+values and `observedWindow`.
 
 ```http
 GET /api/v1/devices/60cf84f22290/wifi-clients/usage-summary?timestampTill=2026-07-27T12:00:00Z&lookbackHours=24&includeCalculationDetails=true
@@ -1294,8 +1302,7 @@ When details are enabled, every returned calculation segment has non-null
 opaque identifiers scoped to the response. Clients must not persist them,
 compare them across requests, parse them, or depend on their format; the
 examples below are illustrative only. If no differential can be calculated, the
-client still has `segment_count: 0` and
-`calculation_segments: []`.
+client has `calculation_segments: []`.
 
 Detailed response invariants:
 
@@ -1303,9 +1310,6 @@ Detailed response invariants:
 client.rx_bytes == SUM(calculation_segments[].rx_bytes)
 client.tx_bytes == SUM(calculation_segments[].tx_bytes)
 client.total_bytes == SUM(calculation_segments[].total_bytes)
-client.segment_count == calculation_segments.length
-client.boundary_fallback_used ==
-  true when any calculation segment has boundary_fallback_used = true
 ```
 
 Example detailed response for the same calculated result:
@@ -1329,10 +1333,6 @@ Example detailed response for the same calculated result:
       "data_consume_rx": "106.49 MB",
       "data_consume_tx": "3.85 MB",
       "total_data_usage": "110.34 MB",
-      "usage_accuracy": "exact",
-      "incomplete": false,
-      "segment_count": 1,
-      "boundary_fallback_used": false,
       "calculation_segments": [
         {
           "stream_id": "e2:51:95:ed:0f:28|bssid=18:34:af:01:02:03|ssid=Corp|band=5G",
@@ -1343,8 +1343,6 @@ Example detailed response for the same calculated result:
           "effective_end_time": "2026-07-27T12:00:00Z",
           "actual_start_time": "2026-07-26T12:00:00Z",
           "actual_end_time": "2026-07-27T12:00:00Z",
-          "boundary_fallback_used": false,
-          "accuracy": "exact",
           "rx_bytes": 106487500,
           "tx_bytes": 3851250,
           "total_bytes": 110338750
@@ -1359,10 +1357,6 @@ Example detailed response for the same calculated result:
       "data_consume_rx": "30.07 MB",
       "data_consume_tx": "16.49 MB",
       "total_data_usage": "46.56 MB",
-      "usage_accuracy": "bounded_interval",
-      "incomplete": false,
-      "segment_count": 1,
-      "boundary_fallback_used": true,
       "calculation_segments": [
         {
           "stream_id": "28:39:26:a1:7c:a5|bssid=18:34:af:04:05:06|ssid=Corp|band=5G",
@@ -1373,8 +1367,6 @@ Example detailed response for the same calculated result:
           "effective_end_time": "2026-07-27T12:00:00Z",
           "actual_start_time": "2026-07-26T11:55:00Z",
           "actual_end_time": "2026-07-27T12:05:00Z",
-          "boundary_fallback_used": true,
-          "accuracy": "bounded_interval",
           "rx_bytes": 30071250,
           "tx_bytes": 16486250,
           "total_bytes": 46557500
@@ -1389,10 +1381,6 @@ Example detailed response for the same calculated result:
       "data_consume_rx": "4.20 MB",
       "data_consume_tx": "0.60 MB",
       "total_data_usage": "4.80 MB",
-      "usage_accuracy": "exact",
-      "incomplete": false,
-      "segment_count": 2,
-      "boundary_fallback_used": false,
       "calculation_segments": [
         {
           "stream_id": "54:6c:0e:44:11:09|bssid=18:34:af:07:08:09|ssid=Corp|band=5G",
@@ -1403,8 +1391,6 @@ Example detailed response for the same calculated result:
           "effective_end_time": "2026-07-26T18:30:00Z",
           "actual_start_time": "2026-07-26T12:00:00Z",
           "actual_end_time": "2026-07-26T18:30:00Z",
-          "boundary_fallback_used": false,
-          "accuracy": "exact",
           "rx_bytes": 1800000,
           "tx_bytes": 250000,
           "total_bytes": 2050000
@@ -1418,8 +1404,6 @@ Example detailed response for the same calculated result:
           "effective_end_time": "2026-07-27T12:00:00Z",
           "actual_start_time": "2026-07-26T19:00:00Z",
           "actual_end_time": "2026-07-27T12:00:00Z",
-          "boundary_fallback_used": false,
-          "accuracy": "exact",
           "rx_bytes": 2400000,
           "tx_bytes": 350000,
           "total_bytes": 2750000
@@ -1434,7 +1418,7 @@ Example detailed response for the same calculated result:
 
 When a client is observed in-window (`[startTime, endTime)`) but no usage interval can be calculated, such as when
 only one cumulative-counter sample exists in or bounding the requested range,
-return the safely provable minimum with no calculation segments:
+return zero usage with no calculation segments:
 
 ```json
 {
@@ -1455,10 +1439,6 @@ return the safely provable minimum with no calculation segments:
       "data_consume_rx": "0.00 MB",
       "data_consume_tx": "0.00 MB",
       "total_data_usage": "0.00 MB",
-      "usage_accuracy": "lower_bound",
-      "incomplete": true,
-      "segment_count": 0,
-      "boundary_fallback_used": false,
       "calculation_segments": []
     }
   ],
@@ -1512,7 +1492,6 @@ For confirmed independent session split/reset:
 
 For ambiguous reset/session split:
   calculate only safely observed nonnegative segment deltas
-  mark the stream lower_bound
 
 stream_key = association/session id when available, otherwise:
   station MAC
@@ -1528,22 +1507,15 @@ effective boundaries:
   effective_end = min(requested_end, proven_session_end)
 
 start_sample:
-  exact sample at effective_start, if available
+  sample at effective_start, if available
   otherwise latest available sample at or before effective_start
 
 end_sample:
-  exact sample at effective_end, if available
+  sample at effective_end, if available
   otherwise earliest available sample at or after effective_end
-
-boundary tolerance:
-  abs(effective_start - actual_start_time) <= 2 * expected_collection_interval
-  abs(actual_end_time - effective_end) <= 2 * expected_collection_interval
 
 actual_start_time = start_sample.timestamp
 actual_end_time = end_sample.timestamp
-boundary_fallback_used =
-  actual_start_time != effective_start ||
-  actual_end_time != effective_end
 
 uninterrupted segment differential:
   counterDelta(end_sample.rx_bytes, start_sample.rx_bytes)
@@ -1555,109 +1527,68 @@ samples between start_sample and end_sample:
   do not sum raw cumulative values as usage
   do sum proven segment deltas when resets or session splits are confirmed
 
-rx_bytes    = SUM(stream rx_bytes segment differentials or lower-bound deltas)
-tx_bytes    = SUM(stream tx_bytes segment differentials or lower-bound deltas)
+rx_bytes    = SUM(stream rx_bytes segment differentials)
+tx_bytes    = SUM(stream tx_bytes segment differentials)
 total_bytes = rx_bytes + tx_bytes
 
 data_consume_rx  = format_bytes(rx_bytes)
 data_consume_tx  = format_bytes(tx_bytes)
 total_data_usage = format_bytes(total_bytes)
-
-stream accuracy =
-  exact when the segment has authoritative counter evidence at effective_start
-    and effective_end, and every internal sub-segment is fully proven
-  bounded_interval when the segment uses immediate fallback samples within
-    tolerance and every internal sub-segment is fully proven
-  lower_bound when the stream lacks a usable boundary pair, exceeds boundary
-    tolerance, has an ambiguous reset/session change, or only has partially
-    observed segments
-
-client usage_accuracy precedence =
-  lower_bound if any contributing stream is lower_bound
-  otherwise bounded_interval if any contributing stream is bounded_interval
-  otherwise exact
-
-incomplete = true when usage_accuracy is lower_bound
 ```
 
 Calculate counter deltas independently for RX and TX per `stream_key` and
 internal calculable segment. After segment deltas are calculated, aggregate the
 resulting RX/TX deltas by station MAC for the response. Client `rx_bytes` and
 `tx_bytes` must equal the sum of internal segment RX/TX deltas; each internal
-segment's `total_bytes` must equal its `rx_bytes + tx_bytes`. The default
-response exposes `segment_count` and `boundary_fallback_used` instead of the
-segment objects. When `includeCalculationDetails=true`, the detailed
-`calculation_segments[]` array must satisfy the same byte-sum invariants. If
-any segment contributing to a station MAC is lower_bound, that station's usage
-is lower_bound.
+segment's `total_bytes` must equal its `rx_bytes + tx_bytes`. When
+`includeCalculationDetails=true`, the detailed `calculation_segments[]` array
+must satisfy the same byte-sum invariants.
 
 Client MAC values in API responses must be normalized canonical lowercase colon-separated MAC addresses matching `^[0-9a-f]{2}(:[0-9a-f]{2}){5}$`.
 
-Usage accuracy contract:
+Usage calculation contract:
 
 ```text
-Returned usage is exact only when every contributing calculation segment has
-authoritative boundary evidence matching effective boundaries exactly:
-  effective_start = max(requested_start, proven_session_start), and
-  effective_end = min(requested_end, proven_session_end), and
-  actual_start_time == effective_start and actual_end_time == effective_end,
-  and every counter reset, rollover, or session transition is unambiguously proven
-  and accounted for using independent segment differentials or verified rollover arithmetic.
+Use only valid persisted samples to calculate cumulative-counter deltas.
+Outside-window samples may be used as boundary samples when needed to calculate
+the first or last differential segment for a client observed in the requested
+range. The response must include requested timestamps and aggregate actual
+sample timestamps through `observedWindow`. When `includeCalculationDetails=true`,
+it must also include effective and actual timestamps for each returned segment.
 
-Returned usage is bounded_interval when exact boundary samples are unavailable but
-the latest available starting sample at or before `effective_start` and the
-earliest available ending sample at or after `effective_end` are available
-within two times the configured telemetry sampling interval, and no reset or gap
-prevents the segment differential from being calculated. The response must
-include requested timestamps and aggregate actual sample timestamps. When
-`includeCalculationDetails=true`, it must also include the effective and actual
-timestamps for each returned segment. This is usage over an interval containing
-the segment's overlap with the requested interval; when counters are monotonic
-and uninterrupted, the returned value is greater than or equal to usage in that
-overlap.
+If a stream lacks a usable bounding sample pair or has an ambiguous counter
+decrease/session change, skip the ambiguous interval rather than inventing
+traffic. Sum only safely calculable nonnegative consecutive segment deltas. If
+no differential segment can be calculated for an observed client, return that
+client with zero byte totals and, when details are enabled,
+`calculation_segments: []`.
 
-When a stream lacks a usable bounding sample pair or has an ambiguous counter
-decrease/session change, or when either fallback boundary exceeds tolerance, the
-returned usage is a lower-bound estimate. The algorithm must avoid overcounting
-unknown traffic, so it adds only safely provable nonnegative consecutive segment
-deltas inside the requested range and treats the result as incomplete/estimated.
-If no positive interval can be safely proven, return 0 bytes for that stream with
-`lower_bound`. Include a client in `items[]` and count it in `totalClients` only when it has at least one in-window observation (`[startTime, endTime)`) or proven session overlap during the requested interval, even if the safely provable lower-bound delta is 0. Outside-window bounding samples (e.g. pre-window baseline or post-window fallback samples) are used exclusively as boundary calculation aids for clients that have proven in-window presence or session overlap. A station MAC with only outside-window samples and no in-window observation or session overlap during `[startTime, endTime)` must be excluded from `items[]` and `totalClients`. If no differential segment can be calculated
-for that client, return `segment_count: 0` and `boundary_fallback_used: false`;
-do not create a segment with fabricated effective or actual boundary timestamps.
-If details are enabled, return `calculation_segments: []` for that client.
-
-The response must expose `usage_accuracy`, `segment_count`, and
-`boundary_fallback_used` per client:
-  exact: all contributing streams are fully accounted for
-  bounded_interval: at least one contributing segment used fallback samples
-    within tolerance that bound the requested range
-  lower_bound: at least one contributing stream used a conservative zero delta
-    for an ambiguous interval, missing usable boundary pair, or out-of-tolerance
-    boundary
-
-When `usage_accuracy` is `lower_bound`, the reported byte and formatted usage
-values are the safely observed minimum. Actual usage may be higher.
+Include a client in `items[]` and count it in `totalClients` only when it has at
+least one in-window observation (`[startTime, endTime)`) or proven session
+overlap during the requested interval. Outside-window boundary samples are used
+only as calculation aids for clients with proven requested-window presence or
+session overlap. A station MAC with only outside-window samples and no in-window
+observation or session overlap during `[startTime, endTime)` must be excluded
+from `items[]` and `totalClients`.
 ```
 
-Differential response decision table:
+Differential data-handling rules:
 
-| Condition | Result |
+| Condition | Handling |
 |---|---|
-| Exact effective start and effective end counter evidence exists, no reset/session ambiguity | `exact` differential |
-| Fallback start and end samples bound the effective segment range and both are within `2 * expected_collection_interval`, no reset/session ambiguity | `bounded_interval` differential |
-| Session starts inside the requested window with proven zero/session baseline and authoritative end evidence | `exact` if effective boundaries are fully proven |
-| Session ends inside the requested window with authoritative start and proven session-end evidence | `exact` if effective boundaries are fully proven |
-| Start sample missing and session start inside the requested window is confirmed but complete effective-boundary evidence is unavailable | sum safely provable nonnegative segment deltas; `lower_bound` |
-| Start sample missing and session origin is unknown | `lower_bound` |
-| End sample missing | sum safely provable nonnegative consecutive segment deltas through the latest usable sample; `lower_bound` |
-| Both boundary samples missing | sum safely provable nonnegative consecutive segment deltas inside the requested range; `lower_bound` |
-| Only one in-window sample exists | return 0 bytes, `lower_bound`, `segment_count: 0`, and `boundary_fallback_used: false`; if details are enabled, return `calculation_segments: []` |
-| Client appears during the window without reliable session-start proof | sum safely provable post-appearance segment deltas only; `lower_bound` |
-| Client disappears before the end boundary | sum safely provable segment deltas through the last usable sample; `lower_bound` |
-| Client reconnects and counters reset | split only when session identity proves independent streams; otherwise `lower_bound` |
-| Multiple sessions for the same MAC | calculate per proven session stream, then aggregate by MAC; mark client `lower_bound` if any contributing stream is incomplete |
-| Ambiguous counter reset, stale sample, duplicate conflict, or out-of-order telemetry | `lower_bound` |
+| Usable start and end counter samples exist, no reset/session ambiguity | calculate the differential |
+| Boundary samples immediately outside the requested range are needed | use them as calculation inputs and expose their timestamps through `observedWindow` |
+| Session starts inside the requested window with a usable session baseline and later sample | calculate deltas from the usable session samples |
+| Session ends inside the requested window with usable samples | calculate deltas through the last usable session sample |
+| Start sample missing | sum safely calculable nonnegative consecutive segment deltas from available samples |
+| End sample missing | sum safely calculable nonnegative consecutive segment deltas through the latest usable sample |
+| Both boundary samples missing | sum safely calculable consecutive segment deltas inside the requested range |
+| Only one in-window sample exists | return zero bytes for that client; if details are enabled, return `calculation_segments: []` |
+| Client appears during the window without reliable session-start proof | sum safely calculable post-appearance segment deltas only |
+| Client disappears before the end boundary | sum safely calculable segment deltas through the last usable sample |
+| Client reconnects and counters reset | split only when session identity proves independent streams; otherwise skip the ambiguous interval |
+| Multiple sessions for the same MAC | calculate per proven session stream, then aggregate by MAC |
+| Ambiguous counter reset, stale sample, duplicate conflict, or out-of-order telemetry | skip the ambiguous interval |
 
 When `current < previous` and the counter width is known for that source, and
 the decrease is not explained by a proven session reset/reconnect or ambiguous
@@ -1670,16 +1601,14 @@ delta = (counterMax - previous) + current + 1
 
 If the counter width is unknown, multiple wraps are plausible, or the decrease
 could be a reset/reconnect/stale sample, treat the interval as ambiguous and
-return `lower_bound`.
-
-If the expected collection interval is missing, zero, invalid, or cannot be resolved reliably for the requested retention period, fallback boundary samples cannot qualify as `bounded_interval`; exact boundary samples are required to avoid `lower_bound`.
+skip that interval.
 
 ### Reset-Safe Delta Logic
 
 ```cpp
 struct CounterDeltaResult {
     uint64_t delta;
-    bool incomplete;
+    bool usable;
 };
 
 CounterDeltaResult counterDelta(uint64_t current,
@@ -1688,14 +1617,14 @@ CounterDeltaResult counterDelta(uint64_t current,
                                 bool decreaseAmbiguous,
                                 uint64_t counterMax) {
     if (current >= previous) {
-        return {current - previous, false};
+        return {current - previous, true};
     }
 
     if (counterWidthKnown && !decreaseAmbiguous) {
-        return {(counterMax - previous) + current + 1, false};
+        return {(counterMax - previous) + current + 1, true};
     }
 
-    return {0, true};
+    return {0, false};
 }
 ```
 
@@ -1703,8 +1632,7 @@ Session starts are handled by segment construction, not by blindly adding the
 current counter on every decrease. When reliable session evidence proves a new
 session started inside the requested window, use that session's first valid
 counter sample as the segment baseline and sum only subsequent proven segment
-deltas. If there is no subsequent usable sample, that segment contributes 0 with
-`lower_bound`.
+deltas. If there is no subsequent usable sample, that segment contributes 0.
 
 Do not treat every lower counter as a reset where `current` should be added. A lower value can mean a new association session, movement between radios/BSSIDs, stale or out-of-order telemetry, duplicate station records inside one timepoint, or counter-width rollover. Adding `current` on every decrease can overcount traffic by attributing unknown pre-window traffic to the requested window.
 
@@ -1747,15 +1675,12 @@ Independent Directional Counter Rules (RX vs TX):
    - RX bytes are calculated normally and included in data_consume_rx.
    - TX bytes return 0 as a required non-null integer in calculation_segments (and formatted "0.00 MB" in summary strings).
    - Total segment bytes total_bytes = rx_bytes + 0 = rx_bytes.
-   - The stream accuracy is classified as lower_bound.
 3. If TX is present and valid but RX is missing/invalid:
    - TX bytes are calculated normally and included in data_consume_tx.
    - RX bytes return 0 as a required non-null integer in calculation_segments (and formatted "0.00 MB" in summary strings).
    - Total segment bytes total_bytes = 0 + tx_bytes = tx_bytes.
-   - The stream accuracy is classified as lower_bound.
-4. If a boundary sample has RX but not TX (or vice versa), the missing direction cannot form a calculable boundary delta; that direction returns 0 bytes and is marked uncalculable (lower_bound).
-5. segment_count is incremented if at least one direction (RX or TX) produces a valid calculable segment delta.
-6. A client MAC is included in totalClients and items[] if it has proven in-window presence or session overlap, regardless of whether one counter direction was missing or uncalculable.
+4. If a boundary sample has RX but not TX (or vice versa), the missing direction cannot form a calculable boundary delta; that direction returns 0 bytes.
+5. A client MAC is included in totalClients and items[] if it has proven in-window presence or session overlap, regardless of whether one counter direction was missing or uncalculable.
 
 If current < previous:
   if a new association/session is confirmed:
@@ -1763,27 +1688,21 @@ If current < previous:
       close the previous segment at the last pre-reset sample
       start a new segment with current as its baseline
       add only subsequent proven nonnegative deltas for the new segment
-      mark the stream lower_bound unless both session segments can be fully proven
     else:
-      treat current as the new baseline, add delta 0, and mark the result
-      incomplete/estimated
+      treat current as the new baseline and add delta 0
   else if counter width is known and the decrease is not ambiguous:
     assume at most one rollover occurred and apply single-rollover math
   else:
-    treat current as the new baseline, add delta 0, and mark the result
-    incomplete/estimated
+    treat current as the new baseline and add delta 0
 ```
 
 For usage differential calculation, choose the start and end samples first, then
-calculate the boundary differential for each segment. Exact usage requires
-authoritative counter evidence exactly at each segment's `effective_start` and
-`effective_end`, where effective boundaries are clipped to proven session
-lifetime and the requested window. If fallback samples within tolerance are used,
-classify the result as `bounded_interval`. The default response exposes the
-requested window, observed window, and fallback summary
-fields. When `includeCalculationDetails=true`, each returned segment
-additionally exposes its effective and actual boundary timestamps. Do not add a
-cumulative counter directly unless it is known to represent traffic that started inside the
+calculate the boundary differential for each segment. Effective boundaries are
+clipped to proven session lifetime and the requested window. The default
+response exposes the requested window, observed window, and calculated values.
+When `includeCalculationDetails=true`, each returned segment additionally
+exposes its effective and actual boundary timestamps. Do not add a cumulative
+counter directly unless it is known to represent traffic that started inside the
 segment's effective interval.
 
 A new association/session is confirmed only when the source provides reliable session identity or timing evidence. For example, a session id change, association id change, or connected-duration reset may prove a new session if it also proves the session start time is within the requested window. BSSID, SSID, band, or radio changes define separate calculation streams, but they do not by themselves prove that the new cumulative counter started inside the requested window.
@@ -1800,17 +1719,14 @@ Delta 10:00 -> 10:05 = 500
 If 10:10 is a confirmed new session that started inside the request window WITH authoritative proof of starting at counter zero (e.g. session_start event with baseline 0 at session origin):
   add 200 (delta from zero baseline)
   total rx_bytes = 700
-  usage_accuracy = exact, unless another stream is incomplete
 
 If 10:10 is a confirmed new session that started inside the request window WITHOUT authoritative proof of starting at zero:
   treat 200 as the new segment baseline (delta = 0 for 10:10 sample alone)
   total rx_bytes = 500
-  usage_accuracy = lower_bound (until a subsequent sample in Session B establishes a proven delta)
 
 If 10:10 is an ambiguous decrease:
   add 0 (treat 200 as baseline)
   total rx_bytes = 500
-  usage_accuracy = lower_bound
 
 If previous = 9900, current = 100, counterMax = 9999, and rollover is confirmed:
   delta = (9999 - 9900) + 100 + 1
@@ -2137,9 +2053,7 @@ progress or lag as availability-domain data.
 
 The `availability-summary` endpoint is an observed-data API. It reports the
 availability transition rows currently persisted in Analytics storage at request
-time. It does not prove that Kafka has delivered every possible source event,
-that the consumer is caught up, that no delayed message exists, or that the
-requested interval is ingestion-complete.
+time. It does not prove what Analytics has not yet received.
 
 ## API Logic
 
@@ -2441,14 +2355,13 @@ It does not prove what Analytics has not yet received.
 Explicitly out of scope for `availability-summary`:
 
 ```text
-strong read-after-Kafka-ingestion consistency
-zero-lag guarantees
-source-to-API delivery SLA
-Kafka consumer freshness validation
-historical ingestion-completeness proof
-availability coverage proof
-durable gap persistence
-durable checkpoint persistence
+strong read-after-Kafka-ingestion consistency guarantees
+source-to-API delivery SLA guarantees
+request-time Kafka consumer position validation
+historical source-event delivery proof
+server-side availability data-quality classification
+durable ingestion data-loss persistence
+durable ingestion checkpoint persistence
 waiting for Kafka catch-up before answering
 high availability across Kafka/DB failure scenarios
 ```
@@ -3002,7 +2915,7 @@ observedWindow.endTime =
 
 Do not set `observedWindow` to the requested range merely because the query
 covers that range. It reflects observed persisted transition events, not
-ingestion coverage.
+server-side data-status classification.
 
 Example:
 
@@ -3078,10 +2991,9 @@ Use an HTTP error:
 
 A zero result means no persisted offline transition was observed in the
 requested post-cutover interval based on the data currently available in
-Analytics storage. It does not mean no outage definitely occurred, Kafka is
-fully consumed through `endTime`, all producer events have reached Analytics, or
-there are no delayed messages. Kafka consumer lag is operational state and is
-not represented as availability-domain response metadata.
+Analytics storage. It does not make claims about outages not yet observed,
+delayed messages, or Kafka consumer position. Kafka consumer lag is operational
+state and is not represented as availability-domain response metadata.
 
 `offlineEventCount` is the number of offline transition rows in
 `device_availability_events` that contribute to `offline_count`. Online recovery
@@ -3167,7 +3079,7 @@ struct ClientRssiQualityResponse;
 struct GatewayOfflineSummary;
 ```
 
-JSON field names should match the MCP CSV where the API is directly returning MCP fields. `usage-summary` additionally returns raw byte totals and usage accuracy fields so callers can distinguish exact usage from lower-bound estimates.
+JSON field names should match the MCP CSV where the API is directly returning MCP fields. `usage-summary` additionally returns raw byte totals alongside display-formatted usage strings.
 
 Client MAC addresses (`mac`) must be normalized to canonical lowercase colon-separated format matching pattern `^[0-9a-f]{2}(:[0-9a-f]{2}){5}$` across all client metrics endpoints.
 
@@ -3301,7 +3213,7 @@ bool GetGatewayAvailabilitySummary(...);
 |---|---|---|---|
 | `get_gateway_free_memory` | `GET /devices/{routerId}/memory-summary` | `timepoints.resource_data.memory_free` | Resolve routerId to venueId and boardId, then aggregate `timepoints` |
 | `get_gateway_wifi_temp` | `GET /devices/{routerId}/radio-temperature-summary` | `timepoints.radio_data[].wifi_temp` | Resolve routerId to venueId and boardId, then aggregate present Wi-Fi temperature samples from `timepoints` |
-| `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then calculate reset-safe cumulative-counter differentials with concise quality metadata by default; include segment provenance only when `includeCalculationDetails=true` |
+| `get_device_bandwidth_consumption` | `GET /devices/{routerId}/wifi-clients/usage-summary` | `timepoints.ssid_data[].associations[]` | Resolve routerId to venueId and boardId, then calculate reset-safe cumulative-counter differentials from available persisted samples; include segment provenance only when `includeCalculationDetails=true` |
 | `get_device_rssi_quality` | `GET /devices/{routerId}/wifi-clients/rssi-summary` | `timepoints.ssid_data[].associations[].rssi` | Resolve routerId to venueId and boardId, then classify RSSI samples |
 | `get_gateway_offline_count` | `GET /devices/{routerId}/availability-summary` | Existing gateway `connection` topic plus `device_availability_events` and `device_availability_state` | Use routerId as durable serialNumber, use `device_availability_state.current_state` and `last_event_time` for restart-safe transition detection, then count offline events by serialNumber |
 

--- a/analytics_apis_for_mcp.md
+++ b/analytics_apis_for_mcp.md
@@ -1563,7 +1563,18 @@ Differential response decision table:
 | Multiple sessions for the same MAC | calculate per proven session stream, then aggregate by MAC; mark client `lower_bound` if any contributing stream is incomplete |
 | Ambiguous counter reset, stale sample, duplicate conflict, or out-of-order telemetry | `lower_bound` |
 
-A fixed-width rollover is confirmed only when the counter width is known for that source, the observed decrease is consistent with a rollover for that counter, and the maximum possible counter increase during the observation gap cannot exceed one full counter range. If the counter width is unknown, if multiple wraps may have occurred, or if the decrease could also be a reset/reconnect/stale sample, treat it as ambiguous and return `lower_bound`.
+When `current < previous` and the counter width is known for that source, and
+the decrease is not explained by a proven session reset/reconnect or ambiguous
+stream change, assume at most one counter rollover occurred between the two
+samples and apply single-rollover arithmetic:
+
+```text
+delta = (counterMax - previous) + current + 1
+```
+
+If the counter width is unknown, multiple wraps are plausible, or the decrease
+could be a reset/reconnect/stale sample, treat the interval as ambiguous and
+return `lower_bound`.
 
 If the expected collection interval is missing, zero, invalid, or cannot be resolved reliably for the requested retention period, fallback boundary samples cannot qualify as `bounded_interval`; exact boundary samples are required to avoid `lower_bound`.
 
@@ -1577,14 +1588,14 @@ struct CounterDeltaResult {
 
 CounterDeltaResult counterDelta(uint64_t current,
                                 uint64_t previous,
-                                bool confirmedFixedWidthRollover,
-                                bool singleRolloverBoundProven,
+                                bool counterWidthKnown,
+                                bool decreaseAmbiguous,
                                 uint64_t counterMax) {
     if (current >= previous) {
         return {current - previous, false};
     }
 
-    if (confirmedFixedWidthRollover && singleRolloverBoundProven) {
+    if (counterWidthKnown && !decreaseAmbiguous) {
         return {(counterMax - previous) + current + 1, false};
     }
 
@@ -1660,8 +1671,8 @@ If current < previous:
     else:
       treat current as the new baseline, add delta 0, and mark the result
       incomplete/estimated
-  else if fixed-width rollover is known, one-wrap bound is proven, and can be confirmed:
-    apply rollover math
+  else if counter width is known and the decrease is not ambiguous:
+    assume at most one rollover occurred and apply single-rollover math
   else:
     treat current as the new baseline, add delta 0, and mark the result
     incomplete/estimated

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -215,10 +215,6 @@ components:
       type: object
       additionalProperties: true
 
-    Fingerprint:
-      type: object
-      additionalProperties: true
-
     UETimePoint:
       type: object
       properties:
@@ -859,7 +855,7 @@ components:
             type: string
 
 paths:
-  /api/v1/boards:
+  /boards:
     get:
       tags:
         - Boards
@@ -911,7 +907,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/board/{id}:
+  /board/{id}:
     get:
       tags:
         - Boards
@@ -1020,7 +1016,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/board/{id}/devices:
+  /board/{id}/devices:
     get:
       tags:
         - Board Devices
@@ -1048,7 +1044,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/board/{id}/timepoints:
+  /board/{id}/timepoints:
     get:
       tags:
         - Board data
@@ -1142,7 +1138,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/wifiClientHistory:
+  /wifiClientHistory:
     get:
       tags:
         - WiFiClientHistory
@@ -1212,7 +1208,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/wifiClientHistory/{client}:
+  /wifiClientHistory/{client}:
     get:
       tags:
         - WiFiClientHistory
@@ -1337,7 +1333,7 @@ paths:
   ## These are endpoints that all services in the OpenWiFi stack must provide
   ##
   #########################################################################################
-  /api/v1/system:
+  /system:
     post:
       tags:
         - System Commands
@@ -1398,7 +1394,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/systemConfiguration:
+  /systemConfiguration:
     get:
       tags:
         - SystemConfiguration

--- a/openapi/owanalytics.yaml
+++ b/openapi/owanalytics.yaml
@@ -215,6 +215,10 @@ components:
       type: object
       additionalProperties: true
 
+    Fingerprint:
+      type: object
+      additionalProperties: true
+
     UETimePoint:
       type: object
       properties:
@@ -855,7 +859,7 @@ components:
             type: string
 
 paths:
-  /boards:
+  /api/v1/boards:
     get:
       tags:
         - Boards
@@ -907,7 +911,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /board/{id}:
+  /api/v1/board/{id}:
     get:
       tags:
         - Boards
@@ -1016,7 +1020,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /board/{id}/devices:
+  /api/v1/board/{id}/devices:
     get:
       tags:
         - Board Devices
@@ -1044,7 +1048,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /board/{id}/timepoints:
+  /api/v1/board/{id}/timepoints:
     get:
       tags:
         - Board data
@@ -1138,7 +1142,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /wifiClientHistory:
+  /api/v1/wifiClientHistory:
     get:
       tags:
         - WiFiClientHistory
@@ -1208,7 +1212,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /wifiClientHistory/{client}:
+  /api/v1/wifiClientHistory/{client}:
     get:
       tags:
         - WiFiClientHistory
@@ -1333,7 +1337,7 @@ paths:
   ## These are endpoints that all services in the OpenWiFi stack must provide
   ##
   #########################################################################################
-  /system:
+  /api/v1/system:
     post:
       tags:
         - System Commands
@@ -1394,7 +1398,7 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /systemConfiguration:
+  /api/v1/systemConfiguration:
     get:
       tags:
         - SystemConfiguration


### PR DESCRIPTION
## Summary

This PR expands and formalizes the MCP-facing WLAN Analytics API specification, covering the public API contract, request validation, aggregation behavior, persistence requirements, and ingestion/cutover semantics.

The goal is to provide an implementation-ready specification for the analytics endpoints used by MCP while clearly separating the external API contract from the internal storage and pipeline architecture.

A key design principle in this version is that Analytics APIs return results calculated from the valid data currently persisted in Analytics storage. The APIs expose `requestedWindow` and `observedWindow` so callers can see the requested interval and the actual timestamps of the data that contributed to the response. The API does not classify results as exact, partial, lower-bound, bounded, complete, or incomplete.

## What changed

* Defined the specification across three areas:
  * Public API contracts
  * Persistence and ingestion architecture
  * Test/verification requirements
* Added a strict request-processing and validation order:
  * Bearer-token authentication
  * Input parsing and validation
  * Router ownership/serial resolution through OWPROV
  * Retention, duration, and endpoint-specific cutover validation
* Defined `routerId`, `timestampTill`, and `lookbackHours` validation rules and field-specific error responses.
* Standardized time-window calculations using checked 64-bit epoch arithmetic and `[startTime, endTime)` semantics.
* Standardized response time metadata using:
  * `requestedWindow.startTime`
  * `requestedWindow.endTime`
  * `observedWindow.startTime`
  * `observedWindow.endTime`
* Defined `observedWindow` as the earliest and latest persisted sample/event timestamps that actually contributed to the returned result. When no valid persisted data contributes, both observed timestamps are `null`.
* Documented endpoint-specific retrieval strategies:
  * `all` for gauge/event aggregations
  * `differential` for cumulative-counter usage calculation
* Clarified cumulative-counter calculation behavior using available persisted samples, session-aware boundaries, reset/rollover handling, and safe skipping of ambiguous intervals without exposing result-quality classifications in the public API.
* Strengthened memory telemetry validation to reject structurally invalid values and enforce aggregation-time consistency between free and total memory.
* Defined radio temperature units, valid sample handling, and explicit migration-cutover configuration/behavior.
* Added availability persistence and ingestion architecture using:
  * `device_availability_events` for persisted transition history
  * `device_availability_state` for restart-safe current-state tracking
  * Kafka partition ordering keyed by `serialNumber`
  * DB-commit-before-Kafka-offset-commit semantics
  * Kafka consumer-group replay/restart/rebalance behavior
  * idempotent transition processing
* Explicitly keeps Kafka lag, consumer progress, high-watermark checks, ingestion checkpoints, and gap tracking out of the availability API request path. The availability endpoint reports the transition rows currently persisted in Analytics storage at request time.
* Defined durable `availabilityValidFrom` and temperature migration cutover behavior for historical validity boundaries.
* Clarified that production persistence and Kafka pipeline changes require separate architecture approval before deployment.

## API behavior

The documented MCP analytics APIs use strict RFC3339 UTC timestamps, derive their maximum lookback from the configured monitoring duration, enforce configured retention windows, and return deterministic error codes for invalid requests.

For metric responses, Analytics returns the values calculated from valid persisted data together with the requested and observed time windows. `observedWindow` communicates which persisted timestamps actually contributed to the result; the API does not attach accuracy, completeness, coverage, or confidence classifications to the response.

For availability specifically, `offline_count` is the number of persisted offline transition events currently available in `device_availability_events` for the requested `[startTime, endTime)` interval. A value of `0` means no matching offline transition is currently persisted for that interval; it does not make a claim about Kafka consumer freshness or unconsumed upstream events.

The specification also defines how missing, malformed, stale, ambiguous, or historically unreliable telemetry should be handled so invalid data does not silently affect analytics results.

## Notes

This PR primarily defines and tightens the analytics API and backend architecture specification; it does not by itself authorize the production persistence/Kafka architecture changes described in the document.

Functional OpenAPI contract/schema updates for these MCP analytics endpoints are intended as a follow-up deliverable.